### PR TITLE
feat(niv): update home-manager

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a965b097b1e0c3bcf22f39413afd1ec6cc1f5335",
-        "sha256": "1df6a9gfkb2b1qaahxmy1aqrqnndnljlm22dmq4zkzkmmscvf3s9",
+        "rev": "72f3bc6fa461a2899a06c87c137c7135e410e387",
+        "sha256": "19346841har81bgj4vfb2ks222846ng185fcdhrwygxj6m3kbw5v",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/a965b097b1e0c3bcf22f39413afd1ec6cc1f5335.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/72f3bc6fa461a2899a06c87c137c7135e410e387.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixos-hardware": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                           | Timestamp              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------- | ---------------------- |
| [`72f3bc6f`](https://github.com/nix-community/home-manager/commit/72f3bc6fa461a2899a06c87c137c7135e410e387) | `flameshot: add some service sandboxing` | `2021-08-14 13:13:31Z` |
| [`654d82f8`](https://github.com/nix-community/home-manager/commit/654d82f8884f11804c7b20f9a092807e3bd95de9) | `syncthing: add more service sandboxing` | `2021-08-14 13:13:27Z` |