### PR TITLE
feat(niv): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d7b436eac25921844e28b97bc3bc19f64af10927",
-        "sha256": "0jyhrs7i4rm87w26fhmasr8qs0k1334qq5kba6r2im35jjq6x3cd",
+        "rev": "740ecbc162789b7038cedcbee4e6b543e050e597",
+        "sha256": "0rfqvdj6mpgmzyvyz01d6427h3w0cgxsj8hzmbn3fh3z987n84j0",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/d7b436eac25921844e28b97bc3bc19f64af10927.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/740ecbc162789b7038cedcbee4e6b543e050e597.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
|SHA256|Commit Message|Timestamp|
|---|---|---|
|[`d3841d1e`](https://github.com/NixOS/nixpkgs/commit/d3841d1e7bcfe061800816f1b414288bc04b4663)|`CONTRIBUTING.md: fix link to COPYING`|`2021-08-10 12:38:41Z`|
|[`642b36cb`](https://github.com/NixOS/nixpkgs/commit/642b36cb7acc925a72da48ae597c97dfb9198faa)|`opensc: 0.21.0 -> 0.22.0`|`2021-08-10 12:35:43Z`|
|[`79744f0e`](https://github.com/NixOS/nixpkgs/commit/79744f0ea04aff8d206e9312da2e4a24fd83f3c3)|`electron_11: 11.4.10 -> 11.4.11`|`2021-08-10 12:23:58Z`|
|[`4f7a4bd0`](https://github.com/NixOS/nixpkgs/commit/4f7a4bd0fe213f3f4baa6c1dafeb55b3f26e339f)|`electron_12: 12.0.15 -> 12.0.16`|`2021-08-10 12:23:21Z`|
|[`14d9f4f6`](https://github.com/NixOS/nixpkgs/commit/14d9f4f6976b082942cb723991195ccdb5e8e950)|`electron_13: 13.1.7 -> 13.1.8`|`2021-08-10 12:22:38Z`|
|[`c3a7c453`](https://github.com/NixOS/nixpkgs/commit/c3a7c4531ac79480592fe5a2e61d1fbea7535113)|`nodePackages.generator-code: init at 1.5.5`|`2021-08-10 11:25:51Z`|
|[`e2b0f0ea`](https://github.com/NixOS/nixpkgs/commit/e2b0f0ea710e484b001fb92ab9874ac88d1fab4e)|`zsh-fzf-tab: unstable-2021-04-01 -> unstable-2021-08-05`|`2021-08-10 11:22:52Z`|
|[`cf42c599`](https://github.com/NixOS/nixpkgs/commit/cf42c5992106c90b112abc93b0bed1c13905d0a5)|`nss_wrapper: switch to pname + version`|`2021-08-10 11:01:56Z`|
|[`d7a6dc0b`](https://github.com/NixOS/nixpkgs/commit/d7a6dc0bb96b6f879b2ad8e90772a66d3d3ba327)|`nss: format, cleanup`|`2021-08-10 11:01:51Z`|
|[`4b84c7a0`](https://github.com/NixOS/nixpkgs/commit/4b84c7a0c814f5a470f469e48c5237ddc9f8611e)|`nss: format, cleanup`|`2021-08-10 11:01:37Z`|
|[`81777e9a`](https://github.com/NixOS/nixpkgs/commit/81777e9a43c36e392e4bf735058865325f91f6fb)|`nspr: format, cleanup`|`2021-08-10 11:01:28Z`|
|[`ca2cc06e`](https://github.com/NixOS/nixpkgs/commit/ca2cc06e5d38738f10e1b950046c3b3ad869b74c)|`java-language-server: init at 0.2.38 (#131262)`|`2021-08-10 10:41:28Z`|
|[`110c6328`](https://github.com/NixOS/nixpkgs/commit/110c6328cffcc30bec5945e1a0c5bd3b265fabba)|`python3Packages.runway-python: fix build`|`2021-08-10 10:39:38Z`|
|[`2a40707b`](https://github.com/NixOS/nixpkgs/commit/2a40707bc7f7dad9e04554a7a2f1a1ac8a8bb040)|`kepubify: 4.0.0 -> 4.0.1`|`2021-08-10 10:22:41Z`|
|[`236c1159`](https://github.com/NixOS/nixpkgs/commit/236c1159bf2a46d4e32e2c32649561bd6ed2c8b7)|`fuse-overlayfs: 1.7 -> 1.7.1`|`2021-08-10 10:22:29Z`|
|[`7b317005`](https://github.com/NixOS/nixpkgs/commit/7b3170056d6e9f36a860b7ae11416b5ee5529ae3)|`yt-dlp: 2021.07.21 -> 2021.08.02`|`2021-08-10 10:16:35Z`|
|[`ccd2fa8b`](https://github.com/NixOS/nixpkgs/commit/ccd2fa8bb85e2e3ace2d8bd5401324066290c99f)|`backblaze-b2: 2.5.0 -> 3.0.1`|`2021-08-10 09:53:15Z`|
|[`ad512641`](https://github.com/NixOS/nixpkgs/commit/ad51264131eb082954f05a2633db15b455191eaa)|`python3Packages.b2sdk: 1.11.0 -> 1.12.0`|`2021-08-10 09:48:45Z`|
|[`64c8dd32`](https://github.com/NixOS/nixpkgs/commit/64c8dd32dac52df4ce7abfd2dfc0b21278257278)|`python3Packages.b2sdk: 1.9.0 -> 1.11.0`|`2021-08-10 09:47:28Z`|
|[`b38e90ff`](https://github.com/NixOS/nixpkgs/commit/b38e90ff79531f3df7f60acef89513031286cc0e)|`starboard-octant-plugin: 0.10.3 -> 0.11.0`|`2021-08-10 09:47:24Z`|
|[`e9badbf4`](https://github.com/NixOS/nixpkgs/commit/e9badbf41491b5213c252b1770e35f228a6c8525)|`terraform-ls: 0.20.0 -> 0.20.1`|`2021-08-10 09:40:07Z`|
|[`f8d82208`](https://github.com/NixOS/nixpkgs/commit/f8d8220875c45cb02ed9a5a4dd165d8949cf5b3b)|`clightning: 0.10.0 -> 0.10.1`|`2021-08-10 09:20:42Z`|
|[`d3ae3bdd`](https://github.com/NixOS/nixpkgs/commit/d3ae3bdd736189448e698f1fbc0a0a1166dd3652)|`obs-studio-plugins.obs-multi-rtmp: 0.2.6 -> 0.2.6.1`|`2021-08-10 09:18:09Z`|
|[`132f8888`](https://github.com/NixOS/nixpkgs/commit/132f888882f1c6641b3e7644c8a87c2bb41a5dec)|`gjs: 1.68.1 -> 1.68.2`|`2021-08-10 09:10:15Z`|
|[`cb2d6f5b`](https://github.com/NixOS/nixpkgs/commit/cb2d6f5b4aa45cab7ff4c403e51b25f83234ddcb)|`fetchmail: cleanup`|`2021-08-10 08:48:12Z`|
|[`22e1d3f1`](https://github.com/NixOS/nixpkgs/commit/22e1d3f1afc947e9d4e3d2ea68d3c6682637939d)|`python3Packages.clevercsv: 0.6.8 -> 0.7.0`|`2021-08-10 08:41:59Z`|
|[`ceb417aa`](https://github.com/NixOS/nixpkgs/commit/ceb417aaf1a03a21683dc4687d2c7628f00ef70a)|`docker: format`|`2021-08-10 08:32:46Z`|
|[`daa36171`](https://github.com/NixOS/nixpkgs/commit/daa36171c0a740e72a46b867ba4633f8ede92a5e)|`paraview: cleanup, format`|`2021-08-10 08:32:45Z`|
|[`19be7f9c`](https://github.com/NixOS/nixpkgs/commit/19be7f9c3e61088307825410d8f90afaa7875ed7)|`sanoid: format`|`2021-08-10 08:32:45Z`|
|[`047fea53`](https://github.com/NixOS/nixpkgs/commit/047fea53925c50138f40c815afb51b5ab90dcb7d)|`ecl: format, cleanup`|`2021-08-10 08:32:45Z`|
|[`483c89cf`](https://github.com/NixOS/nixpkgs/commit/483c89cf590c1c4aa1d2ceb37c675dfbe1ce9c5b)|`tailscale: format`|`2021-08-10 08:32:44Z`|
|[`e61bbf2e`](https://github.com/NixOS/nixpkgs/commit/e61bbf2eb03c3e5aa99d5a0fd2c40575206780c6)|`scala-runners: remove unused input`|`2021-08-10 08:32:44Z`|
|[`b1655a0c`](https://github.com/NixOS/nixpkgs/commit/b1655a0c1c292e36c5c8f89502b90b6940dc97fe)|`knot-dns: 3.1.0 -> 3.1.1`|`2021-08-10 08:21:50Z`|
|[`4a698c65`](https://github.com/NixOS/nixpkgs/commit/4a698c6580ae5284311472968b38376a8e503e59)|`backends: format`|`2021-08-10 08:19:32Z`|
|[`f502c006`](https://github.com/NixOS/nixpkgs/commit/f502c006402af32f63244f48b47f1016aa8cb66d)|`top-level: format`|`2021-08-10 08:19:32Z`|
|[`97cf8539`](https://github.com/NixOS/nixpkgs/commit/97cf8539801f9d65b96516f29f22aa3bd6cf9e89)|`wxsqlite3: format, cleanup`|`2021-08-10 08:19:31Z`|
|[`e566af7f`](https://github.com/NixOS/nixpkgs/commit/e566af7f40d37fe1f34d695916fd8df7b3ec8283)|`bisq-desktop: format, cleanup, use hooks instead of manually calling copyDesktopItems`|`2021-08-10 08:19:30Z`|
|[`b2bdf29c`](https://github.com/NixOS/nixpkgs/commit/b2bdf29ced21b0f2c339cf2c073614bb8699bb40)|`ecwolf: cleanup, format`|`2021-08-10 08:19:29Z`|
|[`70b69cdc`](https://github.com/NixOS/nixpkgs/commit/70b69cdcc20c4c38433086cc66a05712a7d4c265)|`operator-sdk: 1.5.0 -> 1.10.0 (#133238)`|`2021-08-10 08:06:30Z`|
|[`3eef0b8d`](https://github.com/NixOS/nixpkgs/commit/3eef0b8df144804540304daf7997c60af6d5dec7)|`zx: expose in top-level`|`2021-08-10 08:00:34Z`|
|[`dfe3b739`](https://github.com/NixOS/nixpkgs/commit/dfe3b739c72b934f2be4ed78f191f6fda717f4cc)|`zeroad: make sure hydra builds zeroad-unwrapped`|`2021-08-10 07:37:34Z`|
|[`ce81702e`](https://github.com/NixOS/nixpkgs/commit/ce81702e84a7aa1bcf6eda7d02f00c27062822bf)|`rust-analyzer: 2021-08-02 -> 2021-08-09`|`2021-08-10 06:16:20Z`|
|[`cd9ed036`](https://github.com/NixOS/nixpkgs/commit/cd9ed036d6d744de8c6ce6879a591286d730e9bc)|`vscode-extensions.matklad.rust-analyzer: use extension version and apply patches`|`2021-08-10 06:16:20Z`|
|[`99717c16`](https://github.com/NixOS/nixpkgs/commit/99717c1644e08b9d1da0536870fd989e954b3013)|`aften: apple silicon support`|`2021-08-10 06:13:17Z`|
|[`44b130d3`](https://github.com/NixOS/nixpkgs/commit/44b130d392ac6391d801372fc2a8dbf8b655f9db)|`webkitgtk: remove reference to private Apple SDK`|`2021-08-10 05:59:05Z`|
|[`429c5c1b`](https://github.com/NixOS/nixpkgs/commit/429c5c1b1e593cd62adedde07995d9b97156412c)|`disfetch: 2.7 -> 2.9`|`2021-08-10 05:55:18Z`|
|[`e40ceba3`](https://github.com/NixOS/nixpkgs/commit/e40ceba3fc172b6610eb0da96384636e08a510e2)|`yt-dlp: init at 2021.07.21`|`2021-08-10 04:49:34Z`|
|[`1d8b058f`](https://github.com/NixOS/nixpkgs/commit/1d8b058fa08dbdd21d9e61d06996694285569175)|`fetchmail: 6.4.20 -> 6.4.21`|`2021-08-10 04:00:28Z`|
|[`0db6011c`](https://github.com/NixOS/nixpkgs/commit/0db6011c7faf44e9b0259621241a8e638f0c0fde)|`coreboot-utils: add missing phase hooks`|`2021-08-10 03:46:14Z`|
|[`b43389f4`](https://github.com/NixOS/nixpkgs/commit/b43389f49d52db6084abf6ad26872e8d93d74fc7)|`iasl: drop pacakge`|`2021-08-10 03:46:01Z`|
|[`2f59b54e`](https://github.com/NixOS/nixpkgs/commit/2f59b54e3f1318c4e0a6079baebf621b9b402880)|`betterlockscreen 3.2.0 -> 4.0.0`|`2021-08-10 02:05:07Z`|
|[`595ef1a2`](https://github.com/NixOS/nixpkgs/commit/595ef1a2072b30d66c689b3730ebcd3b98606d3f)|`ckbcomp: 1.199 -> 1.205`|`2021-08-10 00:07:48Z`|
|[`86296623`](https://github.com/NixOS/nixpkgs/commit/86296623c6782af4c4f5600d5812faf337c1db61)|`isso: added NixOS module to configure `isso` in NixOS`|`2021-08-09 23:42:54Z`|
|[`c1a7bbc3`](https://github.com/NixOS/nixpkgs/commit/c1a7bbc38f62033eeb51a644e300969bf4efd3cf)|`isso: added a test to verify that the server is able to start and a generated javascript file is available`|`2021-08-09 23:41:35Z`|
|[`21f0b451`](https://github.com/NixOS/nixpkgs/commit/21f0b451550d7880384899fc118816d8d2815560)|`isso: added  generation of javascript files to build phase`|`2021-08-09 23:41:35Z`|
|[`50a5bfaa`](https://github.com/NixOS/nixpkgs/commit/50a5bfaaff411a4febfd137e8ca3f766e5ae7258)|`rubyPackages: add github-pages`|`2021-08-09 23:01:00Z`|
|[`85fe192e`](https://github.com/NixOS/nixpkgs/commit/85fe192e579e9ee9cb18179e56a827cec74533ae)|`maintainers/scripts/update-ruby-packages: force platform-independent bundler lock`|`2021-08-09 23:00:00Z`|
|[`8f54273f`](https://github.com/NixOS/nixpkgs/commit/8f54273f1e1ac72f7e095c36889561b811ff2928)|`python3Packages.mutesync: 0.0.1 -> 0.0.2`|`2021-08-09 22:21:34Z`|
|[`65db4268`](https://github.com/NixOS/nixpkgs/commit/65db4268d056afefac988705bae2f65651b1f7c2)|`gpsd: 3.22 -> 3.23`|`2021-08-09 21:57:27Z`|
|[`8d347b14`](https://github.com/NixOS/nixpkgs/commit/8d347b14190550c5d3cbf998137f5af3b51e6785)|`bitcoin-unlimited: 1.9.1.1 -> 1.9.2.0`|`2021-08-09 21:56:42Z`|
|[`8c701f58`](https://github.com/NixOS/nixpkgs/commit/8c701f580525fb480f94f92eee125b8fd6ea6da5)|`minio-client: 2021-06-13T17-48-22Z -> 2021-07-27T06-46-19Z`|`2021-08-09 20:59:27Z`|
|[`c756b732`](https://github.com/NixOS/nixpkgs/commit/c756b732d40da2a9bc656c3c01fd86ba4effd205)|`ledger-live-desktop: 2.31.1 -> 2.32.2`|`2021-08-09 20:32:33Z`|
|[`5fb27d46`](https://github.com/NixOS/nixpkgs/commit/5fb27d46d987fe996fcdc64b058b938828cf508c)|`vimix-gtk-themes: 2021-04-25 -> 2021-08-09`|`2021-08-09 15:57:20Z`|
|[`efbfe894`](https://github.com/NixOS/nixpkgs/commit/efbfe894e3380043d4b88cc5e95d807370818657)|`yandex-browser: 21.5.3.753-1 -> 21.6.2.817-1`|`2021-08-09 15:45:12Z`|
|[`29850a46`](https://github.com/NixOS/nixpkgs/commit/29850a46838eb46287bf003086cd08feee5e3d14)|`marwaita: 10.0 -> 10.2`|`2021-08-09 15:39:09Z`|
|[`10b2c83f`](https://github.com/NixOS/nixpkgs/commit/10b2c83fcae0cfd48ed9899ee1d769986f42030f)|`dasel: 1.16.1 -> 1.17.0`|`2021-08-09 14:33:12Z`|
|[`14a6ba8e`](https://github.com/NixOS/nixpkgs/commit/14a6ba8e4750da6500f17bbda84fffc363ee5d7d)|`python3Packages.hstspreload: 2021.7.5 -> 2021.8.1`|`2021-08-09 14:31:48Z`|
|[`06a8b080`](https://github.com/NixOS/nixpkgs/commit/06a8b080e58d4394d750aa5d1cb42e4262ed7bf2)|`python3Packages.py-air-control-exporter: fix build and cleanup`|`2021-08-09 11:29:02Z`|
|[`0282a1ef`](https://github.com/NixOS/nixpkgs/commit/0282a1ef86bfcb2db9fea7fb886b0f26c1c466d7)|`python3Packages.coapthon3: 1.0.1 -> 1.0.2`|`2021-08-09 10:18:24Z`|
|[`cef01167`](https://github.com/NixOS/nixpkgs/commit/cef0116759fc2214cb74941d0cafd59b80cd9d9f)|`python3Packages.zeroconf: 0.33.4 -> 0.34.3`|`2021-08-09 06:37:53Z`|
|[`e63d487c`](https://github.com/NixOS/nixpkgs/commit/e63d487cd80754ca9ce18d66fa09e0bcb7dce3f7)|`python3Packages.arcam-fmj: 0.7.0 -> 0.10.0`|`2021-08-09 06:25:41Z`|
|[`d62ab966`](https://github.com/NixOS/nixpkgs/commit/d62ab966988bfe7f6f61d5bf0ec2e3b4fa857b7b)|`plm: fix old link & deprecate phases`|`2021-08-08 21:53:53Z`|
|[`1e0f240b`](https://github.com/NixOS/nixpkgs/commit/1e0f240b10b98b6587d668bf9fa8b6399ca27de5)|`paraview: license is bsd3`|`2021-08-08 20:05:07Z`|
|[`b8611ee7`](https://github.com/NixOS/nixpkgs/commit/b8611ee768c3d72f774e964b5f85a22018156bed)|`paraview: install doc files by default`|`2021-08-08 20:05:06Z`|
|[`da89ec8b`](https://github.com/NixOS/nixpkgs/commit/da89ec8b8dd6d3d9b42c5432e8bc59c6c3183354)|`terraform-providers.cloudfoundry: 0.12.6 -> 0.14.2`|`2021-08-08 18:41:43Z`|
|[`b15a7c71`](https://github.com/NixOS/nixpkgs/commit/b15a7c718e127d6046328c474244a40e70b9e317)|`gitea: 1.14.5 -> 1.14.6`|`2021-08-08 07:58:09Z`|
|[`89bcf569`](https://github.com/NixOS/nixpkgs/commit/89bcf569f610afc0f514bcd0c71ae61435a26de9)|`paraview: use fetchFromGitLab`|`2021-08-06 02:43:47Z`|
|[`ab5810a2`](https://github.com/NixOS/nixpkgs/commit/ab5810a2e1afbbbb100358f2422f62025a901b66)|`paraview: 5.8.0 -> 5.9.1`|`2021-08-06 02:43:19Z`|
|[`94b5fbe5`](https://github.com/NixOS/nixpkgs/commit/94b5fbe5e78ac9b61ef2d24b043e44366513d9b2)|`perf: define only if kernel version > 3.12`|`2021-05-13 16:20:09Z`|
|[`408b107b`](https://github.com/NixOS/nixpkgs/commit/408b107b0cae3687bf87b6b300dacaf51bdd76d5)|`doas: don't configure pamdir`|`2021-02-04 19:19:56Z`|