### PR TITLE
feat(niv): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "740ecbc162789b7038cedcbee4e6b543e050e597",
-        "sha256": "0rfqvdj6mpgmzyvyz01d6427h3w0cgxsj8hzmbn3fh3z987n84j0",
+        "rev": "d0c67e30d3788e27a9a82fc3bfd519eb75bc7a55",
+        "sha256": "19imiiysidb0i31rrda1j4fqnv1yq2gkrx58kd2rihf1g2fws009",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/740ecbc162789b7038cedcbee4e6b543e050e597.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/d0c67e30d3788e27a9a82fc3bfd519eb75bc7a55.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
|SHA256|Commit Message|Timestamp|
|---|---|---|
|[`260181cf`](https://github.com/NixOS/nixpkgs/commit/260181cf0ca9322a22a775a6ae31a76fc3436cb0)|`python3Packages.debugpy: add apple silicon support`|`2021-08-10 21:10:38Z`|
|[`1c54ce56`](https://github.com/NixOS/nixpkgs/commit/1c54ce56abb405500984c260102d98eff0678b4f)|`nixos/minio: add release notes`|`2021-08-10 20:37:30Z`|
|[`3417f18f`](https://github.com/NixOS/nixpkgs/commit/3417f18f96ccc1d9e6b3fccf8024515c87f4d183)|`nixos/minio: allow configuring console port`|`2021-08-10 20:37:30Z`|
|[`345e5829`](https://github.com/NixOS/nixpkgs/commit/345e58292dd1b0a9ed3b83e6211b27a90f9546ce)|`minio: 2021-05-16T05-32-34Z -> 2021-08-05T22-01-19Z`|`2021-08-10 20:37:30Z`|
|[`0ed4412e`](https://github.com/NixOS/nixpkgs/commit/0ed4412e40b68d2ef500afaec9b75b4c6b7c1f4a)|`remind: 03.03.06 -> 03.03.07`|`2021-08-10 20:30:32Z`|
|[`36e0fc76`](https://github.com/NixOS/nixpkgs/commit/36e0fc76ae6e0d68b6f40920a5daf910517aa361)|`python3Packages.angrop: 9.0.9355 -> 9.0.9438`|`2021-08-10 20:26:32Z`|
|[`3acb8e0b`](https://github.com/NixOS/nixpkgs/commit/3acb8e0b718bbb5c90061161ab9fb468ea26ba69)|`python3Packages.angr: 9.0.9355 -> 9.0.9438`|`2021-08-10 20:26:29Z`|
|[`e2acd670`](https://github.com/NixOS/nixpkgs/commit/e2acd670bf2dd965737c0d92fce5c795f1a5d236)|`python3Packages.cle: 9.0.9355 -> 9.0.9438`|`2021-08-10 20:26:25Z`|
|[`32e6ac27`](https://github.com/NixOS/nixpkgs/commit/32e6ac273b79687151b20e7c2ba70e8cc38d9940)|`python3Packages.claripy: 9.0.9355 -> 9.0.9438`|`2021-08-10 20:26:23Z`|
|[`c950cc4d`](https://github.com/NixOS/nixpkgs/commit/c950cc4deb97b0998edcf4532a8ac317f40930c0)|`python3Packages.pyvex: 9.0.9355 -> 9.0.9438`|`2021-08-10 20:26:20Z`|
|[`ab7ce2be`](https://github.com/NixOS/nixpkgs/commit/ab7ce2befea31ed773a5e00c81e322ca98c65edf)|`python3Packages.ailment: 9.0.9355 -> 9.0.9438`|`2021-08-10 20:26:17Z`|
|[`8f69556b`](https://github.com/NixOS/nixpkgs/commit/8f69556be30a5f761b7dc46d485c9cabc51117a1)|`python3Packages.archinfo: 9.0.9355 -> 9.0.9438`|`2021-08-10 20:26:14Z`|
|[`99784356`](https://github.com/NixOS/nixpkgs/commit/99784356acc5be1fd1de5e176093bfbc9148c96f)|`python3Packages.env-canada: 0.4.1 -> 0.5.0`|`2021-08-10 20:23:30Z`|
|[`84879878`](https://github.com/NixOS/nixpkgs/commit/848798787ef464e6081398f595b22fe95ee7b516)|`bklk: init at unstable-2020-12-29`|`2021-08-10 20:17:43Z`|
|[`844bb647`](https://github.com/NixOS/nixpkgs/commit/844bb647fb7dca7c1495ff218c4c020cdef0c843)|`haskellPackages.hevm: Fix eval by disabling on aarch64`|`2021-08-10 19:57:23Z`|
|[`e5f407ad`](https://github.com/NixOS/nixpkgs/commit/e5f407ad7a38e110fc095085bca135820442a633)|`python3Packages.typed-settings: 0.9.2 -> 0.10.0`|`2021-08-10 19:49:19Z`|
|[`c591215a`](https://github.com/NixOS/nixpkgs/commit/c591215a4c7ed16653a0107e93e3dcec50e28679)|`python3Packages.phonenumbers: 8.12.28 -> 8.12.29`|`2021-08-10 19:42:14Z`|
|[`e14ecb19`](https://github.com/NixOS/nixpkgs/commit/e14ecb19eaae281ee67e4d3f24bbe3e54a8308ab)|`vscode-langservers-extracted: init at 2.4.0`|`2021-08-10 19:38:17Z`|
|[`dbc59a8c`](https://github.com/NixOS/nixpkgs/commit/dbc59a8c8ddf7d7e60d59d1fd1ccb46ae80f6df4)|`betterlockscreen: Fix duplicate preInstall hook introduced in #133306`|`2021-08-10 19:36:17Z`|
|[`14600776`](https://github.com/NixOS/nixpkgs/commit/146007769fa8765e136e88c1f4c7104956f6a640)|`haskellPackages: mark builds failing on hydra as broken`|`2021-08-10 19:16:37Z`|
|[`25821765`](https://github.com/NixOS/nixpkgs/commit/2582176554c6e483f1dc777542684acd7244c4a0)|`catgirl: 1.8 -> 1.9`|`2021-08-10 19:08:50Z`|
|[`c946a886`](https://github.com/NixOS/nixpkgs/commit/c946a8861adfd6dee13f16b687e768d9091f23fb)|`terraform.providers: use allowAliases for exposing deprecated providers`|`2021-08-10 18:43:24Z`|
|[`2aaf4117`](https://github.com/NixOS/nixpkgs/commit/2aaf41173d28c86c7037680b2ffbb91aec274d92)|`linux_lqx: 5.12.19 -> 5.13.9`|`2021-08-10 18:37:56Z`|
|[`724a0fc8`](https://github.com/NixOS/nixpkgs/commit/724a0fc8464540846c384a94f640612d3d7e338c)|`python3Packages.exchangelib: 4.4.0 -> 4.5.0`|`2021-08-10 17:51:41Z`|
|[`04f5726f`](https://github.com/NixOS/nixpkgs/commit/04f5726f4820e84a49de6377e238bc6f209496d7)|`nodePackages.clipboard-cli: init at 2.0.1`|`2021-08-10 14:52:17Z`|
|[`bb086738`](https://github.com/NixOS/nixpkgs/commit/bb0867389f00a23d7e451e1591f0d07121cf7863)|`wasm-bindgen-cli: 0.2.74 -> 0.2.75`|`2021-08-10 14:51:16Z`|
|[`069a145a`](https://github.com/NixOS/nixpkgs/commit/069a145ae033fe22f78220e752b9d2da88518cf7)|`python3Packages.eth-typing: 2.2.1 -> 2.2.2`|`2021-08-10 14:32:50Z`|
|[`fe010524`](https://github.com/NixOS/nixpkgs/commit/fe01052444c1d66ed6ef76df2af798c9769e9e79)|`fnm: init at 1.26.0 (#130788)`|`2021-08-10 14:31:46Z`|
|[`7b6af9e5`](https://github.com/NixOS/nixpkgs/commit/7b6af9e542eda798072b1951ffce91c600bc73ea)|`betterlockscreen: format`|`2021-08-10 14:26:34Z`|
|[`4477421b`](https://github.com/NixOS/nixpkgs/commit/4477421b05b9e3e1d801c8bb08bd6d5db9ee49ad)|`changelog: re-add by accident deleted sections`|`2021-08-10 14:26:18Z`|
|[`c0097aa8`](https://github.com/NixOS/nixpkgs/commit/c0097aa84adb19a9e5d947487c118505faf98bc0)|`nixos/tests: unbreak the tested job`|`2021-08-10 14:15:57Z`|
|[`4abb57f1`](https://github.com/NixOS/nixpkgs/commit/4abb57f19bcf2e58a9852c54501a4c6424e1f8da)|`findomain: 4.3.0 -> 5.0.0`|`2021-08-10 14:14:37Z`|
|[`fd5c6aad`](https://github.com/NixOS/nixpkgs/commit/fd5c6aada3c38e7410f130ebf8fb01ef00257cd7)|`disfetch: change owner username (#133377)`|`2021-08-10 14:14:10Z`|
|[`a3df0491`](https://github.com/NixOS/nixpkgs/commit/a3df0491aadb30e64bd0cd727b6f8396beb9025f)|`python3Packages.dbutils: 2.0.1 -> 2.0.2`|`2021-08-10 14:00:50Z`|
|[`1488241d`](https://github.com/NixOS/nixpkgs/commit/1488241dbc567480aaba33dd1f47138a15fbdd70)|`python3Packages.pymyq: 3.0.4 -> 3.1.0`|`2021-08-10 13:54:13Z`|
|[`55444245`](https://github.com/NixOS/nixpkgs/commit/55444245f8cb67b86012815d6168492ad6ec46c8)|`duperemove: 0.11.2 -> 0.11.3`|`2021-08-10 13:29:29Z`|
|[`6856e6ec`](https://github.com/NixOS/nixpkgs/commit/6856e6ecee7e5de23baeb29452b07eab8d95da99)|`pymupdf: add patches for nix`|`2021-08-10 13:26:29Z`|
|[`01a6d300`](https://github.com/NixOS/nixpkgs/commit/01a6d30016c254660464ed1ed351d9d0146552f0)|`xorg.xrdb: 1.2.0 -> 1.2.1`|`2021-08-10 13:25:40Z`|
|[`b5c36a1d`](https://github.com/NixOS/nixpkgs/commit/b5c36a1d5b607f018d30e3d95140e66f16bb6c1d)|`zeroad: recurse into zeroadPackages to make sure hydra builds zeroad-unwrapped`|`2021-08-10 13:21:27Z`|
|[`ded0f0ed`](https://github.com/NixOS/nixpkgs/commit/ded0f0ede6c5ebda4eb88e8158a4115b2780a9fe)|`mosquitto: 2.0.10 -> 2.0.11`|`2021-08-10 13:20:33Z`|
|[`31a66b92`](https://github.com/NixOS/nixpkgs/commit/31a66b9239ac272d59e7ff7694e67dc8224f719d)|`distrobuilder: 1.2 -> 1.3`|`2021-08-10 13:08:09Z`|
|[`fa0f9b76`](https://github.com/NixOS/nixpkgs/commit/fa0f9b76a3ea7828d7a71ba7e78ea087308f619e)|`gpsd: remove ? null`|`2021-08-10 12:46:40Z`|
|[`50dc9c1b`](https://github.com/NixOS/nixpkgs/commit/50dc9c1b67f7471e576cc10a4b30c7287da7a325)|`haskellPackages.chs-cabal: Fix build by overriding Cabal dep`|`2021-08-10 12:33:36Z`|
|[`1445bec5`](https://github.com/NixOS/nixpkgs/commit/1445bec521a45d4ef3b06705b50739f6fa0258a4)|`haskellPackages.cabal-install: Switch Cabal back to 3.4 on older ghcs`|`2021-08-10 11:46:37Z`|
|[`aeb4364b`](https://github.com/NixOS/nixpkgs/commit/aeb4364bb340448cf52526e426ba58086dc5f18d)|`haskellPackages.witch: Add maralorn as maintainer`|`2021-08-10 11:45:54Z`|
|[`7032cf29`](https://github.com/NixOS/nixpkgs/commit/7032cf2944fee72c4c5115ce68057fb547e11b60)|`python3Packages.hass-nabucasa: 0.44.0 -> 0.45.1`|`2021-08-10 11:26:14Z`|
|[`4ccee1f0`](https://github.com/NixOS/nixpkgs/commit/4ccee1f01274bc8b4150b2f4e272f665a2ceeec0)|`home-assistant: 2021.8.4 -> 2021.8.5`|`2021-08-10 11:25:15Z`|
|[`22a46ba4`](https://github.com/NixOS/nixpkgs/commit/22a46ba471b89bf5536fbecc84f8639c335a67e2)|`nuclei: 2.4.2 -> 2.4.3`|`2021-08-10 11:04:10Z`|
|[`da74ac37`](https://github.com/NixOS/nixpkgs/commit/da74ac3753cd7075b8e88fd350e2b777c187f2d0)|`tfsec: 0.56.0 -> 0.57.1`|`2021-08-10 10:59:18Z`|
|[`1acb054c`](https://github.com/NixOS/nixpkgs/commit/1acb054c8af2f65313255deccf11e5c01d85676c)|`python3Packages.deemix: 3.4.1 -> 3.4.2`|`2021-08-10 10:46:00Z`|
|[`3e2939af`](https://github.com/NixOS/nixpkgs/commit/3e2939af92db61fb4d01ded0ad5a6c35bf2d878a)|`python3Packages.deezer-py: 1.1.1 -> 1.1.2`|`2021-08-10 10:45:49Z`|
|[`3747daf3`](https://github.com/NixOS/nixpkgs/commit/3747daf3422a6ecd1da9ca867e474fd1ddcb9604)|`conda: invoke bash login shell to source /etc/profile`|`2021-08-10 10:39:17Z`|
|[`98b9a7fd`](https://github.com/NixOS/nixpkgs/commit/98b9a7fdeae051bd37d8105f7b03aa8077d6c10e)|`nodePackages.node-gyp: local nodejs header files`|`2021-08-10 10:28:31Z`|
|[`f29b9da6`](https://github.com/NixOS/nixpkgs/commit/f29b9da698b7170fca15727de659f5b089077b70)|`portmidi: add support for darwin`|`2021-08-10 09:47:38Z`|
|[`51816dff`](https://github.com/NixOS/nixpkgs/commit/51816dff1a342a2a142fb0c2a5d9595d28f40442)|`vscx/ms-vsliveshare-vsliveshare: 1.0.4498 -> 1.0.4673`|`2021-08-10 09:36:41Z`|
|[`72aea3fe`](https://github.com/NixOS/nixpkgs/commit/72aea3fe891afb8a06364c426e891246cad62f52)|`scorecard: 2.1.2 -> 2.1.3`|`2021-08-10 09:11:11Z`|
|[`b91e7081`](https://github.com/NixOS/nixpkgs/commit/b91e7081da52a649f55cc36db478a5546375f9f1)|`zerobin: fix build`|`2021-08-10 09:10:41Z`|
|[`a3faaa75`](https://github.com/NixOS/nixpkgs/commit/a3faaa753e4112dbaa4f0bdb0a59ff52f71e041d)|`python3Packages.clize: 4.1.1 -> 4.2.0`|`2021-08-10 08:49:10Z`|
|[`2a1cfd75`](https://github.com/NixOS/nixpkgs/commit/2a1cfd7536677028342e19e15a6bbee98244efa5)|`cloudflared: 2021.8.1 -> 2021.8.2`|`2021-08-10 00:56:38Z`|
|[`97f61384`](https://github.com/NixOS/nixpkgs/commit/97f6138420257935de53bc39f7cf129b80298939)|`atomicparsley: 20210617.200601.1ac7c08 -> 20210715.151551.e7ad03a`|`2021-08-10 00:48:29Z`|
|[`ab94e3d2`](https://github.com/NixOS/nixpkgs/commit/ab94e3d2001823e0c327e8ea8e8fb314660afe3c)|`usbredir: 0.9.0 -> 0.10.0`|`2021-08-09 22:26:59Z`|
|[`922791fb`](https://github.com/NixOS/nixpkgs/commit/922791fbc64f8f99f6a9e18ddf9c18ba9681da52)|`python3Packages.scrapy: fix build`|`2021-08-09 21:19:43Z`|
|[`a794c51c`](https://github.com/NixOS/nixpkgs/commit/a794c51c07e28ca6f3f33c630fbe7216eb53f3f8)|`haskell.compiler.ghcHEAD: 9.3.20210504 -> 9.3.20210806`|`2021-08-09 20:28:41Z`|
|[`9153df24`](https://github.com/NixOS/nixpkgs/commit/9153df24d579f5853ef362b540fe7fb7254b64e3)|`python3Packages.sopel: 7.1.0 -> 7.1.2`|`2021-08-09 20:21:10Z`|
|[`8b4f1e41`](https://github.com/NixOS/nixpkgs/commit/8b4f1e4111ac62e43c03200c65c5212d5b6ded07)|`python3Packages.testfixtures: 6.17.1 -> 6.18.0`|`2021-08-09 19:38:29Z`|
|[`1bd9c358`](https://github.com/NixOS/nixpkgs/commit/1bd9c358be41d7d9f6b9607f256a45ea3413040c)|`proxmark3-rrg: 4.9237 -> 4.13441`|`2021-08-09 17:50:57Z`|
|[`43d83eae`](https://github.com/NixOS/nixpkgs/commit/43d83eae366b6d3a9ba2f01af8617ea03812b5e3)|`python3Packages.rich: 10.4.0 -> 10.7.0`|`2021-08-08 22:36:51Z`|
|[`d6907765`](https://github.com/NixOS/nixpkgs/commit/d6907765bbe4eff9020f3cd0fae2f2b9a0e97508)|`xfce.mousepad: 0.5.5 -> 0.5.6`|`2021-08-08 21:12:34Z`|
|[`aa6e8990`](https://github.com/NixOS/nixpkgs/commit/aa6e8990672124bb858ced36dd311568eeb32c25)|`xfce.catfish: 1.4.13 -> 4.16.2`|`2021-08-08 21:12:29Z`|
|[`dd040a6c`](https://github.com/NixOS/nixpkgs/commit/dd040a6cc199689f1147780067f39ddcc6855258)|`xfce.xfce4-sensors-plugin: 1.3.95 -> 1.4.1`|`2021-08-08 20:41:35Z`|
|[`124d658e`](https://github.com/NixOS/nixpkgs/commit/124d658eff308e678eee5b3b8a514490c18fbee1)|`haskellPackages.{cabal-install, cabal-install-parsers}: use Cabal 3.6.0.0`|`2021-08-07 14:23:10Z`|
|[`14467d17`](https://github.com/NixOS/nixpkgs/commit/14467d17353ccf7d484907bbd45d1ea82264bd7c)|`haskellPackages: regenerate package set based on current config`|`2021-08-07 14:18:37Z`|
|[`981cf6a6`](https://github.com/NixOS/nixpkgs/commit/981cf6a6e2b4fe09653eff0e1d9f88c967c74cdd)|`all-cabal-hashes: 2021-08-04T07:53:53Z -> 2021-08-07T10:52:35Z`|`2021-08-07 14:17:16Z`|