### PR TITLE
feat(niv): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d0c67e30d3788e27a9a82fc3bfd519eb75bc7a55",
-        "sha256": "19imiiysidb0i31rrda1j4fqnv1yq2gkrx58kd2rihf1g2fws009",
+        "rev": "911b8a569cd44d3e3f2e8c39f5e1162506e7941c",
+        "sha256": "1xbkfbp47s313w4lg0kmz505lhrg703fx29pmh19l181n4wpk0yi",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/d0c67e30d3788e27a9a82fc3bfd519eb75bc7a55.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/911b8a569cd44d3e3f2e8c39f5e1162506e7941c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                   | Timestamp              |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ---------------------- |
| [`737c4db9`](https://github.com/NixOS/nixpkgs/commit/737c4db9e3565b201e5fc2c39becc2c41180b86e) | `opensc: change maintainer`                                      | `2021-08-11 10:01:14Z` |
| [`d0cd76a4`](https://github.com/NixOS/nixpkgs/commit/d0cd76a4f86bd00a2289e72ce6f32a80d22866e5) | `maintainers: add michaeladler`                                  | `2021-08-11 10:01:14Z` |
| [`92d9a2a0`](https://github.com/NixOS/nixpkgs/commit/92d9a2a0ddc37d6731a991e3073c301b1bf56f9e) | `archivebox: fix runtime`                                        | `2021-08-11 09:49:27Z` |
| [`1560fde9`](https://github.com/NixOS/nixpkgs/commit/1560fde9892893d022b9d70557d433c683bb92a2) | `buf: 0.46.0 -> 0.49.0`                                          | `2021-08-11 09:29:52Z` |
| [`f0feb77b`](https://github.com/NixOS/nixpkgs/commit/f0feb77b4f3ae6a76fd95d328a182b6396c0bd74) | `nix-simple-deploy: 0.2.1 -> 0.2.2`                              | `2021-08-11 09:29:25Z` |
| [`9a7fb140`](https://github.com/NixOS/nixpkgs/commit/9a7fb1407009e157590a04156e7d36627ced4cec) | `telepresence2: 2.3.6 -> 2.4.0`                                  | `2021-08-11 08:13:38Z` |
| [`e5fd43a1`](https://github.com/NixOS/nixpkgs/commit/e5fd43a1559ddecfdedf99aea5437dce64bcfe37) | `archivebox: init at 0.6.2`                                      | `2021-08-11 07:56:21Z` |
| [`0ac49d7c`](https://github.com/NixOS/nixpkgs/commit/0ac49d7c7b5625a2554f393ddfba72128c8f0f5d) | `nixos: rewrite uhub module`                                     | `2021-08-11 07:51:23Z` |
| [`4f78c88e`](https://github.com/NixOS/nixpkgs/commit/4f78c88e819e5e6566096d8e3350a9d27b0e8562) | `uhub: 0.5.0 -> unstable-2019-12-13`                             | `2021-08-11 07:51:23Z` |
| [`a5a771c8`](https://github.com/NixOS/nixpkgs/commit/a5a771c88142242ecd1b6a9019e3130da6bf3a15) | `exoscale-cli: 1.39.0 -> 1.40.0`                                 | `2021-08-11 07:49:51Z` |
| [`b4c85a2e`](https://github.com/NixOS/nixpkgs/commit/b4c85a2e682d02048e43b7f4e968bdceb6081ae9) | `httpx: 1.1.0 -> 1.1.1`                                          | `2021-08-11 07:29:47Z` |
| [`82358d47`](https://github.com/NixOS/nixpkgs/commit/82358d47b0dde2d838832c5f176c5b3584a10506) | `betterlockscreen: 4.0.0 -> 4.0.1`                               | `2021-08-11 07:23:40Z` |
| [`793509b6`](https://github.com/NixOS/nixpkgs/commit/793509b6253520c027f79a6c4f26e2ca71339d85) | `dnsx: 1.0.5 -> 1.0.6`                                           | `2021-08-11 07:18:11Z` |
| [`0cf5fbfd`](https://github.com/NixOS/nixpkgs/commit/0cf5fbfd95021cb26e0ee2a022c64e52fb9c91fc) | `terraform-docs: 0.14.1 -> 0.15.0`                               | `2021-08-11 07:01:13Z` |
| [`cf427857`](https://github.com/NixOS/nixpkgs/commit/cf427857a50390b17c382c75a0aa147ec297f48a) | `vscode: Fix vscode-with-extensions with #70486`                 | `2021-08-11 06:41:51Z` |
| [`5dfe6e1a`](https://github.com/NixOS/nixpkgs/commit/5dfe6e1a2a8b8c4ee4ae87663d106f2c3e0fd56d) | `conftest: 0.26.0 -> 0.27.0`                                     | `2021-08-11 06:36:31Z` |
| [`3c77195e`](https://github.com/NixOS/nixpkgs/commit/3c77195e816e529c863f482156506fb86d8dab12) | `pscale: 0.60.0 -> 0.63.0`                                       | `2021-08-11 06:26:41Z` |
| [`c93b6827`](https://github.com/NixOS/nixpkgs/commit/c93b682775a946cea63c48e2634870997cd4564c) | `clair: 4.1.2 -> 4.2.0`                                          | `2021-08-11 06:16:34Z` |
| [`247b53f4`](https://github.com/NixOS/nixpkgs/commit/247b53f48491cdebded4ead91d0a0863961b92d3) | `hydra-unstable: 2021-05-03 -> 2021-08-11`                       | `2021-08-11 06:14:48Z` |
| [`83bc698f`](https://github.com/NixOS/nixpkgs/commit/83bc698fba4d05ef37826fb1fe732647f420c8ab) | `nixUnstable: 2.4pre20210707_02dd6bb  -> 2.4pre20210802_47e96bb` | `2021-08-11 06:14:48Z` |
| [`8bd7a7de`](https://github.com/NixOS/nixpkgs/commit/8bd7a7deb5bb6dde33f3c8f2c690b0f730529e59) | `portmidi: fix libporttime extension regression`                 | `2021-08-11 06:09:34Z` |
| [`e7836bc5`](https://github.com/NixOS/nixpkgs/commit/e7836bc5a5a2a2257afd515e3e221c8ff5d67b97) | `sparse: add perl to buildInputs`                                | `2021-08-11 06:06:17Z` |
| [`d02ee5f7`](https://github.com/NixOS/nixpkgs/commit/d02ee5f701e1b1a89104b4c4c60f7f62e864a194) | `python3Packages.pybotvac: 0.0.21 -> 0.0.22`                     | `2021-08-11 05:54:41Z` |
| [`30a6f6f2`](https://github.com/NixOS/nixpkgs/commit/30a6f6f2a8711b3c40baf8e6e51a5258bd8e7b4f) | `python3Packages.pylutron: 0.2.8 -> 0.2.9`                       | `2021-08-11 05:52:12Z` |
| [`e4a64e49`](https://github.com/NixOS/nixpkgs/commit/e4a64e4948a74cce034124e71c38c7400995c51b) | `python3Packages.plugwise: 0.11.2 -> 0.12.0`                     | `2021-08-11 05:48:07Z` |
| [`74521637`](https://github.com/NixOS/nixpkgs/commit/74521637c7208d7e494912515386bd3cebe53409) | `python3Packages.opensimplex: remove unneeded dependencies`      | `2021-08-11 05:11:14Z` |
| [`b42b61c6`](https://github.com/NixOS/nixpkgs/commit/b42b61c636c2a85d44b2fbc06277e3dfe7ead802) | `python3Packages.pywebpush: 1.13.0 -> 1.14.0`                    | `2021-08-11 05:03:06Z` |
| [`87e0fb54`](https://github.com/NixOS/nixpkgs/commit/87e0fb5464d450250bf3dbca396ba430b72f7ddb) | `python3Packages.python-gitlab: 2.9.0 -> 2.10.0`                 | `2021-08-11 04:55:04Z` |
| [`6b9dc66a`](https://github.com/NixOS/nixpkgs/commit/6b9dc66a14e3e9aaf927d8071388043e98a5aa9e) | `radicle-upstream: 0.2.3 → 0.2.9, enable on darwin`              | `2021-08-11 04:38:12Z` |
| [`a375bbc5`](https://github.com/NixOS/nixpkgs/commit/a375bbc5f06144bafa4972c74add063d212429da) | `python3Packages.pymunk: add x86_64-darwin support`              | `2021-08-11 04:01:37Z` |
| [`e3324b34`](https://github.com/NixOS/nixpkgs/commit/e3324b346a0e8d6da6b34155e16d8f9cb384849b) | `flyctl: 0.0.229 -> 0.0.230`                                     | `2021-08-11 02:14:55Z` |
| [`314fa1c0`](https://github.com/NixOS/nixpkgs/commit/314fa1c0e620da78ee455b4dcffac498fe331a3e) | `grafana: 8.1.0 -> 8.1.1`                                        | `2021-08-11 02:07:44Z` |
| [`827142a4`](https://github.com/NixOS/nixpkgs/commit/827142a43cdaca217a3106e77654c8dc6e5edf92) | `cryptpad: add comment about EOL dependencies`                   | `2021-08-11 02:04:39Z` |
| [`04412d1f`](https://github.com/NixOS/nixpkgs/commit/04412d1f518490214081c803362f9b8d14db09d4) | `cryptpad: reformat with nixpkgs-fmt`                            | `2021-08-11 02:04:39Z` |
| [`df0f76b3`](https://github.com/NixOS/nixpkgs/commit/df0f76b39ff419136f742e300eb7c07cc83bd54f) | `cryptpad: add test for nixos module`                            | `2021-08-11 02:04:39Z` |
| [`6e59bc79`](https://github.com/NixOS/nixpkgs/commit/6e59bc79696bc826fdbf6821c0e0eccad93703db) | `cryptpad: use nodejs12`                                         | `2021-08-11 02:04:39Z` |
| [`27c81367`](https://github.com/NixOS/nixpkgs/commit/27c813679e9ecb403c9e63c8362a467f5574d57d) | `cryptpad: generate.sh: stop using outdated nixpkgs`             | `2021-08-11 02:04:39Z` |
| [`2220ca1e`](https://github.com/NixOS/nixpkgs/commit/2220ca1e3ca809e34b105c35b32145d2ebbe0378) | `cryptpad: 3.20.1 -> 4.9.0`                                      | `2021-08-11 02:04:39Z` |
| [`58156d95`](https://github.com/NixOS/nixpkgs/commit/58156d95e927cc51956b03b88a0f187a650fa4ac) | `antsimulator: fix texture path`                                 | `2021-08-11 01:31:46Z` |
| [`cee1de09`](https://github.com/NixOS/nixpkgs/commit/cee1de0975de331ba3de7734501de311adb2e6f9) | `libcef: support i686`                                           | `2021-08-11 01:16:34Z` |
| [`f3209301`](https://github.com/NixOS/nixpkgs/commit/f3209301351de3eed88683489e1fbbf708cd5a4a) | `libcef: add aarch64 support`                                    | `2021-08-11 01:01:36Z` |
| [`46f43918`](https://github.com/NixOS/nixpkgs/commit/46f4391873154fbdcff4093e7baf820b16d4c8e3) | `obs-studio: add aarch64 support`                                | `2021-08-11 01:00:53Z` |
| [`e8f74e79`](https://github.com/NixOS/nixpkgs/commit/e8f74e79261f8b760a6ead718032aec091552f61) | `deno: 1.12.2 -> 1.13.0`                                         | `2021-08-10 23:58:24Z` |
| [`c78baa08`](https://github.com/NixOS/nixpkgs/commit/c78baa08d3f73d15fd063aaa71cbd08f86f64731) | `openimageio2: 2.2.12.0 -> 2.2.17.0`                             | `2021-08-10 23:35:31Z` |
| [`be03a55b`](https://github.com/NixOS/nixpkgs/commit/be03a55b3614e120eee65c8cfb9f95c4dab0cea1) | `neovide: 2021-06-21 -> 2021-08-08`                              | `2021-08-10 23:17:00Z` |
| [`044315a1`](https://github.com/NixOS/nixpkgs/commit/044315a1a5835c8a61561489e1b6f85b89c69f44) | `helix: set meta.mainProgram`                                    | `2021-08-10 23:13:07Z` |
| [`a517d000`](https://github.com/NixOS/nixpkgs/commit/a517d00046a3a0e9764de4a93b02d2e7cd50e704) | `neovide: Remove expat`                                          | `2021-08-10 23:10:31Z` |
| [`6418b5d2`](https://github.com/NixOS/nixpkgs/commit/6418b5d2d54bdd3f103d69b4ce212129329cda54) | `neovide: Fix #133409 by backporting freetype`                   | `2021-08-10 23:06:34Z` |
| [`79a86e7e`](https://github.com/NixOS/nixpkgs/commit/79a86e7ef53d8ebd0ef944d8c2fca645798c43e7) | `treewide: Port type adaptations`                                | `2021-08-10 22:45:08Z` |
| [`20f7b751`](https://github.com/NixOS/nixpkgs/commit/20f7b7517e28f4ac5a4c95a7e2042395120ed4e8) | `ioquake3: 2020-12-26 -> 2021-07-20`                             | `2021-08-10 22:30:53Z` |
| [`6a94af55`](https://github.com/NixOS/nixpkgs/commit/6a94af558bb30ca1494c19be46414f5549b6ace6) | `pymupdf: fix version incorrect cause build error`               | `2021-08-10 22:17:47Z` |
| [`42d109da`](https://github.com/NixOS/nixpkgs/commit/42d109da85e06f07c7f6a833a653ce23974ef631) | `cargo-release: 0.16.2 -> 0.16.3`                                | `2021-08-10 21:20:59Z` |
| [`1eb62cee`](https://github.com/NixOS/nixpkgs/commit/1eb62cee70d5b316376311389aa1981efbfbd1ac) | `python3Packages.yeelight: 0.6.3 -> 0.7.2`                       | `2021-08-10 20:40:53Z` |
| [`652340f7`](https://github.com/NixOS/nixpkgs/commit/652340f7dd3511d21f06792a6f7fa6b22808a17c) | `python3Packages.yfinance: 0.1.61 -> 0.1.63`                     | `2021-08-10 20:31:41Z` |
| [`77d6e9e6`](https://github.com/NixOS/nixpkgs/commit/77d6e9e66c80d292ae87b034b536d08ff11ff23a) | `python3Packages.transmission-rpc: 3.2.5 -> 3.2.6`               | `2021-08-10 20:01:28Z` |
| [`41d065ef`](https://github.com/NixOS/nixpkgs/commit/41d065ef60347e246402e17c87835048d3bae18d) | `crispyDoom: 5.10.1 -> 5.10.2`                                   | `2021-08-10 20:01:17Z` |
| [`60348662`](https://github.com/NixOS/nixpkgs/commit/6034866286a3d69d75e1c3ca97bb1d44af53566e) | `python3Packages.fastapi: 0.67.0 -> 0.68.0`                      | `2021-08-10 19:01:01Z` |
| [`6b210608`](https://github.com/NixOS/nixpkgs/commit/6b21060861f82d4ac4cb2516aa67bcadc0789961) | `python3Packages.eventlet: 0.31.0 -> 0.31.1`                     | `2021-08-10 18:53:49Z` |
| [`4f0e6e98`](https://github.com/NixOS/nixpkgs/commit/4f0e6e9879f821680bd588d701c760b67aa5677e) | `glab: 1.18.1 -> 1.19.0`                                         | `2021-08-10 15:14:36Z` |
| [`0eb2e14a`](https://github.com/NixOS/nixpkgs/commit/0eb2e14a7fad2eec497942de06f1ed12d5c33221) | `mcfly: 0.5.6 -> 0.5.8`                                          | `2021-08-10 14:09:56Z` |
| [`e86780a1`](https://github.com/NixOS/nixpkgs/commit/e86780a18e2a40041673fec39904e29e5a25c7ca) | `doppler: 3.31.0 -> 3.31.1`                                      | `2021-08-10 13:21:11Z` |
| [`14088c31`](https://github.com/NixOS/nixpkgs/commit/14088c31893f79927b3750eaa29b283ff66b76a9) | `doctl: 1.62.0 -> 1.63.1`                                        | `2021-08-10 13:15:50Z` |
| [`07ebaed9`](https://github.com/NixOS/nixpkgs/commit/07ebaed9748fa97ccf3784b88193076211d2c865) | `antsimulator: 1.2 -> 3.1`                                       | `2021-08-10 11:05:35Z` |
| [`f9ec4117`](https://github.com/NixOS/nixpkgs/commit/f9ec4117cc20f4e42e3f1a4ab519d13d32cbac3d) | `geekbench: 5.4.0 -> 5.4.1`                                      | `2021-08-10 07:37:40Z` |
| [`40e9580c`](https://github.com/NixOS/nixpkgs/commit/40e9580ce4ee9c39814c1795e8857e15a1619f59) | `s3fs: 1.89 -> 1.90`                                             | `2021-08-10 07:25:16Z` |
| [`a9bf9c44`](https://github.com/NixOS/nixpkgs/commit/a9bf9c44e516f1097cb3d13e62293bf14669560c) | `linux_zen: 5.13.7 -> 5.13.9`                                    | `2021-08-09 19:31:40Z` |
| [`3815d320`](https://github.com/NixOS/nixpkgs/commit/3815d32010dc57a97fe8f6071a07c73aab7fd824) | `ethminer: fix global-context`                                   | `2021-08-09 16:43:27Z` |
| [`97d4432b`](https://github.com/NixOS/nixpkgs/commit/97d4432b0c88a0e3e0f5dc003e82022630f277c7) | `vimPlugins.bufdelete-nvim: init at 2021-07-24`                  | `2021-08-09 15:56:45Z` |
| [`2c4cdfb6`](https://github.com/NixOS/nixpkgs/commit/2c4cdfb6b221fe4c896d2f769c8501e1dc60488e) | `vimPlugins: update`                                             | `2021-08-09 15:56:25Z` |
| [`8b9bd165`](https://github.com/NixOS/nixpkgs/commit/8b9bd1657a9da08a4e6666ab148f924154c06f35) | `aether: init at 2.0.0-dev.15`                                   | `2021-08-09 08:38:14Z` |
| [`a74eaeba`](https://github.com/NixOS/nixpkgs/commit/a74eaeba5a3b5ba416c848929930045ddda914e4) | `erigon: 2021.05.02 -> 2021.08.01`                               | `2021-08-08 19:22:21Z` |
| [`c708f2f9`](https://github.com/NixOS/nixpkgs/commit/c708f2f92a5bd04b14f58c0d8ab9772d2bc41f96) | `turbo-geth: rename to erigon`                                   | `2021-08-08 19:22:19Z` |
| [`bfbfab56`](https://github.com/NixOS/nixpkgs/commit/bfbfab56cc72d2d0ed400a3992029abb4698cd55) | `dnspeep: init at 0.1.2`                                         | `2021-08-08 19:18:16Z` |
| [`ff862676`](https://github.com/NixOS/nixpkgs/commit/ff86267693ad02aa7e95c0d94ee5d5ccb88032ba) | `sweethome3d: 6.5.2 -> 6.6`                                      | `2021-08-01 13:03:35Z` |
| [`b8a90593`](https://github.com/NixOS/nixpkgs/commit/b8a905931ebf4d416f40c063595daa9245f0cb54) | `maintainers: add maxhille`                                      | `2021-07-20 12:25:45Z` |
| [`1a78bf2d`](https://github.com/NixOS/nixpkgs/commit/1a78bf2dd4fd9f0f9d5d48a835903d8fcd368255) | `aqbanking: 6.2.10 -> 6.3.0`                                     | `2021-05-05 16:24:49Z` |