### PR TITLE
feat(niv): update home-manager

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3d93e1e80274fd014cbdae510c0ca3b07bcfc9b6",
-        "sha256": "0i6ls9bj4xy1p3gq1jhidwkv437z51pjsrvipzaw37x5v8ydka50",
+        "rev": "a965b097b1e0c3bcf22f39413afd1ec6cc1f5335",
+        "sha256": "1df6a9gfkb2b1qaahxmy1aqrqnndnljlm22dmq4zkzkmmscvf3s9",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/3d93e1e80274fd014cbdae510c0ca3b07bcfc9b6.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/a965b097b1e0c3bcf22f39413afd1ec6cc1f5335.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixos-hardware": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                           | Timestamp              |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- | ---------------------- |
| [`a965b097`](https://github.com/nix-community/home-manager/commit/a965b097b1e0c3bcf22f39413afd1ec6cc1f5335) | `lib.gvariant: fix rendering of empty non-string arrays` | `2021-08-13 06:52:13Z` |
| [`a3d691c0`](https://github.com/nix-community/home-manager/commit/a3d691c05308b43afe264a2165f60948cfd2963e) | `lib.gvariant: add a few more functions to test case`    | `2021-08-12 22:45:10Z` |
| [`d819e074`](https://github.com/nix-community/home-manager/commit/d819e0741a08b18aa290f1d12d8d850ecfc28338) | `rofi-pass: remove test dependency on rofi`              | `2021-08-12 22:30:51Z` |
| [`479e26dc`](https://github.com/nix-community/home-manager/commit/479e26dc8c4ee3a24cf7dc61128af17ca9ab6faa) | `scmpuff: remove test dependency on zsh`                 | `2021-08-12 21:11:15Z` |