### PR TITLE
feat(niv): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c5077d5da247a6ef4d8f2c0463b3f112490b4348",
-        "sha256": "03w5zvz8s6z0ip5g1p1bghlwjfsdvwi5zx512nbm053nikdv8hyj",
+        "rev": "2995a644bfa2a6825a11ad49c2ed0e8b8c654252",
+        "sha256": "1h7wld0xqcpllkm4gz4w251670xqm942wlg981vhr4581vkyrknk",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/c5077d5da247a6ef4d8f2c0463b3f112490b4348.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/2995a644bfa2a6825a11ad49c2ed0e8b8c654252.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
|SHA256|Commit Message|Timestamp|
|---|---|---|
|[`732b2f87`](https://github.com/NixOS/nixpkgs/commit/732b2f8759f3f85ed7beba6f371abc15a2b4ad6e)|`firefox-bin: fix parameter of updateScript`|`2021-08-09 10:09:43Z`|
|[`de5a1390`](https://github.com/NixOS/nixpkgs/commit/de5a1390bdb9b6e4fb1d385dcfade28f52225634)|`wolfssl: remove myself from maintainers`|`2021-08-09 09:07:10Z`|
|[`f3bcf7c2`](https://github.com/NixOS/nixpkgs/commit/f3bcf7c2068af2c3317eb1e86039d4011fec4046)|`python3Packages.pyupgrade: 2.23.1 -> 2.23.3`|`2021-08-09 08:12:19Z`|
|[`1884aebc`](https://github.com/NixOS/nixpkgs/commit/1884aebc9a777cb889638849b595c3574b6e42ec)|`rewritefs: 2017-08-14 -> 2020-02-21`|`2021-08-09 07:26:15Z`|
|[`b09e3115`](https://github.com/NixOS/nixpkgs/commit/b09e31159179854eb0abbabd7d5b60b8a53210c5)|`tailscale: fix runtime dependency on procps`|`2021-08-09 07:14:07Z`|
|[`31955622`](https://github.com/NixOS/nixpkgs/commit/319556224cdf20bef78a7395de9fcc5ff06d2d79)|`python3Packages.plugwise: 0.11.1 -> 0.11.2`|`2021-08-09 06:50:35Z`|
|[`f57a3d0f`](https://github.com/NixOS/nixpkgs/commit/f57a3d0f9e3df95bef1f73faa943b0e97bfcdf6e)|`python3Packages.types-requests: 2.25.1 -> 2.25.6`|`2021-08-09 06:39:42Z`|
|[`8e6acb75`](https://github.com/NixOS/nixpkgs/commit/8e6acb7588e282347a2375b7e93f1d7bd9c22f28)|`python3Packages.types-decorator: 0.1.5 -> 0.1.7`|`2021-08-09 06:38:21Z`|
|[`03a7b232`](https://github.com/NixOS/nixpkgs/commit/03a7b232b0e2a0694f5ebbaaf244321229e65d15)|`vscodium: 1.58.2 -> 1.59.0`|`2021-08-09 06:09:03Z`|
|[`5c25004d`](https://github.com/NixOS/nixpkgs/commit/5c25004d57c3269a638a5d245854b214cc86d752)|`ircdHybrid: 8.2.36 -> 8.2.38`|`2021-08-09 06:06:35Z`|
|[`40e4d4d5`](https://github.com/NixOS/nixpkgs/commit/40e4d4d50df435e6c26f8b6d88f31551d544ee9f)|`lenmus: mark as broken for aarch64`|`2021-08-09 06:01:01Z`|
|[`94f9f61f`](https://github.com/NixOS/nixpkgs/commit/94f9f61f64cec4cdb628ce633e7eea2a5cf83922)|`wxsqlite3: 4.6.2 -> 4.6.4`|`2021-08-09 05:58:15Z`|
|[`ebc4dae8`](https://github.com/NixOS/nixpkgs/commit/ebc4dae8cb65706c5d91afe3dc39d1f6c0f17e5e)|`python310: 3.10.0b3 -> 3.10.0rc1`|`2021-08-09 05:49:03Z`|
|[`58647d0b`](https://github.com/NixOS/nixpkgs/commit/58647d0bbf47572e4a9c1eefbd53c2f31c4aeae2)|`vscode: 1.58.2 -> 1.59.0`|`2021-08-09 04:54:36Z`|
|[`d63e4e23`](https://github.com/NixOS/nixpkgs/commit/d63e4e2367bd53089d51673236289468b0256daa)|`aws-sdk-cpp: fix cross-OS crosscompilation (#133182)`|`2021-08-09 01:08:47Z`|
|[`18a4e4f9`](https://github.com/NixOS/nixpkgs/commit/18a4e4f94f50b991280148c9b3b3325d577d5c2b)|`ecl, ecl_16_1_2: make sure ar is in PATH`|`2021-08-09 01:01:02Z`|
|[`32313424`](https://github.com/NixOS/nixpkgs/commit/323134240a18ecd771df0d3258d71949c6de932a)|`gama: 2.12 -> 2.14`|`2021-08-09 00:26:53Z`|
|[`cbb5ca89`](https://github.com/NixOS/nixpkgs/commit/cbb5ca89ca473f09d8c1abf274f48b19700de57c)|`linux/hardened/patches/5.4: 5.4.134-hardened1 -> 5.4.139-hardened1`|`2021-08-08 23:19:19Z`|
|[`7aae6061`](https://github.com/NixOS/nixpkgs/commit/7aae6061b6e9879590e4f4315be2b6bdb3b90c09)|`linux/hardened/patches/5.10: 5.10.52-hardened1 -> 5.10.57-hardened1`|`2021-08-08 23:19:18Z`|
|[`0a411834`](https://github.com/NixOS/nixpkgs/commit/0a41183454eeed7ce105a08ecd8e2ba438bf858d)|`linux/hardened/patches/4.19: 4.19.198-hardened1 -> 4.19.202-hardened1`|`2021-08-08 23:19:17Z`|
|[`b84eecf9`](https://github.com/NixOS/nixpkgs/commit/b84eecf9fc114625f43f9d6cad035d61ad2c439c)|`linux/hardened/patches/4.14: 4.14.240-hardened1 -> 4.14.243-hardened1`|`2021-08-08 23:19:16Z`|
|[`8425e47a`](https://github.com/NixOS/nixpkgs/commit/8425e47a7416facee6cb0b8dce122715c152ed5b)|`linux-rt_5_10: 5.10.52-rt47 -> 5.10.56-rt48`|`2021-08-08 23:18:42Z`|
|[`b570def2`](https://github.com/NixOS/nixpkgs/commit/b570def284bedd5821a5d8faf4fc7110b0c8b809)|`linux: 5.4.134 -> 5.4.139`|`2021-08-08 23:18:07Z`|
|[`d416101b`](https://github.com/NixOS/nixpkgs/commit/d416101b659c8bd8fd3cb224bce5803a0e70e6e8)|`linux: 5.13.8 -> 5.13.9`|`2021-08-08 23:18:00Z`|
|[`cde60469`](https://github.com/NixOS/nixpkgs/commit/cde6046992f56b51de41275340560283c5ae6c7d)|`linux: 5.10.52 -> 5.10.57`|`2021-08-08 23:17:53Z`|
|[`a5713826`](https://github.com/NixOS/nixpkgs/commit/a5713826c48b70b04b6963cd621f4e64a267fab3)|`linux: 4.9.278 -> 4.9.279`|`2021-08-08 23:17:45Z`|
|[`1adb2898`](https://github.com/NixOS/nixpkgs/commit/1adb289851291353b4062c7d0fe10598de804668)|`linux: 4.4.278 -> 4.4.279`|`2021-08-08 23:17:40Z`|
|[`553c6ef1`](https://github.com/NixOS/nixpkgs/commit/553c6ef12af489a7bd60d5ca9260246aca20a1fe)|`linux: 4.19.198 -> 4.19.202`|`2021-08-08 23:17:36Z`|
|[`26ec7c39`](https://github.com/NixOS/nixpkgs/commit/26ec7c39bb796dd5122dbe60288f81741e91bd0a)|`linux: 4.14.240 -> 4.14.243`|`2021-08-08 23:17:24Z`|
|[`64f7698f`](https://github.com/NixOS/nixpkgs/commit/64f7698fc2bd2e2503aa43ec448e6851f65b5b7a)|`scala-runners: unstable-2020-02-02 -> unstable-2021-07-28`|`2021-08-08 22:16:50Z`|
|[`9437d2ca`](https://github.com/NixOS/nixpkgs/commit/9437d2ca411c1857f324de3a02ca72ef6e344979)|`python3Packages.gremlinpython: 3.4.10 -> 3.5.1`|`2021-08-08 21:16:54Z`|
|[`ccef83bd`](https://github.com/NixOS/nixpkgs/commit/ccef83bd40028cb2dd852e9c170307d4936f40d8)|`ecl_16_1_2: fix linking of compiled programs`|`2021-08-08 18:16:36Z`|
|[`38b4a436`](https://github.com/NixOS/nixpkgs/commit/38b4a4364de02412795e4a452a0cfab9189d228f)|`ecl: inform ecl about libraries to link against via configure flags`|`2021-08-08 18:09:38Z`|
|[`c8db49f0`](https://github.com/NixOS/nixpkgs/commit/c8db49f0a939ce2219b41f8d3993268ceeef05f1)|`pkgsi686Linux.llvmPackages_13.compiler-rt: fix build`|`2021-08-08 17:19:54Z`|
|[`a5f07334`](https://github.com/NixOS/nixpkgs/commit/a5f0733461e6937d0397e2afdef73db15f748c61)|`llvmPackages_13.lldb: python into lib & wrap binary`|`2021-08-08 17:19:47Z`|
|[`a6defaf9`](https://github.com/NixOS/nixpkgs/commit/a6defaf953d4470a9dcf8cae3bef1c2c4d17f296)|`llvmPackages_13.lldb: fix python lldb library`|`2021-08-08 17:19:41Z`|
|[`6a1354b1`](https://github.com/NixOS/nixpkgs/commit/6a1354b1fc14dfd549bd88f58aede0178f489415)|`llvmPackages_13.compiler-rt: fix build on darwin`|`2021-08-08 17:19:35Z`|
|[`c858c420`](https://github.com/NixOS/nixpkgs/commit/c858c42002313cc5f9c837c10d8b3babddc77b32)|`llvmPackages_13.clang: fix linker invocation with LLVMgold plugin`|`2021-08-08 17:19:27Z`|
|[`b0fc6e8f`](https://github.com/NixOS/nixpkgs/commit/b0fc6e8ff921343e365f726a96b8419515936f4d)|`make-initrd: fix #132059`|`2021-08-08 05:53:59Z`|
|[`a443496e`](https://github.com/NixOS/nixpkgs/commit/a443496e847ca1def86acd45f06b86c41dc07325)|`meshcentral: 0.8.87 -> 0.8.98`|`2021-08-08 05:52:21Z`|
|[`67a7f010`](https://github.com/NixOS/nixpkgs/commit/67a7f01005321b751a44e07b06a708a3ba165d74)|`buildkit: 0.8.3 -> 0.9.0`|`2021-08-08 04:20:00Z`|
|[`c520a26b`](https://github.com/NixOS/nixpkgs/commit/c520a26b7e8a1754697658dc29fd247a9758d719)|`cntr: add passthru.tests`|`2021-04-07 18:27:18Z`|
|[`b1672eee`](https://github.com/NixOS/nixpkgs/commit/b1672eee0cc014408bff056375436fb25d6235ab)|`nixosTests.cntr: init`|`2021-04-07 18:27:17Z`|
|[`1bfbe393`](https://github.com/NixOS/nixpkgs/commit/1bfbe393c28f2a15b084ff8bd49b73a36dc316fb)|`libsForQt5.phonon-backend-vlc: 0.11.1 -> 0.11.2`|`2021-02-08 02:52:51Z`|