### PR TITLE
feat(niv): update home-manager

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c049a09d1aa74e78d84cbb76a84a0218956650a6",
-        "sha256": "0gkbapjc25mrvvlrgjpw9x63k6ha8zhbzj0d2hhqpi2n4z0hsz9m",
+        "rev": "604561ba9ac45ee30385670b18f15731c541287b",
+        "sha256": "01mj8kqk8gv5v64dmbhx5mk0sz22cs2i0jybnlicv7318xzndzxk",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/c049a09d1aa74e78d84cbb76a84a0218956650a6.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/604561ba9ac45ee30385670b18f15731c541287b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixos-hardware": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                             | Timestamp              |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ | ---------------------- |
| [`604561ba`](https://github.com/nix-community/home-manager/commit/604561ba9ac45ee30385670b18f15731c541287b) | `lib.gvariant: escape newlines in strings` | `2021-08-11 21:30:24Z` |