### PR TITLE
feat(niv): update home-manager

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "604561ba9ac45ee30385670b18f15731c541287b",
-        "sha256": "01mj8kqk8gv5v64dmbhx5mk0sz22cs2i0jybnlicv7318xzndzxk",
+        "rev": "3d93e1e80274fd014cbdae510c0ca3b07bcfc9b6",
+        "sha256": "0i6ls9bj4xy1p3gq1jhidwkv437z51pjsrvipzaw37x5v8ydka50",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/604561ba9ac45ee30385670b18f15731c541287b.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/3d93e1e80274fd014cbdae510c0ca3b07bcfc9b6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixos-hardware": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                  | Timestamp              |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- | ---------------------- |
| [`3d93e1e8`](https://github.com/nix-community/home-manager/commit/3d93e1e80274fd014cbdae510c0ca3b07bcfc9b6) | `bat: support list settings and shell escaping` | `2021-08-12 19:29:14Z` |