### PR TITLE
feat(niv): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "84f5a2e5e5ac352e8400c361e4e648026b636423",
-        "sha256": "1k4d0yp319d35ld3nbn92a4fmv6pcbfxb8pd652y4qk2ckmbnwsz",
+        "rev": "c5077d5da247a6ef4d8f2c0463b3f112490b4348",
+        "sha256": "03w5zvz8s6z0ip5g1p1bghlwjfsdvwi5zx512nbm053nikdv8hyj",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/84f5a2e5e5ac352e8400c361e4e648026b636423.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/c5077d5da247a6ef4d8f2c0463b3f112490b4348.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
|SHA256|Commit Message|Timestamp|
|---|---|---|
|[`b00dd3ac`](https://github.com/NixOS/nixpkgs/commit/b00dd3ac1f53eebfd9c8291ce1fa10b559b04a04)|`nixos/tests/prometheus-exporters/kea: drop enable option`|`2021-08-08 23:49:54Z`|
|[`816b3dec`](https://github.com/NixOS/nixpkgs/commit/816b3decda2cc331ff2f8ef0cbfe39fbdb2882af)|`tabnine: 3.5.15 -> 3.5.37`|`2021-08-08 22:45:59Z`|
|[`7907d803`](https://github.com/NixOS/nixpkgs/commit/7907d803799bbf712fec4fd7ec55afead06dbeae)|`intel-graphics-compiler: deprecate phases and replace it with runCommandLocal`|`2021-08-08 21:55:07Z`|
|[`090a1588`](https://github.com/NixOS/nixpkgs/commit/090a15887460d208e5f382a89d4ae5fd1de5ffd5)|`linux_xanmod: 5.13.8 -> 5.13.9`|`2021-08-08 21:44:08Z`|
|[`8ab578e4`](https://github.com/NixOS/nixpkgs/commit/8ab578e496796accddeeceb48b966983cc90cd09)|`unicorn: 1.0.2 -> 1.0.3`|`2021-08-08 21:40:05Z`|
|[`9e9a7327`](https://github.com/NixOS/nixpkgs/commit/9e9a7327d1ecf4cca60f3362c1b0f1220708bbda)|`argyllcms: 2.1.2 -> 2.2.0`|`2021-08-08 20:59:53Z`|
|[`e19b326e`](https://github.com/NixOS/nixpkgs/commit/e19b326e1cde4de0110a3ffe831cb633ea5fba97)|`dprint: 0.15.0 -> 0.15.1`|`2021-08-08 20:29:33Z`|
|[`865e06fa`](https://github.com/NixOS/nixpkgs/commit/865e06fa211706dde4917ac4652accbe6456b7ee)|`python3Packages.pynetbox: 6.1.2 -> 6.1.3`|`2021-08-08 19:58:15Z`|
|[`da045464`](https://github.com/NixOS/nixpkgs/commit/da045464c49de77b0406e07bfc78d608646c84df)|`lynis: 3.0.5 -> 3.0.6`|`2021-08-08 18:55:39Z`|
|[`d3997e04`](https://github.com/NixOS/nixpkgs/commit/d3997e04fee19429d5c5697f8463c902342a1a7e)|`python3Packages.ha-philipsjs: 2.7.4 -> 2.7.5`|`2021-08-08 18:49:27Z`|
|[`a1a34f71`](https://github.com/NixOS/nixpkgs/commit/a1a34f71dc47eea6fc4b282907c496cd9f505c2f)|`fastnlo_toolkit: refactor to not define rev as environment variable`|`2021-08-08 18:05:32Z`|
|[`717538e9`](https://github.com/NixOS/nixpkgs/commit/717538e9082a42d97dce9f53740045a73865b18e)|`python3Packages.torchvision: added cudaSupport option (#132917)`|`2021-08-08 17:42:58Z`|
|[`8c656947`](https://github.com/NixOS/nixpkgs/commit/8c656947dcc908ea269b9df3dff3b6d83468d59a)|`python3Packages.subarulink: 0.3.14 -> 0.3.15`|`2021-08-08 17:33:16Z`|
|[`3b12f3c3`](https://github.com/NixOS/nixpkgs/commit/3b12f3c3cf1fbb82246b7408e049ce84aa387f17)|`python3Packages.solax: 0.2.6 -> 0.2.7`|`2021-08-08 17:28:17Z`|
|[`c0d7ec43`](https://github.com/NixOS/nixpkgs/commit/c0d7ec431db8af0dfc474617e417895ddc4b4447)|`python3Packages.pymata-express: 1.20 -> 1.21`|`2021-08-08 17:26:13Z`|
|[`1cffbf61`](https://github.com/NixOS/nixpkgs/commit/1cffbf616835878b6d982297346050c5c29b3eff)|`python3Packages.nad-receiver: 0.2.0 -> 0.3.0`|`2021-08-08 17:20:51Z`|
|[`dfc20639`](https://github.com/NixOS/nixpkgs/commit/dfc206394e271d02c7150cf4bc249ca5677f7906)|`ocamlPackages.ocsigen_server: 2.18.0 → 4.0.1`|`2021-08-08 17:18:39Z`|
|[`c1186b57`](https://github.com/NixOS/nixpkgs/commit/c1186b572f73ce45b2d60ce97ada6a25713d659a)|`maintainers: xwvvvvwx -> d-xo`|`2021-08-08 17:11:45Z`|
|[`12a866df`](https://github.com/NixOS/nixpkgs/commit/12a866dfd952c0907337448c7cce7b5e7d58d5a3)|`wbg: unstable-2020-08-01 -> 1.0.2`|`2021-08-08 16:45:16Z`|
|[`792abce1`](https://github.com/NixOS/nixpkgs/commit/792abce19438e0d900c0b8e1002d70322c9a3ed1)|`python3.pkgs.flufl_lock: 5.0.5 -> 5.1`|`2021-08-08 16:35:19Z`|
|[`ccd598cf`](https://github.com/NixOS/nixpkgs/commit/ccd598cfd654794e5d66c0175786e5f9d7eb9f68)|`tllist: refactor derivation`|`2021-08-08 16:26:07Z`|
|[`9bbb2391`](https://github.com/NixOS/nixpkgs/commit/9bbb2391e5ee8cf17fd99b63b93f1ee79441586b)|`orchis-theme: 2021-06-09 -> 2021-06-25`|`2021-08-08 16:21:16Z`|
|[`13be07b2`](https://github.com/NixOS/nixpkgs/commit/13be07b251b8fd64aabd39f97362f10dd0eb0b7a)|`tiny: 0.8.0 -> 0.9.0`|`2021-08-08 16:04:59Z`|
|[`14200c55`](https://github.com/NixOS/nixpkgs/commit/14200c55aa93e20bd099b9817232ef74c35e1f38)|`stylua: 0.10.0 -> 0.10.1`|`2021-08-08 15:33:19Z`|
|[`ceea8b2b`](https://github.com/NixOS/nixpkgs/commit/ceea8b2b35e46e8eddb766ea10cd30439dffe0f7)|`fcft: refactor derivation`|`2021-08-08 15:17:15Z`|
|[`765d5c71`](https://github.com/NixOS/nixpkgs/commit/765d5c71e4d113d17d5bfb712a58683298b369f5)|`keycloak: 15.0.0 -> 15.0.1`|`2021-08-08 14:47:09Z`|
|[`ba4fcbb3`](https://github.com/NixOS/nixpkgs/commit/ba4fcbb33f2a0880ea5f87ef2f2cee19670bb15d)|`foot: refactor derivation`|`2021-08-08 14:42:15Z`|
|[`87255d1f`](https://github.com/NixOS/nixpkgs/commit/87255d1fe7f767cc628a5811449ff88aea24c71a)|`jackett: 0.18.459 -> 0.18.531`|`2021-08-08 14:13:54Z`|
|[`85209382`](https://github.com/NixOS/nixpkgs/commit/85209382c1c4c9553e7d4fcb90cfa97c122545b2)|`nginx: allow overriding SSL trusted certificates when using ACME`|`2021-08-08 14:07:11Z`|
|[`cdba9b4f`](https://github.com/NixOS/nixpkgs/commit/cdba9b4fca8aa87829e8b77cb0a2eb90ea906da1)|`influxdb: 1.8.6 -> 1.8.9`|`2021-08-08 14:04:28Z`|
|[`84f00bc6`](https://github.com/NixOS/nixpkgs/commit/84f00bc630eb954576871fe108a4ef568c2ce524)|`helvum: 0.2.1 -> 0.3.0`|`2021-08-08 14:01:33Z`|
|[`d49cdfed`](https://github.com/NixOS/nixpkgs/commit/d49cdfed55863792c970f584e9ee370351ec8f71)|`pkgsi686Linux.llvmPackages_git.compiler-rt: fix build`|`2021-08-08 13:54:13Z`|
|[`9b10cb2c`](https://github.com/NixOS/nixpkgs/commit/9b10cb2cba5862194b043fd925acb69e5bf5b652)|`llvmPackages_git.lldb: python into lib & wrap binary`|`2021-08-08 13:54:12Z`|
|[`cab7daf2`](https://github.com/NixOS/nixpkgs/commit/cab7daf2c1443041753abf0d22830148a77694b1)|`llvmPackages_git.lldb: fix python lldb library`|`2021-08-08 13:54:12Z`|
|[`3731e2d9`](https://github.com/NixOS/nixpkgs/commit/3731e2d9b1b180a27487d89204e9e538a9983348)|`llvmPackages_git.compiler-rt: fix build on darwin`|`2021-08-08 13:54:12Z`|
|[`3e37e1d9`](https://github.com/NixOS/nixpkgs/commit/3e37e1d98096a50e2063e4ecefbab17aaaaf4c06)|`llvmPackages_git.clang: fix linker invocation with LLVMgold plugin`|`2021-08-08 13:54:11Z`|
|[`88b7302b`](https://github.com/NixOS/nixpkgs/commit/88b7302b9019a1ef08224961a862e9b6547b3b91)|`nitter: add test to passthru.tests`|`2021-08-08 13:33:08Z`|
|[`2e8e8f2c`](https://github.com/NixOS/nixpkgs/commit/2e8e8f2c92a76535fa0d44611a20b97ee6b75927)|`nixos/nitter: test with CAP_NET_BIND_SERVICE`|`2021-08-08 13:29:33Z`|
|[`9898f7e0`](https://github.com/NixOS/nixpkgs/commit/9898f7e0728d45cf9cd60d340e023683b7b6472d)|`nixos/nitter: systemd unit hardening`|`2021-08-08 13:28:27Z`|
|[`d104afea`](https://github.com/NixOS/nixpkgs/commit/d104afea069eb762f35085075c04a176f9c03c6f)|`headscale: 0.5.1 -> 0.5.2`|`2021-08-08 13:26:45Z`|
|[`e783c89a`](https://github.com/NixOS/nixpkgs/commit/e783c89ad978c438058c603b7bbb4d6aaf3daf28)|`hcloud: 1.21.0 -> 1.26.1`|`2021-08-08 13:19:08Z`|
|[`1f714c82`](https://github.com/NixOS/nixpkgs/commit/1f714c8205bb816dc71962ab97a771236f8f4218)|`grc: 1.12 -> 1.13`|`2021-08-08 13:03:21Z`|
|[`326a0a95`](https://github.com/NixOS/nixpkgs/commit/326a0a958da327ecc6b82acaae7482ac2e0bc430)|`gpg-tui: 0.7.3 -> 0.7.4`|`2021-08-08 12:52:39Z`|
|[`361fef52`](https://github.com/NixOS/nixpkgs/commit/361fef520190a28a0434274b3f13525138179453)|`fwts: cleanup`|`2021-08-08 12:42:48Z`|
|[`faab2fda`](https://github.com/NixOS/nixpkgs/commit/faab2fda34ba8fbc4f0ce93be47388fd17df9eb9)|`top-level/all-packages.nix: Remove self`|`2021-08-08 12:37:10Z`|
|[`8090305b`](https://github.com/NixOS/nixpkgs/commit/8090305b6496795ac8d3875e45733b00e00b4882)|`spamassassin: 3.4.5 -> 3.4.6`|`2021-08-08 12:28:44Z`|
|[`dbae6eea`](https://github.com/NixOS/nixpkgs/commit/dbae6eea00f5044e561493cc51ec60a9e5a3d8c8)|`ghq: 1.1.7 -> 1.2.1`|`2021-08-08 12:09:59Z`|
|[`3cd9a760`](https://github.com/NixOS/nixpkgs/commit/3cd9a760929c43e79c280f643c7ad7f355c8f3bd)|`go-containerregistry: make the package easier to find`|`2021-08-08 12:08:13Z`|
|[`76901019`](https://github.com/NixOS/nixpkgs/commit/7690101953af3be73576f7550427a7924a7afad4)|`nodePackages.degit: init at 2.8.4`|`2021-08-08 11:56:02Z`|
|[`09339da8`](https://github.com/NixOS/nixpkgs/commit/09339da83209e8b953ea3a7b829883aef4a7da68)|`frp: 0.36.1 -> 0.37.1`|`2021-08-08 11:49:40Z`|
|[`9c086360`](https://github.com/NixOS/nixpkgs/commit/9c086360f5037061424a16da9e75965daa82c8ec)|`tflint: 0.30.0 -> 0.31.0`|`2021-08-08 11:39:40Z`|
|[`d4d144e9`](https://github.com/NixOS/nixpkgs/commit/d4d144e98fc34c2331169595e5148972e19fdb11)|`wifite2: 2.5.5 -> 2.5.7`|`2021-08-08 11:30:40Z`|
|[`b8fbf8ac`](https://github.com/NixOS/nixpkgs/commit/b8fbf8acac6f54704e92ad5f4cb8675b0eb21933)|`fission: 1.13.1 -> 1.14.1`|`2021-08-08 11:26:27Z`|
|[`0ed79602`](https://github.com/NixOS/nixpkgs/commit/0ed7960274b3740b5741414f95322fcbc67a6dc1)|`reg: init at 0.16.1`|`2021-08-08 11:14:23Z`|
|[`6a04d273`](https://github.com/NixOS/nixpkgs/commit/6a04d273d660f2170686adf6103da1de0b5f500b)|`vscode-extensions/rust-analyzer: pin rollup dep to avoid regression.`|`2021-08-08 11:07:28Z`|
|[`56c9d57d`](https://github.com/NixOS/nixpkgs/commit/56c9d57d58dd31653b7c5d5d084a5d641395a449)|`lxd: add marsam to maintainers`|`2021-08-08 11:02:00Z`|
|[`861697b8`](https://github.com/NixOS/nixpkgs/commit/861697b840e27934b6d6989500dfaaea01a30101)|`lxd: 4.16 -> 4.17`|`2021-08-08 11:01:00Z`|
|[`023f0daa`](https://github.com/NixOS/nixpkgs/commit/023f0daa24ff2fada579570029038c170c382e67)|`esbuild: 0.12.18 -> 0.12.19`|`2021-08-08 11:00:42Z`|
|[`b2ca1b97`](https://github.com/NixOS/nixpkgs/commit/b2ca1b97cef97dc73605fdf5b54a2bb15725c5c0)|`raft-canonical: 0.10.1 -> 0.11.2`|`2021-08-08 11:00:00Z`|
|[`98533894`](https://github.com/NixOS/nixpkgs/commit/98533894909de2dfaf956339935e3380e31e9e30)|`rocksdb: 6.17.3 -> 6.23.2`|`2021-08-08 11:00:00Z`|
|[`7956e6e8`](https://github.com/NixOS/nixpkgs/commit/7956e6e8721ca91fe03afb88fbc9396713f73fee)|`zola: 2021-07-14 -> 0.14.0`|`2021-08-08 11:00:00Z`|
|[`d111adc1`](https://github.com/NixOS/nixpkgs/commit/d111adc10fa59c16f252475155c134c1359b6528)|`dqlite: 1.8.0 -> 1.9.0`|`2021-08-08 11:00:00Z`|
|[`02130271`](https://github.com/NixOS/nixpkgs/commit/021302710e17054502ae55c127b08c33d05a6448)|`epubcheck: 4.2.4 -> 4.2.6`|`2021-08-08 10:55:55Z`|
|[`f8634b5d`](https://github.com/NixOS/nixpkgs/commit/f8634b5d952787f395def53353c51a01329e80f3)|`lagrange: 1.5.2 → 1.6.2`|`2021-08-08 10:54:39Z`|
|[`dc44b90b`](https://github.com/NixOS/nixpkgs/commit/dc44b90bbcb6eedb1a5eae9b279f407b23f70f03)|`entt: 3.8.0 -> 3.8.1`|`2021-08-08 10:46:14Z`|
|[`ea1d43b1`](https://github.com/NixOS/nixpkgs/commit/ea1d43b12f9f6009371d60e315abca1bb0df3fef)|`cl-wrapper-script: deprecate phases`|`2021-08-08 10:38:41Z`|
|[`d89f7ca8`](https://github.com/NixOS/nixpkgs/commit/d89f7ca8de29e2300b6fd8b4784d0f1653cbd3d9)|`elogind: 246.9.2 -> 246.10`|`2021-08-08 10:38:28Z`|
|[`802e5faf`](https://github.com/NixOS/nixpkgs/commit/802e5fafc6a6cb69344d97a53afbe75d37da9ed5)|`eggdrop: 1.8.4 -> 1.9.1`|`2021-08-08 10:26:38Z`|
|[`a57ddffc`](https://github.com/NixOS/nixpkgs/commit/a57ddffcab06048086a38c082dc0400c9acb1446)|`dolt: 0.24.1 -> 0.27.2`|`2021-08-08 10:13:50Z`|
|[`a613b9c7`](https://github.com/NixOS/nixpkgs/commit/a613b9c7a5a1edbe43008c65288cfeff11d9fea3)|`czkawka: 3.1.0 -> 3.2.0`|`2021-08-08 09:44:47Z`|
|[`891a21cd`](https://github.com/NixOS/nixpkgs/commit/891a21cddeb3f165c4639b53dea43e3b80a409b0)|`maintainers: add ereslibre`|`2021-08-08 09:39:04Z`|
|[`59b6ec82`](https://github.com/NixOS/nixpkgs/commit/59b6ec82f38ddacd1150d48f96b449c6626f9e79)|`cherrytree: 0.99.39 -> 0.99.40`|`2021-08-08 08:50:26Z`|
|[`dfd825e2`](https://github.com/NixOS/nixpkgs/commit/dfd825e2e21e6a500db36dabb53ae53895079fe8)|`boops: 1.6.0 -> 1.6.4`|`2021-08-08 08:17:59Z`|
|[`03c5948c`](https://github.com/NixOS/nixpkgs/commit/03c5948c1223b96a664c8c6731e28d637ccfb82d)|`AusweisApp2: 1.22.1 -> 1.22.2`|`2021-08-08 07:25:27Z`|
|[`c070b9e4`](https://github.com/NixOS/nixpkgs/commit/c070b9e4f55bf474241359621bbb564fc00a39bc)|`pythonPackages.resolvelib: 0.7.1 -> 0.5.5`|`2021-08-07 23:27:54Z`|
|[`b5eb352a`](https://github.com/NixOS/nixpkgs/commit/b5eb352a05ebea3dddf6ca68d8795edefd5a2dd8)|`python3Packages.trackpy: unbreak`|`2021-08-07 21:04:32Z`|
|[`696651e5`](https://github.com/NixOS/nixpkgs/commit/696651e5684cc7a547380509681563c2cd962237)|`fllog: 1.2.6 -> 1.2.7`|`2021-08-07 20:36:28Z`|
|[`a2943e74`](https://github.com/NixOS/nixpkgs/commit/a2943e74e3bb7c8c793bf6e03a81b446038f6b53)|`nixos/nullmailer: Create "failed" directory`|`2021-08-06 08:48:19Z`|
|[`9ad29128`](https://github.com/NixOS/nixpkgs/commit/9ad291281098db0268a53f3b3943e8b180ec774d)|`kodi.packages.steam-library: init at 0.8.0`|`2021-08-05 23:46:30Z`|
|[`57cf959a`](https://github.com/NixOS/nixpkgs/commit/57cf959a4226d2ddc664561a1f4c0bdcb38fc24c)|`kodi.packages.requests-cache: init at 0.5.2+matrix.2`|`2021-08-05 23:46:20Z`|
|[`5b6ced84`](https://github.com/NixOS/nixpkgs/commit/5b6ced844c465e9d9ce5b05ae706d23eaac41ec6)|`kodi.packages.routing: init at 0.2.3+matrix.1`|`2021-08-05 23:46:02Z`|
|[`24ba262f`](https://github.com/NixOS/nixpkgs/commit/24ba262fbe335f6cb853f9c66b48968b0acf6dfb)|`ddccontrol-db: 20210505 -> 20210804`|`2021-08-05 05:16:00Z`|
|[`32f27126`](https://github.com/NixOS/nixpkgs/commit/32f2712625b845aaf4f457d60ff660b58315c38a)|`fastnlo_toolkit: enable tests`|`2021-08-02 11:41:35Z`|
|[`3e4f2f4f`](https://github.com/NixOS/nixpkgs/commit/3e4f2f4f51bd2e6c07d304b5f46247b6fb8a00f8)|`fastnlo_toolkit: 2.3.1pre-2411 -> 2.5.0pre-2823`|`2021-08-02 11:41:34Z`|
|[`48642977`](https://github.com/NixOS/nixpkgs/commit/48642977c571fc2f496bf5b738ebc3a2cb76b005)|`acme-sh: 2.9.0 -> 3.0.0`|`2021-08-02 09:01:25Z`|
|[`bd14d737`](https://github.com/NixOS/nixpkgs/commit/bd14d737946ecc507b73850ce16887703751a567)|`nixos/modules/virtualisation/containerd: do not wipe runtime directory on restart or stop`|`2021-07-29 15:17:40Z`|
|[`de61196f`](https://github.com/NixOS/nixpkgs/commit/de61196f4500b2e5d36a3738d089120aaf047e48)|`evolution-ews: 3.40.1 -> 3.40.3`|`2021-07-28 16:00:20Z`|
|[`7b8f06d2`](https://github.com/NixOS/nixpkgs/commit/7b8f06d27c0a2a019d3ad6a2c10fc5b55a2b48da)|`dendrite: 0.4.0 -> 0.4.1`|`2021-07-28 14:43:43Z`|
|[`6b2f8539`](https://github.com/NixOS/nixpkgs/commit/6b2f85397585441209be0edd33e17293458a6dbc)|`commonsCompress: 1.20 -> 1.21`|`2021-07-25 13:25:09Z`|
|[`3f24366c`](https://github.com/NixOS/nixpkgs/commit/3f24366cdad97834f0662d5844996f9d439e82cc)|`cwltool: init at 3.1.20210628163208`|`2021-07-22 02:11:17Z`|
|[`81e3df35`](https://github.com/NixOS/nixpkgs/commit/81e3df355a6ea9cf3af0565de9604eaee08ebafb)|`pythonPackages.shellescape: init at 3.8.1`|`2021-07-22 02:11:16Z`|
|[`ee63a081`](https://github.com/NixOS/nixpkgs/commit/ee63a081baa0b31e8a8f39ef07cb6cd86df5d82f)|`pythonPackages.schema-salad: init at 8.1.20210716111910`|`2021-07-22 02:11:15Z`|
|[`088aee7b`](https://github.com/NixOS/nixpkgs/commit/088aee7bf0c0067ad927d4a8da66ba1aca60bbda)|`pythonPackages.bagit: init at 1.8.1`|`2021-07-22 02:11:15Z`|
|[`b5f5a5e3`](https://github.com/NixOS/nixpkgs/commit/b5f5a5e3413d2ae7d6f56608eff101823c2bb8e6)|`nixos/polkit: put polkituser into polkitgroup`|`2021-07-18 06:58:30Z`|
|[`f3dfc114`](https://github.com/NixOS/nixpkgs/commit/f3dfc114680d3e191fccdbaed4051b0837647b04)|`nixos/tinc: don't run as nogroup`|`2021-07-18 06:57:14Z`|
|[`ad59e627`](https://github.com/NixOS/nixpkgs/commit/ad59e62780bd8889cd73c4e5427cf5acaeaafe4d)|`nixos/journald: don't set nogroup`|`2021-07-18 06:46:54Z`|
|[`19b1eac1`](https://github.com/NixOS/nixpkgs/commit/19b1eac1b07b2c13555593fa4fbc53cffc61952c)|`nixos/mullvad-vpn: fix firewall issues & remove xfix as maintainer`|`2021-07-13 09:14:13Z`|
|[`eba6713e`](https://github.com/NixOS/nixpkgs/commit/eba6713e8f47b4f50374f8bf27034a3bc2826514)|`nixos/tests/acme: test access to files outside /var/lib/acme in postRun`|`2021-07-06 13:16:24Z`|
|[`7a10478e`](https://github.com/NixOS/nixpkgs/commit/7a10478ea7b992ffa1f19f389e53df0fe2aa936d)|`nixos/acme: harden systemd units`|`2021-07-06 13:16:01Z`|
|[`3cd3aa74`](https://github.com/NixOS/nixpkgs/commit/3cd3aa74ba1955fb100c4f93c7032aa4cd8ef4cd)|`gnomeExtensions.gsconnect: 46 -> 47`|`2021-06-19 20:07:52Z`|
|[`8c3cc186`](https://github.com/NixOS/nixpkgs/commit/8c3cc186b26add445bc0a1b4a3aea752aaa0d65a)|`liblouis: 3.17.0 -> 3.18.0`|`2021-06-08 06:25:39Z`|
|[`4ff18186`](https://github.com/NixOS/nixpkgs/commit/4ff181860d41dcbd86217b5e52e29c7e51d6b137)|`gbenchmark: 1.5.2 -> 1.5.3`|`2021-04-25 23:53:49Z`|
|[`5b296b6a`](https://github.com/NixOS/nixpkgs/commit/5b296b6af896cbbbb24c6870dc7e046f6dd306e4)|`t1utils: 1.41 -> 1.42`|`2021-03-10 01:51:10Z`|
|[`620a0dbf`](https://github.com/NixOS/nixpkgs/commit/620a0dbfbb258865755d52d2c40e7c8c7d8ca3d8)|`sysvinit: 2.97 -> 2.99`|`2021-03-09 22:28:28Z`|
|[`bf9cf100`](https://github.com/NixOS/nixpkgs/commit/bf9cf1004306d183b198e1f967c383991da70ce4)|`rsyslog: 8.2006.0 -> 8.2102.0`|`2021-03-09 15:28:15Z`|
|[`5085ef3e`](https://github.com/NixOS/nixpkgs/commit/5085ef3e03213d2a4a1c05496bc74d6158c3d2bc)|`sg3_utils: 1.45 -> 1.46r862`|`2021-03-09 14:44:04Z`|
|[`14232284`](https://github.com/NixOS/nixpkgs/commit/1423228413e28d4f4f8fffced1dcea529ef6ba5a)|`xl2tpd: 1.3.15 -> 1.3.16`|`2021-02-09 19:14:21Z`|
|[`193f7f21`](https://github.com/NixOS/nixpkgs/commit/193f7f211cd5468bf431f60e2b01bc004424884b)|`kdevelop-unwrapped: 5.6.1 -> 5.6.2`|`2021-02-04 16:51:32Z`|
|[`6f4e6cd8`](https://github.com/NixOS/nixpkgs/commit/6f4e6cd819173f8d2aaebdc73b7583d6f10973bb)|`nixos/chrony: split the initstepslew attrset into options`|`2021-02-03 00:26:47Z`|
|[`087011cc`](https://github.com/NixOS/nixpkgs/commit/087011cc68bc0b8a955220ec400a6bad9d0819e9)|`nixos/wakeonlan: add types`|`2021-01-31 12:26:12Z`|
|[`5a589075`](https://github.com/NixOS/nixpkgs/commit/5a589075f6b3a4f49be58b47a1fd775a59f97f7b)|`libsForQt5.kquickimageedit: 0.1.2 -> 0.1.3`|`2021-01-30 07:43:26Z`|