### PR TITLE
feat(niv): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e087f5def9adc76ff649fd8f007cc06eb0ad607e",
-        "sha256": "1y6rh2d977m3ikny8c0a6lkiyd11b4p0s495z0kbbvc2pgf22ng9",
+        "rev": "84f5a2e5e5ac352e8400c361e4e648026b636423",
+        "sha256": "1k4d0yp319d35ld3nbn92a4fmv6pcbfxb8pd652y4qk2ckmbnwsz",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/e087f5def9adc76ff649fd8f007cc06eb0ad607e.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/84f5a2e5e5ac352e8400c361e4e648026b636423.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
|SHA256|Commit Message|Timestamp|
|---|---|---|
|[`7a0c6cdd`](https://github.com/NixOS/nixpkgs/commit/7a0c6cdd396521b2d0207bd97bf7b119fbd8e3ea)|`nixos/miniflux: systemd unit hardening (#133123)`|`2021-08-08 11:58:30Z`|
|[`0f572158`](https://github.com/NixOS/nixpkgs/commit/0f572158bb08182b1400bab92a14a49a3b9dd11d)|`rtv: drop package (#133085)`|`2021-08-08 10:33:15Z`|
|[`3d59c44d`](https://github.com/NixOS/nixpkgs/commit/3d59c44dfda83b00b57f047e35cd67fe2b37ea2c)|`nix-simple-deploy: 0.1.1 -> 0.2.1 (#133104)`|`2021-08-08 10:16:12Z`|
|[`fbaa499c`](https://github.com/NixOS/nixpkgs/commit/fbaa499c62958e5576ec81a04b7e233c15333b30)|`cozy: 0.7.2 -> 1.0.3`|`2021-08-08 10:15:22Z`|
|[`cc3a5e1e`](https://github.com/NixOS/nixpkgs/commit/cc3a5e1e45c15221431cb1a16ce84bef1fb1eaee)|`pantheon.granite: propagate dependencies`|`2021-08-08 10:15:22Z`|
|[`9ccb5859`](https://github.com/NixOS/nixpkgs/commit/9ccb5859fba07e105931c9527f059ada0ca6fdea)|`dnsproxy: 0.39.1 -> 0.39.2`|`2021-08-08 10:05:40Z`|
|[`90d14641`](https://github.com/NixOS/nixpkgs/commit/90d14641289b1d18c9919bef32afd84472231efc)|`cloudflared: 2021.7.4 -> 2021.8.1`|`2021-08-08 09:07:28Z`|
|[`23cedc30`](https://github.com/NixOS/nixpkgs/commit/23cedc3088a628e1f5454cab6864f9b1a059e1ba)|`circleci-cli: 0.1.15149 -> 0.1.15663`|`2021-08-08 08:55:26Z`|
|[`e1012bc6`](https://github.com/NixOS/nixpkgs/commit/e1012bc6f1ed0a9ad7b99d9fa9d7f8187e8530a2)|`yarn: 1.22.10 -> 1.22.11`|`2021-08-08 08:53:43Z`|
|[`9ec3ed91`](https://github.com/NixOS/nixpkgs/commit/9ec3ed91b88835db42d14b0df69e6d1a2a105349)|`mdbook: 0.4.10 -> 0.4.12`|`2021-08-08 07:03:03Z`|
|[`3015c82e`](https://github.com/NixOS/nixpkgs/commit/3015c82ecad73712579db990c2878980db72b1dd)|`etcher: fix desktop file`|`2021-08-08 06:54:17Z`|
|[`79031751`](https://github.com/NixOS/nixpkgs/commit/79031751b9586a9b74c773d06148f82904a45c57)|`python3Packages.pynvml: 8.0.4 -> 11.0.0`|`2021-08-08 06:22:19Z`|
|[`0429b202`](https://github.com/NixOS/nixpkgs/commit/0429b202a32022f1626b08f00aaca9d3c31c03a6)|`python3Packages.ignite: 0.4.5 -> 0.4.6`|`2021-08-08 06:10:36Z`|
|[`3a3f8263`](https://github.com/NixOS/nixpkgs/commit/3a3f82631fa60bece8a7d499eee29e522c770fd8)|`kmsxx: 2020-08-04 -> 2021-07-26 unbreak`|`2021-08-08 05:37:56Z`|
|[`90fcd8e7`](https://github.com/NixOS/nixpkgs/commit/90fcd8e7a948601a7a9c9d5b752aa40bfb5fbec1)|`vistafonts-cht: init`|`2021-08-08 05:35:11Z`|
|[`23615cdd`](https://github.com/NixOS/nixpkgs/commit/23615cdd9e1a794f7824a925e493be951da3ca85)|`python3Packages.threadpoolctl: 2.1.0 -> 2.2.0`|`2021-08-08 05:16:41Z`|
|[`90832a03`](https://github.com/NixOS/nixpkgs/commit/90832a038710a2d925626a4f5230f5ccbead89c5)|`python39Packages.xml-marshaller: add pythonImportsCheck`|`2021-08-08 04:50:00Z`|
|[`240cf37b`](https://github.com/NixOS/nixpkgs/commit/240cf37b505554ba7466993b7b11682ad2dcec74)|`python39Packages.awslambdaric: move depedency patching to right phase`|`2021-08-08 04:44:13Z`|
|[`826e592c`](https://github.com/NixOS/nixpkgs/commit/826e592c2c1f57c974f76b285bff43cd7c48cc67)|`flow: cleanup, format`|`2021-08-08 04:11:29Z`|
|[`a687f1ae`](https://github.com/NixOS/nixpkgs/commit/a687f1aef482c602da86f84133465d2b4e07e60b)|`vscode-extensions.matklad.rust-analyzer: fix server path`|`2021-08-08 04:09:22Z`|
|[`bc520477`](https://github.com/NixOS/nixpkgs/commit/bc520477f49c0a5a7ba6014a7126da05dbcb2fef)|`yambar: document breaking changes`|`2021-08-08 04:05:40Z`|
|[`0f70b1bc`](https://github.com/NixOS/nixpkgs/commit/0f70b1bc9e51f00c6e2e8b56f6b1cfda53f80ae3)|`vscode-extensions.matklad.rust-analyzer: nixpkgs-fmt`|`2021-08-08 04:05:33Z`|
|[`99d8d553`](https://github.com/NixOS/nixpkgs/commit/99d8d553da44fb065f9cb8bb54e2e93b85417fab)|`nixos/gitea: init/migrate db in startup script`|`2021-08-08 03:48:15Z`|
|[`82076fcd`](https://github.com/NixOS/nixpkgs/commit/82076fcde4f878e74a6a9e341526c9f796dee522)|`yambar: refactor derivation and split backends as separate packages`|`2021-08-08 03:46:29Z`|
|[`42b315fa`](https://github.com/NixOS/nixpkgs/commit/42b315fa7931f141bcc2885e535dcc76784dd27d)|`grafana-loki: 2.2.1 -> 2.3.0 (#133011)`|`2021-08-08 03:31:09Z`|
|[`107b43ae`](https://github.com/NixOS/nixpkgs/commit/107b43ae9688360dcfeb3dd28b98fc55e8bdf9ba)|`yder: format, cleanup`|`2021-08-08 03:22:27Z`|
|[`609eb35c`](https://github.com/NixOS/nixpkgs/commit/609eb35c3264fed87474af4b1034f1347d8f57e7)|`fuzzel: add polykernel to maintainers list`|`2021-08-08 03:20:02Z`|
|[`1531e34b`](https://github.com/NixOS/nixpkgs/commit/1531e34bdfd607b7e2f7d990cd5be8c3d2461a3f)|`fuzzel: refactor dependencies`|`2021-08-08 03:20:01Z`|
|[`3b85ec48`](https://github.com/NixOS/nixpkgs/commit/3b85ec48e6a67c3cdc1d284e2d5e07e47f3cd011)|`blktrace: switch to pname + version, cleanup`|`2021-08-08 02:58:30Z`|
|[`1eb713de`](https://github.com/NixOS/nixpkgs/commit/1eb713de57be783dbdec24bdccde783fac5e0d9e)|`linux_xanmod: 5.13.7 -> 5.13.8`|`2021-08-08 02:13:42Z`|
|[`44ac8719`](https://github.com/NixOS/nixpkgs/commit/44ac8719ed46f1e06208d911f11b846fcac82689)|`linux_xanmod: add lovesegfault to maintainers`|`2021-08-08 02:01:10Z`|
|[`08c8e87b`](https://github.com/NixOS/nixpkgs/commit/08c8e87b998c981cc58dccc45a0a21936ddbebea)|`anki-bin: 2.1.44 -> 2.1.46`|`2021-08-08 01:30:38Z`|
|[`f047ae82`](https://github.com/NixOS/nixpkgs/commit/f047ae82cdacd93187cb8477992dc2c209f99f5a)|`mit-scheme: 10.1.10 -> 11.2`|`2021-08-08 01:27:21Z`|
|[`fc333f19`](https://github.com/NixOS/nixpkgs/commit/fc333f19d45a663bcb2beb319b038c9e5d83ca40)|`python3Packages.rising: 0.2.0post0 -> 0.2.1`|`2021-08-08 01:25:22Z`|
|[`1c109e6e`](https://github.com/NixOS/nixpkgs/commit/1c109e6e8ca1b2c9c5654612f933cf6be578927d)|`vimPlugins.gitlinker-nvim: init at 2021-07-15`|`2021-08-08 00:56:31Z`|
|[`16ffbe75`](https://github.com/NixOS/nixpkgs/commit/16ffbe7582166c6e26c4543330be33f50e9c4b0d)|`marathon: format`|`2021-08-08 00:38:43Z`|
|[`913f76c9`](https://github.com/NixOS/nixpkgs/commit/913f76c9d9531f3b44f16bd4796848c07ea6f028)|`frostwire: remove extra with lib`|`2021-08-08 00:27:29Z`|
|[`3fa5fabf`](https://github.com/NixOS/nixpkgs/commit/3fa5fabf3f7f164bf7395dcd041d2a13fa5f7341)|`lynx: format, cleanup`|`2021-08-08 00:19:11Z`|
|[`b2fe4752`](https://github.com/NixOS/nixpkgs/commit/b2fe4752a4e074a336512356ccc726528c9dac91)|`prometheus-postfix-exporter: buildFlags -> tags`|`2021-08-08 00:17:23Z`|
|[`4db0983a`](https://github.com/NixOS/nixpkgs/commit/4db0983ae49122e31b6eb8387154e397b4269d12)|`prometheus: buildFlags{,Array} -> ldflags, tags`|`2021-08-08 00:17:23Z`|
|[`7b2efac5`](https://github.com/NixOS/nixpkgs/commit/7b2efac5ac983c369adce1258c9807165c7ad18d)|`drone: buildFlagsArray -> tags`|`2021-08-08 00:17:23Z`|
|[`60ca07fa`](https://github.com/NixOS/nixpkgs/commit/60ca07fadc10e10bd382668717c9a2a5964450f2)|`gogs: buildFlags{,Array} -> tags`|`2021-08-08 00:17:23Z`|
|[`6b18e415`](https://github.com/NixOS/nixpkgs/commit/6b18e415e8b4fd2d17bdb073d2ea7cbb570eba47)|`filebot: 4.9.3 -> 4.9.4`|`2021-08-08 00:12:43Z`|
|[`45f3eea9`](https://github.com/NixOS/nixpkgs/commit/45f3eea9224ea71176526db7dc0c858e9e4b31f5)|`angband: 4.2.2 -> 4.2.3 (#132372)`|`2021-08-08 00:05:24Z`|
|[`6520949c`](https://github.com/NixOS/nixpkgs/commit/6520949c3ce60b20f765a06a4d6daf6f24d2a5aa)|`linuxConfig: fix build`|`2021-08-07 23:50:55Z`|
|[`1893e966`](https://github.com/NixOS/nixpkgs/commit/1893e966535496ace9af3bd102f669d1030c94ad)|`corrscope: cleanup`|`2021-08-07 23:49:08Z`|
|[`5e26d952`](https://github.com/NixOS/nixpkgs/commit/5e26d95279e2dc4d5e3fcda3b54f1614f0d8ffe9)|`usql: 0.9.1 -> 0.9.2`|`2021-08-07 23:35:17Z`|
|[`c54b4950`](https://github.com/NixOS/nixpkgs/commit/c54b4950597b6a8626a38ff71c3948a2fce7fbf5)|`ajour: 1.2.5 -> 1.3.0`|`2021-08-07 23:15:49Z`|
|[`8f126648`](https://github.com/NixOS/nixpkgs/commit/8f1266482df58a5627b7660c423b5b40d7d54805)|`python3Packages.mayavi: 4.7.1 -> 4.7.3`|`2021-08-07 22:46:16Z`|
|[`ddce0ec1`](https://github.com/NixOS/nixpkgs/commit/ddce0ec126f1c92504761bd8ece98548a40aa44f)|`lynx: add patch for CVE-2021-38165`|`2021-08-07 22:42:54Z`|
|[`0dcffb7b`](https://github.com/NixOS/nixpkgs/commit/0dcffb7b0f456cd00d5bc6d294996205d255e01e)|`flexibee: 2020.2.6 -> 2021.2.1`|`2021-08-07 22:41:04Z`|
|[`4925f536`](https://github.com/NixOS/nixpkgs/commit/4925f5367eda85059f96eb5fb02f43d410cf1c15)|`weather-icons: forgot to update sha256`|`2021-08-07 22:08:04Z`|
|[`753c4bd3`](https://github.com/NixOS/nixpkgs/commit/753c4bd371b9037af92f7b84f94c0d130df032c4)|`corrscope: Move poetry-core to nativeBuildInputs`|`2021-08-07 21:51:11Z`|
|[`ab7cedea`](https://github.com/NixOS/nixpkgs/commit/ab7cedeab006c009018d629bf567bddfc7896aee)|`python3Packages.google-cloud-iam: 2.2.0 -> 2.3.1`|`2021-08-07 21:21:28Z`|
|[`07f30b4b`](https://github.com/NixOS/nixpkgs/commit/07f30b4b132fb91eeb66822f4cc657cdf291c0b1)|`frostwire-bin: 6.8.9 -> 6.9.4`|`2021-08-07 21:11:53Z`|
|[`adfd9f5c`](https://github.com/NixOS/nixpkgs/commit/adfd9f5cc94d3e4744216373426696767baf6ef9)|`kdsoap: format`|`2021-08-07 20:49:29Z`|
|[`e9c2e5b7`](https://github.com/NixOS/nixpkgs/commit/e9c2e5b741791d2c54f5825bc6ed39d368e0a114)|`fldigi: 4.1.19 -> 4.1.20`|`2021-08-07 20:19:15Z`|
|[`8e139f07`](https://github.com/NixOS/nixpkgs/commit/8e139f0750587f96adb9048598df3356c59f3336)|`weather-icons: 2.0.10 -> 2.0.12`|`2021-08-07 20:14:51Z`|
|[`ae43a849`](https://github.com/NixOS/nixpkgs/commit/ae43a849a9852904e8e4b421953179ca4d0260aa)|`python39Packages.roonapi: remove unused input`|`2021-08-07 20:09:20Z`|
|[`a9f11671`](https://github.com/NixOS/nixpkgs/commit/a9f116715b80329c21657e91fe8eb2464a9d1533)|`python39Packages.pytest-resource-path: move pytest to buildInputs, remove pytest-runner`|`2021-08-07 20:09:20Z`|
|[`038a01fe`](https://github.com/NixOS/nixpkgs/commit/038a01feeab7195e4291bc752620338cc47a670c)|`opentx: fix licence`|`2021-08-07 19:54:14Z`|
|[`c97e7e13`](https://github.com/NixOS/nixpkgs/commit/c97e7e13806d75d471d1fe3759333f70ba66a51a)|`tailscale: 1.12.2 -> 1.12.3`|`2021-08-07 19:39:26Z`|
|[`14783d58`](https://github.com/NixOS/nixpkgs/commit/14783d58ab74784f12e549c0847ce379c2aec927)|`Systemtap: 4.1 -> 4.5`|`2021-08-07 19:07:02Z`|
|[`187760e0`](https://github.com/NixOS/nixpkgs/commit/187760e07a9f50f29ffc7f6a08f849367d4dbe81)|`fuzzel: refactor derivation for long formal argument and list`|`2021-08-07 18:40:56Z`|
|[`b067c371`](https://github.com/NixOS/nixpkgs/commit/b067c371ed2444cc57d0da690c8ddf7333370f03)|`fuzzel: use fetchFromGitea instead of fetchgit`|`2021-08-07 18:38:31Z`|
|[`3886eed3`](https://github.com/NixOS/nixpkgs/commit/3886eed32cbfae19d04f4b5f63cc4047092eef9b)|`python39Packages.pytest-mockservers: move pytest to buildInputs`|`2021-08-07 18:19:08Z`|
|[`c121c5f2`](https://github.com/NixOS/nixpkgs/commit/c121c5f295452185982c7604c8e41060c84946d3)|`eksctl: 0.59.0 -> 0.60.0`|`2021-08-07 15:59:27Z`|
|[`d1c0ed87`](https://github.com/NixOS/nixpkgs/commit/d1c0ed87d2cbb2d6cc1063603f71d069599ecce9)|`lowdown: 0.8.5 -> 0.8.6`|`2021-08-07 11:35:21Z`|
|[`6d15e844`](https://github.com/NixOS/nixpkgs/commit/6d15e844789a7c47b34a085bfc4ded30b49d0910)|`ktlint: 0.42.0 -> 0.42.1`|`2021-08-07 10:54:54Z`|
|[`dd90700f`](https://github.com/NixOS/nixpkgs/commit/dd90700f6167ac9239f0d651354cc45ffc087414)|`kora-icon-theme: 1.4.4 -> 1.4.5`|`2021-08-07 10:47:25Z`|
|[`c19127cf`](https://github.com/NixOS/nixpkgs/commit/c19127cf93d8f862f940f6dbbf7a4c4090352d7d)|`k9s: 0.24.14 -> 0.24.15`|`2021-08-07 10:30:13Z`|
|[`25ab1a6d`](https://github.com/NixOS/nixpkgs/commit/25ab1a6d69b7762e0537105b96866a92058eb964)|`headscale: 0.4.0 -> 0.5.1`|`2021-08-07 09:24:25Z`|
|[`c2a33522`](https://github.com/NixOS/nixpkgs/commit/c2a335220c2782405dfcb13ee900ed1b5009799e)|`gcsfuse: 0.35.1 -> 0.36.0`|`2021-08-07 08:13:01Z`|
|[`34892123`](https://github.com/NixOS/nixpkgs/commit/34892123a4edf8479c1d93e5b0c96feacf86a6a2)|`folly: 2021.01.25.00 -> 2021.08.02.00`|`2021-08-07 07:48:50Z`|
|[`09cb9682`](https://github.com/NixOS/nixpkgs/commit/09cb9682a2661206e05555e1da21263a2f19e679)|`fluxcd: 0.16.1 -> 0.16.2`|`2021-08-07 07:43:27Z`|
|[`a4cd1123`](https://github.com/NixOS/nixpkgs/commit/a4cd1123fee07dea719486dd72bf1a8f529d8aaf)|`fheroes2: 0.9.5 -> 0.9.6`|`2021-08-07 07:19:40Z`|
|[`385b1c32`](https://github.com/NixOS/nixpkgs/commit/385b1c3293a85105db8df5d317509ada31a6fe83)|`faudio: 21.02 -> 21.08`|`2021-08-07 06:25:50Z`|
|[`00a68ad5`](https://github.com/NixOS/nixpkgs/commit/00a68ad5b16b6f8b555f3dc81a629dd258013099)|`buildkite-agent: 3.32.0 -> 3.32.1`|`2021-08-07 04:24:20Z`|
|[`7f3755e6`](https://github.com/NixOS/nixpkgs/commit/7f3755e67a3f147d8627f35030470e14aac62a42)|`blueman: 2.2.1 -> 2.2.2`|`2021-08-07 04:13:01Z`|
|[`7444a4b9`](https://github.com/NixOS/nixpkgs/commit/7444a4b946f6cca464b3103661d1000a35e48818)|`ispell: 3.4.00 -> 3.4.04`|`2021-08-07 01:56:05Z`|
|[`51ce9692`](https://github.com/NixOS/nixpkgs/commit/51ce9692ef438b18a90dd4350a456d50d63c6f65)|`keepass: 2.46 -> 2.48.1`|`2021-08-07 01:42:45Z`|
|[`0c0b5661`](https://github.com/NixOS/nixpkgs/commit/0c0b5661c71cc4913399e8fe6a8fe749666f9013)|`vault-bin: 1.8.0 -> 1.8.1`|`2021-08-06 22:26:18Z`|
|[`c4e68cb4`](https://github.com/NixOS/nixpkgs/commit/c4e68cb4518ef838e0479deda6703ae70f9a7520)|`vault: 1.8.0 -> 1.8.1`|`2021-08-06 22:26:08Z`|
|[`bf6d934c`](https://github.com/NixOS/nixpkgs/commit/bf6d934cf80e6f5365d3193e01840397709d4d87)|`rgbds: 0.4.2 -> 0.5.1`|`2021-08-06 20:07:12Z`|
|[`74f86bdb`](https://github.com/NixOS/nixpkgs/commit/74f86bdb64ec8836f091500ccf26057930521c55)|`clojure: 1.10.3.933 expects tools.edn`|`2021-08-06 18:18:49Z`|
|[`fceabc3a`](https://github.com/NixOS/nixpkgs/commit/fceabc3a388456634a3bd690daa03c5e564402d5)|`teensy-loader-cli: 2.1.20191110 → 2.1+unstable=2021-04-10`|`2021-08-06 16:23:36Z`|
|[`303f9b6b`](https://github.com/NixOS/nixpkgs/commit/303f9b6b4421f3cfcb20f77c1a0f7b11f32a9454)|`kind: patch for correct kernal module path`|`2021-08-06 16:10:12Z`|
|[`9cb3f3ad`](https://github.com/NixOS/nixpkgs/commit/9cb3f3addfab7b0293a4a91f453690b00b720533)|`docker-slim: 1.36.1 -> 1.36.2`|`2021-08-06 16:00:19Z`|
|[`49a62543`](https://github.com/NixOS/nixpkgs/commit/49a6254362cf5c2ce6c23c3f1eb3fec71ead6c61)|`coqPackages.coqeal: 1.0.5 → 1.0.6`|`2021-08-06 09:42:07Z`|
|[`1b3618cc`](https://github.com/NixOS/nixpkgs/commit/1b3618cc67aa1186b72f76862ccc47d0779b4ea7)|`boundary: 0.4.0 -> 0.5.0`|`2021-08-06 09:29:37Z`|
|[`4770cd20`](https://github.com/NixOS/nixpkgs/commit/4770cd20a182eea19a2a61fe02b6ece17efecfa8)|`flow: 0.156.0 -> 0.157.0`|`2021-08-06 06:53:46Z`|
|[`926fb939`](https://github.com/NixOS/nixpkgs/commit/926fb9396881202e727e5ec1fbf609b64455b388)|`nixos/tests/test-driver: normalise test driver entrypoint(s)`|`2021-08-06 00:07:11Z`|
|[`91b7879f`](https://github.com/NixOS/nixpkgs/commit/91b7879feda05962f6ba914a2f03a81539c7a9f7)|`smos: deprecate phases`|`2021-08-05 19:20:30Z`|
|[`d947fc3f`](https://github.com/NixOS/nixpkgs/commit/d947fc3f3cb47b7e286d177ec0508491210b393a)|`hello-unfree: deprecate phases`|`2021-08-05 19:20:30Z`|
|[`bd52b05a`](https://github.com/NixOS/nixpkgs/commit/bd52b05ad2c666bcfc73c48b49806fff35e00bb1)|`gollum: deprecate phases`|`2021-08-05 19:20:30Z`|
|[`2bd399b9`](https://github.com/NixOS/nixpkgs/commit/2bd399b9daca383bc0501ce6dc7e0347280f245f)|`ganttproject-bin: remove phases`|`2021-08-05 19:20:29Z`|
|[`5f6fa38b`](https://github.com/NixOS/nixpkgs/commit/5f6fa38b58a67b47e50152083a87f383ae62a07e)|`emem: deprecate phases`|`2021-08-05 19:20:29Z`|
|[`9a6357c7`](https://github.com/NixOS/nixpkgs/commit/9a6357c736071ca5636f9818cfeb29dbbd14077c)|`azuredatastudio: deprecate phases`|`2021-08-05 19:20:29Z`|
|[`4660bf1d`](https://github.com/NixOS/nixpkgs/commit/4660bf1d1b450a87aa1ac8b1ddb8d4944a457a11)|`avrdudess: deprecate phases`|`2021-08-05 19:20:29Z`|
|[`a1371d3e`](https://github.com/NixOS/nixpkgs/commit/a1371d3e523a067edb2d0470bc32fa3c594d6535)|`wavrsocvt: remove phases`|`2021-08-05 19:20:29Z`|
|[`0ded71cf`](https://github.com/NixOS/nixpkgs/commit/0ded71cf29a3a3cf9c1b256b77661045b2178ae5)|`agi: 2.1.0-dev-20210729 -> 2.1.0-dev-20210804`|`2021-08-05 03:00:59Z`|
|[`22626353`](https://github.com/NixOS/nixpkgs/commit/22626353b4e4d1988883e9098ed1825185bd0b7c)|`ocaml/ounit: deprecate phases`|`2021-08-04 15:43:19Z`|
|[`565234fd`](https://github.com/NixOS/nixpkgs/commit/565234fdb9c4b3eb56a9209c32bb39118806efa0)|`ocaml/z3: deprecate phases`|`2021-08-04 15:43:19Z`|
|[`b22dd978`](https://github.com/NixOS/nixpkgs/commit/b22dd97818af18ec826997c99f8dfbf0b9d76115)|`miniball: deprecate phases`|`2021-08-04 15:43:19Z`|
|[`50bf14a4`](https://github.com/NixOS/nixpkgs/commit/50bf14a4d4e406b476b7d9cc3cc08216a40abddd)|`avr8-burn-omat: remove phases`|`2021-08-04 15:43:19Z`|
|[`afe3fa49`](https://github.com/NixOS/nixpkgs/commit/afe3fa49f9583536cb4808515cb13e5ceefa8caa)|`hunspell: remove phases`|`2021-08-04 15:43:16Z`|
|[`e7a35cdb`](https://github.com/NixOS/nixpkgs/commit/e7a35cdb31f84152b0090f653ae9bba50dd73082)|`aspell: deprecate phases`|`2021-08-04 15:42:38Z`|
|[`b80e2fa5`](https://github.com/NixOS/nixpkgs/commit/b80e2fa5090ff7a9d91a642c3410d631c1e43b94)|`postgresql_jdbc: remove phases`|`2021-08-04 15:39:00Z`|
|[`cfb9f807`](https://github.com/NixOS/nixpkgs/commit/cfb9f807557f350d9337b91925dd01cc6b642d9e)|`activemq: remove phases`|`2021-08-04 15:39:00Z`|
|[`1d847651`](https://github.com/NixOS/nixpkgs/commit/1d847651bcaad9d98ccccab329a3187eafc0f701)|`juju: 2.9.9 -> 2.9.10`|`2021-08-03 08:20:09Z`|
|[`579c17d7`](https://github.com/NixOS/nixpkgs/commit/579c17d7bcbe500b26cbacaa445608289f32ddd9)|`pympress: 1.5.1 -> 1.6.3`|`2021-08-02 22:57:38Z`|
|[`2c588e0e`](https://github.com/NixOS/nixpkgs/commit/2c588e0edde3d439988af84315a845df4f7e2bb0)|`wine{Unstable,Staging}: 6.13 -> 6.14`|`2021-08-02 19:19:43Z`|
|[`8d497293`](https://github.com/NixOS/nixpkgs/commit/8d497293052790ae8f08d369e80ba0b51cdba2be)|`qgis: 3.16.7 → 3.16.9`|`2021-08-01 10:36:28Z`|
|[`c98ce413`](https://github.com/NixOS/nixpkgs/commit/c98ce413852d42328b95458d12c032adf591c23b)|`opentx: 2.3.13 -> 2.3.14`|`2021-08-01 00:24:42Z`|
|[`90b7de20`](https://github.com/NixOS/nixpkgs/commit/90b7de20ac46928d14b5f8c3f2b95dc8638f415e)|`tree-sitter-fish: init at HEAD`|`2021-07-31 15:49:21Z`|
|[`71878bc1`](https://github.com/NixOS/nixpkgs/commit/71878bc1c919b283ea53b2d2724703baf874bd85)|`python3Packages.torrequest: init at 0.1.0`|`2021-07-31 05:11:29Z`|
|[`415bef17`](https://github.com/NixOS/nixpkgs/commit/415bef179d6ef9dce374700c29763dddd52ee9f3)|`omnisharp-roslyn: upgrade nuget to match msbuild`|`2021-07-30 20:10:03Z`|
|[`4a8f979c`](https://github.com/NixOS/nixpkgs/commit/4a8f979cf751b53090065f48a3e2eaffb8089c5c)|`omnisharp-roslyn: use dotnet-sdk_5`|`2021-07-30 20:10:03Z`|
|[`cb7c09ed`](https://github.com/NixOS/nixpkgs/commit/cb7c09eddb6d310937125dea98f0ac8007e7cbd1)|`omnisharp-roslyn: switch dotnet-sdk to PATH suffix`|`2021-07-30 20:10:03Z`|
|[`3672c0a3`](https://github.com/NixOS/nixpkgs/commit/3672c0a33fe52d2dd9b383f9d4114ad2e62eb590)|`msbuild: 16.8 -> 16.10.1`|`2021-07-30 20:10:03Z`|
|[`2615cc1b`](https://github.com/NixOS/nixpkgs/commit/2615cc1b131feb5cbcc23b5d98d5050f0c05dc85)|`pulumi-bin: 3.6.0 -> 3.9.0`|`2021-07-29 16:34:45Z`|
|[`666c2058`](https://github.com/NixOS/nixpkgs/commit/666c20584a156b2be9b08bd8f05497fc5708aebb)|`ledger2beancount: 2.5 -> 2.6`|`2021-07-28 07:57:34Z`|
|[`afb908bf`](https://github.com/NixOS/nixpkgs/commit/afb908bfbdc66dbf8892b862a04b18c6142225c3)|`tree-sitter-comment: init at 2021-04-27`|`2021-07-28 03:58:33Z`|
|[`9504a98c`](https://github.com/NixOS/nixpkgs/commit/9504a98c3266c247d47c0f56ee2c239863b2319b)|`avogadro2: init at 1.94.0`|`2021-07-27 16:43:15Z`|
|[`43e749aa`](https://github.com/NixOS/nixpkgs/commit/43e749aa76d28a28d3153ddeff6bf75204d71de1)|`avogadrolibs: init at 1.94.0`|`2021-07-27 16:43:15Z`|
|[`b5bf1346`](https://github.com/NixOS/nixpkgs/commit/b5bf1346c0e1379561029b0252742b7dc3b68856)|`molequeue: init at 0.9.0`|`2021-07-27 16:43:15Z`|
|[`3ea182f3`](https://github.com/NixOS/nixpkgs/commit/3ea182f32180abbb0bfd8896d812609f5a8c137a)|`mmtf-cpp: init at 1.0.0`|`2021-07-27 16:43:15Z`|
|[`a54c0b95`](https://github.com/NixOS/nixpkgs/commit/a54c0b9503e35e08fa6eef5dae87fda164267fa8)|`libmsym: init at 0.2.3`|`2021-07-27 16:43:15Z`|
|[`d7423272`](https://github.com/NixOS/nixpkgs/commit/d7423272a86b5104cd8cd65ee0a4c2adfe00b40c)|`codeql: 2.5.7 -> 2.5.8`|`2021-07-26 23:26:11Z`|
|[`045d6f35`](https://github.com/NixOS/nixpkgs/commit/045d6f35d92e932541ef4f1ab53062c01fb867ef)|`polymake: 3.2.rc4 -> 4.4`|`2021-07-25 23:12:21Z`|
|[`b1399834`](https://github.com/NixOS/nixpkgs/commit/b1399834acc8b3bd92e52b8d4ef8effc0dee66e6)|`entt: 3.7.1 -> 3.8.0`|`2021-07-23 04:51:33Z`|
|[`26a70a63`](https://github.com/NixOS/nixpkgs/commit/26a70a63cdb9f846c4a11847fe062c9705ba82a9)|`keybase-gui: 5.6.1 -> 5.7.1`|`2021-07-14 00:19:32Z`|
|[`57d0e94d`](https://github.com/NixOS/nixpkgs/commit/57d0e94d863d5027da4fb39e3c15e60f4e742068)|`minecraft-server: 1.17 -> 1.17.1`|`2021-07-06 20:30:59Z`|
|[`e28a8e1a`](https://github.com/NixOS/nixpkgs/commit/e28a8e1abeacd760fba767ba00b3e4d15841f933)|`joplin-desktop: fix icon`|`2021-07-04 12:28:25Z`|
|[`e7235d86`](https://github.com/NixOS/nixpkgs/commit/e7235d863c397c51715a1588865f1996ecc63608)|`vhd2vl: apply linting suggestions`|`2021-06-01 05:29:13Z`|
|[`0c2c7038`](https://github.com/NixOS/nixpkgs/commit/0c2c7038919a0e4a5802ab04a12302d4c73b13b2)|`vhd2vl: fix build error`|`2021-05-31 22:14:32Z`|
|[`bb544b10`](https://github.com/NixOS/nixpkgs/commit/bb544b10e7ae1cdb9b3dd88283188689ed9c726f)|`adoptopenjdk-icedtea-web: 1.8.6 -> 1.8.7`|`2021-05-28 00:33:30Z`|
|[`49b89bb8`](https://github.com/NixOS/nixpkgs/commit/49b89bb8f0442a30128fffe18974f3083fddd8d5)|`alephone-marathon: 20200904 -> 20210408`|`2021-05-23 02:13:52Z`|
|[`f75ccee1`](https://github.com/NixOS/nixpkgs/commit/f75ccee1f0e7b466e1ec29e7ee0aeec28a750060)|`galene: 0.3.4 -> 0.3.5`|`2021-05-22 16:52:10Z`|
|[`62b9e339`](https://github.com/NixOS/nixpkgs/commit/62b9e3398e24976c9de17769642514db745e21b9)|`felix: 6.0.3 -> 7.0.0`|`2021-04-05 08:41:01Z`|
|[`26c35fc5`](https://github.com/NixOS/nixpkgs/commit/26c35fc50219cb8d11650f07785ea46b9d5163da)|`go-protobuf: 1.5.1 -> 1.5.2`|`2021-03-30 12:20:43Z`|
|[`166e7724`](https://github.com/NixOS/nixpkgs/commit/166e772446eeda6704e57a13300d9a9de42824ed)|`python38Packages.gensim: 3.8.3 -> 4.0.0`|`2021-03-27 05:30:07Z`|
|[`f6914cf5`](https://github.com/NixOS/nixpkgs/commit/f6914cf52aa37d4e1866a9f08759405507d13ae6)|`manaplus: 1.9.3.23 -> 2.1.3.17`|`2021-03-25 15:47:15Z`|
|[`f9ce82fa`](https://github.com/NixOS/nixpkgs/commit/f9ce82fa752fc86ad0aae0c2f3a5bd59e1ba379d)|`hsqldb: 2.5.1 -> 2.6.0`|`2021-03-25 09:27:56Z`|
|[`c4611754`](https://github.com/NixOS/nixpkgs/commit/c4611754e8e53c06560a75ee37d8f055ed10e964)|`cproto: 4.7r -> 4.7s`|`2021-03-22 21:44:49Z`|
|[`6c81f568`](https://github.com/NixOS/nixpkgs/commit/6c81f568877c7cac80d8b8b168950c42d8fc604b)|`postsrsd: 1.10 -> 1.11`|`2021-03-22 14:43:22Z`|
|[`e669ec23`](https://github.com/NixOS/nixpkgs/commit/e669ec230f55aec86ffffeba17b7773650991bb9)|`git-hub: 2.1.0 -> 2.1.1`|`2021-03-22 08:20:31Z`|
|[`0206bf6d`](https://github.com/NixOS/nixpkgs/commit/0206bf6d7539c68108d100d46967983fc578ad4b)|`ibus-engines.bamboo: 0.6.9 -> 0.7.0`|`2021-03-18 08:46:31Z`|
|[`7720b9d9`](https://github.com/NixOS/nixpkgs/commit/7720b9d991d65be2af1620eda555ff0cd6bf0ecb)|`livepeer: 0.5.14 -> 0.5.15`|`2021-03-17 14:46:12Z`|
|[`295ceec2`](https://github.com/NixOS/nixpkgs/commit/295ceec29274801bf5af22eb92afe4173283abbe)|`AusweisApp2: 1.22.0 -> 1.22.1`|`2021-03-15 22:13:54Z`|
|[`029b6999`](https://github.com/NixOS/nixpkgs/commit/029b6999af486d7fd5aaaaaf6f69a84a15b6a0c8)|`fuse-emulator: 1.5.7 -> 1.6.0`|`2021-03-11 12:37:02Z`|
|[`3d014208`](https://github.com/NixOS/nixpkgs/commit/3d014208a5f18d1d75e67c2d10ef24a06dbf00a3)|`atlassian-cli: 9.5.0 -> 9.6.0`|`2021-02-18 20:08:10Z`|
|[`cba9bbf1`](https://github.com/NixOS/nixpkgs/commit/cba9bbf19bf521a0cb534769991d779209e2d682)|`grisbi: 2.0.1 -> 2.0.2`|`2021-02-12 12:20:59Z`|
|[`010f68be`](https://github.com/NixOS/nixpkgs/commit/010f68bef17753752668d66ccd8405f7659ca258)|`inadyn: 2.7 -> 2.8.1`|`2021-02-03 14:57:56Z`|
|[`ba1cf80b`](https://github.com/NixOS/nixpkgs/commit/ba1cf80b7ca43f85b9b31875dff75f8153fd64e8)|`kore: 4.0.1 -> 4.1.0`|`2021-01-30 10:35:03Z`|
|[`3225decd`](https://github.com/NixOS/nixpkgs/commit/3225decddf3965f95410c95ee01a6dfb512a1b99)|`pugixml: 1.11.1 -> 1.11.4`|`2021-01-21 01:37:23Z`|