### PR TITLE
feat(niv): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2995a644bfa2a6825a11ad49c2ed0e8b8c654252",
-        "sha256": "1h7wld0xqcpllkm4gz4w251670xqm942wlg981vhr4581vkyrknk",
+        "rev": "d7b436eac25921844e28b97bc3bc19f64af10927",
+        "sha256": "0jyhrs7i4rm87w26fhmasr8qs0k1334qq5kba6r2im35jjq6x3cd",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/2995a644bfa2a6825a11ad49c2ed0e8b8c654252.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/d7b436eac25921844e28b97bc3bc19f64af10927.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
|SHA256|Commit Message|Timestamp|
|---|---|---|
|[`7ed340a5`](https://github.com/NixOS/nixpkgs/commit/7ed340a58586337896b28a0a02954afa982a36d1)|`firefox-bin: 90.0.2 -> 91.0`|`2021-08-09 22:43:50Z`|
|[`afb0e73e`](https://github.com/NixOS/nixpkgs/commit/afb0e73ebc17e558416491307ccfb02d585e4436)|`firefox-esr-91: init at 91.0esr`|`2021-08-09 22:43:50Z`|
|[`810b0360`](https://github.com/NixOS/nixpkgs/commit/810b03602b7c51c120503a1dbfa2a33c67a6f8d2)|`firefox: 90.0.2 -> 91.0`|`2021-08-09 22:43:50Z`|
|[`a1161b3d`](https://github.com/NixOS/nixpkgs/commit/a1161b3dc0d56407465d88ff18b0a1d64ef298b0)|`vscode-extensions.vadimcn.vscode-lldb: Fix build on Darwin`|`2021-08-09 22:40:56Z`|
|[`3f7771d6`](https://github.com/NixOS/nixpkgs/commit/3f7771d65cca13a229e11f4aeaaf9245414a2134)|`unifi6: 6.2.25 -> 6.2.26`|`2021-08-09 21:28:07Z`|
|[`12e3001d`](https://github.com/NixOS/nixpkgs/commit/12e3001dadb1f08db7ec13ba232894d3874964eb)|`sdcc: honour dontStrip`|`2021-08-09 20:10:14Z`|
|[`f8c133f9`](https://github.com/NixOS/nixpkgs/commit/f8c133f9776560031bb55ea84db5d0b12ab256ec)|`grafana-agent: 0.18.0 -> 0.18.1`|`2021-08-09 19:56:53Z`|
|[`a71cb740`](https://github.com/NixOS/nixpkgs/commit/a71cb740fc9233d2ee5fdb304dc62726e49319ad)|`goxel: 0.10.7 -> 0.10.8`|`2021-08-09 19:43:38Z`|
|[`b02c2651`](https://github.com/NixOS/nixpkgs/commit/b02c26519027b227c268fb4cde0cd5057fa85b67)|`luaPackages: update`|`2021-08-09 19:38:32Z`|
|[`fa1dedee`](https://github.com/NixOS/nixpkgs/commit/fa1dedee47f37c5df65589fcf47f307f9bfabd9e)|`doc: updated lua doc`|`2021-08-09 19:37:58Z`|
|[`560a4e4e`](https://github.com/NixOS/nixpkgs/commit/560a4e4e086ea748a7836c62a167db959d3767d2)|`update-luarocks-packages: use pluginupdate.py`|`2021-08-09 19:37:56Z`|
|[`7b554c94`](https://github.com/NixOS/nixpkgs/commit/7b554c947764b14cec5d6b839a6d52666190e223)|`nixosTests.pleroma: increase server memory size`|`2021-08-09 19:30:42Z`|
|[`885ab928`](https://github.com/NixOS/nixpkgs/commit/885ab9286e4be1f353ee3883361d103791101d7b)|`nixosTests.pleroma: increase certificate validity duration`|`2021-08-09 19:30:42Z`|
|[`817a0e1a`](https://github.com/NixOS/nixpkgs/commit/817a0e1ab1f55f3261cbee1ee0485129070e1c46)|`pleroma: 2.3.0 -> 2.4.0`|`2021-08-09 19:30:42Z`|
|[`06684792`](https://github.com/NixOS/nixpkgs/commit/06684792fb7b739f4081e21824952911d35c1bc7)|`vimPlugins.plenary: init from lua package`|`2021-08-09 19:23:29Z`|
|[`0596bb2b`](https://github.com/NixOS/nixpkgs/commit/0596bb2b1cfa3b082de83100d4fc641510754a1f)|`go-chromecast: 0.2.9 -> 0.2.10`|`2021-08-09 19:23:25Z`|
|[`ad216be1`](https://github.com/NixOS/nixpkgs/commit/ad216be1b05d7946ce8d3fc7438c1125ea3a8faf)|`fend: 0.1.23 -> 0.1.24`|`2021-08-09 18:10:05Z`|
|[`8f31366a`](https://github.com/NixOS/nixpkgs/commit/8f31366a8c36780bb29f3253496d6ed9d5e39fde)|`discordchatexporter-cli: 2.29 -> 2.30`|`2021-08-09 17:30:15Z`|
|[`2b2a5347`](https://github.com/NixOS/nixpkgs/commit/2b2a534741cb19193230b9ea3defa925857d8341)|`dictu: 0.19.0 -> 0.20.0`|`2021-08-09 17:24:52Z`|
|[`0066c05a`](https://github.com/NixOS/nixpkgs/commit/0066c05ae2cfa7b7d56b8bd47468bb34d45fb092)|`nodejs-16_x: 16.5.0 -> 16.6.1`|`2021-08-09 16:12:34Z`|
|[`f57a20cb`](https://github.com/NixOS/nixpkgs/commit/f57a20cb0f20741de7eebaaf8225a1018c36f0ef)|`emacs.pkgs: Unmark various packages as broken`|`2021-08-09 16:10:49Z`|
|[`f16321aa`](https://github.com/NixOS/nixpkgs/commit/f16321aad44d10cd45a3ef3453a3e98133d2f145)|`chrome-token-signing: 1.1.2-1 -> 1.1.5`|`2021-08-09 15:40:37Z`|
|[`9d5be2dc`](https://github.com/NixOS/nixpkgs/commit/9d5be2dce43b583f0ea97bad7535ae67b857e12d)|`checkstyle: 8.45 -> 8.45.1`|`2021-08-09 15:35:52Z`|
|[`224e516c`](https://github.com/NixOS/nixpkgs/commit/224e516ccb02ca1ed914fdbf695fe448737326a6)|`oh-my-fish: init at 7+unstable=2021-03-03`|`2021-08-09 14:54:53Z`|
|[`c660c934`](https://github.com/NixOS/nixpkgs/commit/c660c9342c551547ad51b1087f6400c8177a23ae)|`carla: 2.3.1 -> 2.3.2`|`2021-08-09 14:39:51Z`|
|[`dc79d3b0`](https://github.com/NixOS/nixpkgs/commit/dc79d3b0da29cd63e4e8498feaec23db0bcb6f84)|`emacsPackages: fix for missing passthru`|`2021-08-09 13:34:27Z`|
|[`2df8eb3d`](https://github.com/NixOS/nixpkgs/commit/2df8eb3d19a208b2b870cbf5e8ec108a6b1cfb54)|`guile-lib: 0.2.6.1 -> 0.2.7`|`2021-08-09 13:15:51Z`|
|[`6ae576c8`](https://github.com/NixOS/nixpkgs/commit/6ae576c8da48f5c824ad4b336781c8c969092a7f)|`home-assistant: 2021.8.3 -> 2021.8.4`|`2021-08-09 12:40:54Z`|
|[`22fdabc4`](https://github.com/NixOS/nixpkgs/commit/22fdabc4cbf2c80b9d040b75390da6bbde816d42)|`liquibase: 4.4.2 -> 4.4.3`|`2021-08-09 12:14:56Z`|
|[`938c221d`](https://github.com/NixOS/nixpkgs/commit/938c221de58757fab556d50aecfc286963610634)|`lisgd: 0.3.0 -> 0.3.1`|`2021-08-09 12:10:09Z`|
|[`1eec3990`](https://github.com/NixOS/nixpkgs/commit/1eec3990a05c4225718093e48fb0e8033fad1a3e)|`lombok: 1.18.16 -> 1.18.20`|`2021-08-09 12:05:55Z`|
|[`a7774198`](https://github.com/NixOS/nixpkgs/commit/a777419869c5be14082b03ac11eaae9cd76680b1)|`zeroad: 0.0.24b -> 0.0.25`|`2021-08-09 11:41:01Z`|
|[`98ce437c`](https://github.com/NixOS/nixpkgs/commit/98ce437c4e4aea7912495b13d3159bfc549136ba)|`logseq: 0.2.10 -> 0.3.2`|`2021-08-09 11:40:42Z`|
|[`26c6e505`](https://github.com/NixOS/nixpkgs/commit/26c6e505b0ef7d0a4531d5d0bbf98b20201b476f)|`kodiPackages.inputstream-adaptive: 2.6.22 -> 2.6.23`|`2021-08-09 09:07:41Z`|
|[`0f2b0a58`](https://github.com/NixOS/nixpkgs/commit/0f2b0a583ad000eedb4fa1c03e26ebe5c6e2daf8)|`libaudec: 0.2.4 -> 0.3.4`|`2021-08-09 09:01:48Z`|
|[`e1856e39`](https://github.com/NixOS/nixpkgs/commit/e1856e3955f44e66d555a25e02bcbe03444d8536)|`kube-router: 1.1.1 -> 1.2.2`|`2021-08-09 08:44:10Z`|
|[`72a522e7`](https://github.com/NixOS/nixpkgs/commit/72a522e79562f435e38249d2a91a8fd94f44aa32)|`jmol: 14.31.46 -> 14.31.49`|`2021-08-09 07:27:37Z`|
|[`f745e88f`](https://github.com/NixOS/nixpkgs/commit/f745e88fdd899907c1846ab676950992ad77e486)|`python3Packages.soco: 0.22.3 -> 0.23.3`|`2021-08-09 06:34:47Z`|
|[`280d9203`](https://github.com/NixOS/nixpkgs/commit/280d92039706add32e4c9e525a0c941e776af4d1)|`kdeltachat: supports Linux`|`2021-08-09 04:53:58Z`|
|[`bc112ba4`](https://github.com/NixOS/nixpkgs/commit/bc112ba47488603dd2ae243ec8ef252af772c6e5)|`deltachat-electron: make alias of deltachat-desktop`|`2021-08-09 04:53:58Z`|
|[`8959f1d2`](https://github.com/NixOS/nixpkgs/commit/8959f1d2e822c3775bb2503f400f145f57a04fbb)|`deltachat-desktop: init at unstable-2021-08-04`|`2021-08-09 04:53:58Z`|
|[`e135fdae`](https://github.com/NixOS/nixpkgs/commit/e135fdae7729e6567ec94aa4989bfbdecc04e14b)|`flyway: 7.5.4 -> 7.12.1`|`2021-08-09 00:57:45Z`|
|[`d66335d5`](https://github.com/NixOS/nixpkgs/commit/d66335d57ce20d5abd17eb85e27eda34e6503592)|`flink: 1.12.1 -> 1.13.2`|`2021-08-08 22:44:55Z`|
|[`7ff192b3`](https://github.com/NixOS/nixpkgs/commit/7ff192b335dd183d9708e47a22e55285ad7c93d3)|`drumkv1: 0.9.18 -> 0.9.23`|`2021-08-08 22:29:06Z`|
|[`4d9ddc3e`](https://github.com/NixOS/nixpkgs/commit/4d9ddc3eebd3949c18291632c6986655b50e512c)|`libdeltachat: don't build static lib`|`2021-08-08 22:08:13Z`|
|[`734e2b7b`](https://github.com/NixOS/nixpkgs/commit/734e2b7b11c01164c4e41ec814fd22935b4a52e8)|`libdeltachat: support Darwin`|`2021-08-08 22:08:13Z`|
|[`5c2478ba`](https://github.com/NixOS/nixpkgs/commit/5c2478ba3cc2e66a2373c6ff9946346e2f746f8c)|`nixos/influxdb2: init`|`2021-08-08 14:39:57Z`|
|[`582a9c13`](https://github.com/NixOS/nixpkgs/commit/582a9c13b56faefd98a869d209e5cbd9247c7612)|`nixos/tests/nagios.nix: fix eval`|`2021-08-08 12:00:00Z`|
|[`e15ad63a`](https://github.com/NixOS/nixpkgs/commit/e15ad63acefb7aa27393ee4c7a7863a13806dcf3)|`flmsg: 4.0.17 -> 4.0.19`|`2021-08-07 23:10:16Z`|
|[`e4cbde69`](https://github.com/NixOS/nixpkgs/commit/e4cbde69075dd0ffd175cfc32626bd44c6fd7c14)|`gitstatus: update libgit2`|`2021-08-06 15:23:08Z`|
|[`f4cae704`](https://github.com/NixOS/nixpkgs/commit/f4cae7047edae00693f005c7da5bdb258e9bb850)|`gitstatus: add SuperSandro2000 maintainer`|`2021-08-06 15:22:55Z`|
|[`52cab6b8`](https://github.com/NixOS/nixpkgs/commit/52cab6b8951fb5e69ee932852f36640dc7b5182f)|`gitstatus: move scripts to $out/share/gitstatus, fix a bug when loading from home-manager`|`2021-08-06 15:22:13Z`|
|[`e3bb39da`](https://github.com/NixOS/nixpkgs/commit/e3bb39daf7728d017f7ccdc93bc14d70585ff678)|`gitstatus: format, cleanup`|`2021-08-06 15:21:32Z`|
|[`62ba64d5`](https://github.com/NixOS/nixpkgs/commit/62ba64d5129b473d39080ead434b33f05683d87e)|`tmuxPlugins.better-mouse-mode: fixed broken install path`|`2021-08-05 14:57:53Z`|
|[`e9427520`](https://github.com/NixOS/nixpkgs/commit/e94275202e926e9d7a568c5293a1f118237f8864)|`kubernetes: 1.21.3 -> 1.22.0`|`2021-08-05 09:44:19Z`|
|[`b432c3ca`](https://github.com/NixOS/nixpkgs/commit/b432c3ca0db8d14e2441d735b2ab51dd7fd55e8f)|`nomad-autoscaler: init at 0.3.3`|`2021-06-25 16:53:21Z`|
|[`e61d6106`](https://github.com/NixOS/nixpkgs/commit/e61d610615b6540e8182b42919b70016fce218e0)|`liblscp: 0.6.0 -> 0.9.2`|`2021-05-10 00:39:43Z`|
|[`7cecb8d6`](https://github.com/NixOS/nixpkgs/commit/7cecb8d6faaf6d26273ac81cf18214014cf47112)|`xorriso: 1.5.2 -> 1.5.4.pl02`|`2021-03-10 04:37:22Z`|
|[`c66d4ebf`](https://github.com/NixOS/nixpkgs/commit/c66d4ebfb456ed64a290199524c5677ea6b3eab8)|`python37Packages.flufl_i18n: 3.1.4 -> 3.1.5`|`2021-02-20 07:26:24Z`|
|[`24499bbc`](https://github.com/NixOS/nixpkgs/commit/24499bbc6e50d4be62225614e23cd413c8749a67)|`smartmontools: drop mailutils dependency by default`|`2021-02-18 00:59:23Z`|
|[`7ff74946`](https://github.com/NixOS/nixpkgs/commit/7ff749465cb8c4b82fc84df14385f65a70254343)|`python37Packages.flufl_bounce: 3.0.1 -> 3.0.2`|`2021-02-13 09:57:27Z`|