### PR TITLE
feat(niv): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6b574cd85176ecc96af1b93bf5d004c884863159",
-        "sha256": "020xl42ynn22751y6g6djqagq1q9wrnk7m705l447z34rncvcb2w",
+        "rev": "7915d1e03f93f3072ab397448830d028202e5d3d",
+        "sha256": "0visf2s5hggc4dj4ci8gxkagd95dv77ab43b2fdp0cknisqvyzbs",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/6b574cd85176ecc96af1b93bf5d004c884863159.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/7915d1e03f93f3072ab397448830d028202e5d3d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                       | Timestamp              |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- | ---------------------- |
| [`699e12e4`](https://github.com/NixOS/nixpkgs/commit/699e12e4c7e804c5b2e4c14bb932f6da5dd79f0c) | `texmaker: 5.0.4 -> 5.1.0`                                           | `2021-08-16 09:53:22Z` |
| [`6a8e8b46`](https://github.com/NixOS/nixpkgs/commit/6a8e8b46152c13cd7ae8a072d36aaee943c2f795) | `home-assistant: override total-connect-client`                      | `2021-08-16 09:31:44Z` |
| [`d51f8351`](https://github.com/NixOS/nixpkgs/commit/d51f83516578d092aba498cd42e74338af62c9a7) | `intel2200BGFirmware: less fixed-output derivation`                  | `2021-08-16 08:52:00Z` |
| [`c4af2338`](https://github.com/NixOS/nixpkgs/commit/c4af233882c8b0bba46f345a8a6a0696ac682e29) | `libtins: fix gtest subproject`                                      | `2021-08-16 08:28:35Z` |
| [`739f0b22`](https://github.com/NixOS/nixpkgs/commit/739f0b22b74a35f65e5b862108db4d4380feecc8) | `elixir_ls: 0.7.0 -> 0.8.0`                                          | `2021-08-16 05:48:01Z` |
| [`69789171`](https://github.com/NixOS/nixpkgs/commit/697891710272f11611cf892ec0ab675fffa48e9c) | `oh-my-git: clearify dependency`                                     | `2021-08-16 03:36:28Z` |
| [`58abd733`](https://github.com/NixOS/nixpkgs/commit/58abd7336749c486cfb1844ea74b79fb74007991) | `oh-my-git: fix strict eval (#134281)`                               | `2021-08-16 03:18:23Z` |
| [`a299818b`](https://github.com/NixOS/nixpkgs/commit/a299818b7922e6403034b1bb9a388c0dbe238917) | `mkvtoolnix: fix GUI on darwin (#133848)`                            | `2021-08-16 02:40:11Z` |
| [`6adca802`](https://github.com/NixOS/nixpkgs/commit/6adca8026c26d49de0c07a239642c33df58376a8) | `exa: fix on aarch64-darwin (#133660)`                               | `2021-08-16 01:42:43Z` |
| [`a13f8aa9`](https://github.com/NixOS/nixpkgs/commit/a13f8aa9be146c91c244e25580dd9b6ee369756f) | `oh-my-git: Add libudev`                                             | `2021-08-15 23:37:18Z` |
| [`e6a9fcd4`](https://github.com/NixOS/nixpkgs/commit/e6a9fcd47c6bbaf23951946288088f8754e19b87) | `acl2: Fix typo in cleanup commands`                                 | `2021-08-15 21:05:37Z` |
| [`bc368ab7`](https://github.com/NixOS/nixpkgs/commit/bc368ab7fd28fe442c244d6e53f5f4d6d45f90f7) | `entr: 4.9 -> 5.0`                                                   | `2021-08-15 20:30:41Z` |
| [`63ad6eb8`](https://github.com/NixOS/nixpkgs/commit/63ad6eb8a1603afd528b89cbd1519b353d42e537) | `perlPackages.mod_perl2: add passthru test`                          | `2021-08-15 20:26:50Z` |
| [`672f45b3`](https://github.com/NixOS/nixpkgs/commit/672f45b30ceccf29650f70f772037a6926e3286f) | `apacheHttpdPackages.mod_perl: add passthru test`                    | `2021-08-15 20:25:40Z` |
| [`2fa1bcd7`](https://github.com/NixOS/nixpkgs/commit/2fa1bcd7c3b49a049665fca17e34fc43fe208d98) | `oq: 1.2.0 -> 1.2.1`                                                 | `2021-08-15 17:09:37Z` |
| [`225d62ca`](https://github.com/NixOS/nixpkgs/commit/225d62caec46adf2511e2979b6566919a5644e00) | `python3Packages.pyppeteer: 0.2.5 -> 0.2.6`                          | `2021-08-15 12:50:05Z` |
| [`5dfb052e`](https://github.com/NixOS/nixpkgs/commit/5dfb052ee4a098efee226b05dbec8b338c6c5c94) | `python3Packages.google-cloud-appengine-logging: 0.1.0 -> 0.1.4`     | `2021-08-15 11:34:14Z` |
| [`005c8088`](https://github.com/NixOS/nixpkgs/commit/005c8088e1c8af388d20f5abc21f227cd621825a) | `python3Packages.google-cloud-websecurityscanner: 1.3.0 -> 1.4.1`    | `2021-08-15 11:34:13Z` |
| [`61514be7`](https://github.com/NixOS/nixpkgs/commit/61514be7dccd9c9e487bebf449a7bad25e2349eb) | `python3Packages.google-cloud-vision: 2.3.2 -> 2.4.2`                | `2021-08-15 11:34:12Z` |
| [`0aa06dd2`](https://github.com/NixOS/nixpkgs/commit/0aa06dd238fcfa7dc5726011a72e894559590e2f) | `python3Packages.google-cloud-videointelligence: 2.2.0 -> 2.3.2`     | `2021-08-15 11:34:11Z` |
| [`d128600a`](https://github.com/NixOS/nixpkgs/commit/d128600a146088ffd6f89b3941b9cf1caafae8e1) | `python3Packages.google-cloud-translate: 3.2.0 -> 3.3.2`             | `2021-08-15 11:34:10Z` |
| [`80687d26`](https://github.com/NixOS/nixpkgs/commit/80687d267bb7aef4ec4854e224ac1793c5da009a) | `python3Packages.google-cloud-trace: 1.2.0 -> 1.3.2`                 | `2021-08-15 11:34:10Z` |
| [`4122aeb5`](https://github.com/NixOS/nixpkgs/commit/4122aeb574bea791a21aa19a39cce44d4ab49212) | `python3Packages.google-cloud-texttospeech: 2.4.0 -> 2.5.2`          | `2021-08-15 11:34:09Z` |
| [`16c0db32`](https://github.com/NixOS/nixpkgs/commit/16c0db3213cf4d422c84618d958dba09dd704844) | `python3Packages.google-cloud-testutils: 0.2.0 -> 1.0.0`             | `2021-08-15 11:34:08Z` |
| [`c2539a55`](https://github.com/NixOS/nixpkgs/commit/c2539a557c540c83526e197bc8adc5e715caa9bd) | `python3Packages.google-cloud-tasks: 2.3.0 -> 2.5.1`                 | `2021-08-15 11:34:07Z` |
| [`c0a0401e`](https://github.com/NixOS/nixpkgs/commit/c0a0401e8aaff0ea60dd89bd4c7de482e4456333) | `python3Packages.google-cloud-storage: 1.38.0 -> 1.41.1`             | `2021-08-15 11:34:06Z` |
| [`a5f2209a`](https://github.com/NixOS/nixpkgs/commit/a5f2209a20aeb2de26187dbda61d2690596817f7) | `python3Packages.google-cloud-speech: 2.4.0 -> 2.6.0`                | `2021-08-15 11:34:05Z` |
| [`97ca9a43`](https://github.com/NixOS/nixpkgs/commit/97ca9a433a6c1853a33045a4574de44ef1c06319) | `python3Packages.google-cloud-spanner: 3.5.0 -> 3.7.0`               | `2021-08-15 11:34:04Z` |
| [`3f1faa51`](https://github.com/NixOS/nixpkgs/commit/3f1faa519895ea6d4478419577afa919c13e30fb) | `python3Packages.google-cloud-securitycenter: 1.3.1 -> 1.5.0`        | `2021-08-15 11:34:03Z` |
| [`682043fd`](https://github.com/NixOS/nixpkgs/commit/682043fd31b8330cbd1956e237a4bf7715576b1b) | `python3Packages.google-cloud-secret-manager: 2.5.0 -> 2.7.0`        | `2021-08-15 11:34:02Z` |
| [`920f244b`](https://github.com/NixOS/nixpkgs/commit/920f244b53ae0b055e26c169f582a95e67ef18ae) | `python3Packages.google-cloud-runtimeconfig: 0.32.2 -> 0.32.3`       | `2021-08-15 11:34:02Z` |
| [`02a9832f`](https://github.com/NixOS/nixpkgs/commit/02a9832fa2dfa249f55170d7ec572beda50a4757) | `python3Packages.google-cloud-resource-manager: 0.30.3 -> 1.0.2`     | `2021-08-15 11:34:01Z` |
| [`96d64192`](https://github.com/NixOS/nixpkgs/commit/96d64192e6d17137df1b298cad5f401a6c5fff1d) | `python3Packages.google-cloud-redis: 2.1.1 -> 2.2.2`                 | `2021-08-15 11:34:00Z` |
| [`dbe7f11e`](https://github.com/NixOS/nixpkgs/commit/dbe7f11e84120ec6ac1f2827ee8becf33fb8cf0d) | `python3Packages.google-cloud-pubsub: 2.5.0 -> 2.7.0`                | `2021-08-15 11:33:59Z` |
| [`14224e3e`](https://github.com/NixOS/nixpkgs/commit/14224e3e88d0a7309f758bcf4f899ae51d092b0a) | `python3Packages.google-cloud-os-config: 1.2.0 -> 1.3.2`             | `2021-08-15 11:33:58Z` |
| [`11f99457`](https://github.com/NixOS/nixpkgs/commit/11f99457ae217fb5347e63736e66ee86bb8575f1) | `python3Packages.google-cloud-monitoring: 2.3.0 -> 2.4.2`            | `2021-08-15 11:33:57Z` |
| [`46625027`](https://github.com/NixOS/nixpkgs/commit/466250270e7881be4e7d76fe87cba8e8aacf1045) | `python3Packages.google-cloud-logging: 2.5.0 -> 2.6.0`               | `2021-08-15 11:33:56Z` |
| [`cb9945f4`](https://github.com/NixOS/nixpkgs/commit/cb9945f408ba594ce7b01f56c688cbfe60075588) | `python3Packages.google-cloud-language: 2.1.0 -> 2.2.2`              | `2021-08-15 11:33:55Z` |
| [`eb7de7a5`](https://github.com/NixOS/nixpkgs/commit/eb7de7a5ab764330554707959398e5773ca80f16) | `python3Packages.google-cloud-kms: 2.3.0 -> 2.5.0`                   | `2021-08-15 11:33:54Z` |
| [`c55f040e`](https://github.com/NixOS/nixpkgs/commit/c55f040e4093ceb94567ae14acdf4522e29663ed) | `python3Packages.google-cloud-iot: 2.1.0 -> 2.2.1`                   | `2021-08-15 11:33:53Z` |
| [`7ccfffb0`](https://github.com/NixOS/nixpkgs/commit/7ccfffb04e581ca0c3f2cbaa290b5b9e950ab8b2) | `python3Packages.google-cloud-iam-logging: 0.1.0 -> 0.1.2`           | `2021-08-15 11:33:53Z` |
| [`f79e6c13`](https://github.com/NixOS/nixpkgs/commit/f79e6c138d4c5eb44907dc137621f40e30a2b036) | `python3Packages.google-cloud-firestore: 2.1.3 -> 2.2.0`             | `2021-08-15 11:33:52Z` |
| [`240e1ccf`](https://github.com/NixOS/nixpkgs/commit/240e1ccfd45cdd3993d58cf31d25e65d1dfc5286) | `python3Packages.google-cloud-error-reporting: 1.1.2 -> 1.2.2`       | `2021-08-15 11:33:51Z` |
| [`d8d554cb`](https://github.com/NixOS/nixpkgs/commit/d8d554cba93e4dc95d383dd5c67f27493e1420e5) | `python3Packages.google-cloud-dns: 0.32.3 -> 0.33.0`                 | `2021-08-15 11:33:50Z` |
| [`06f7d4c1`](https://github.com/NixOS/nixpkgs/commit/06f7d4c1d084691fa61fe6028809929763dfd1b0) | `python3Packages.google-cloud-dlp: 3.1.1 -> 3.2.2`                   | `2021-08-15 11:33:49Z` |
| [`e4d016b4`](https://github.com/NixOS/nixpkgs/commit/e4d016b4859c72b7d0fb8acbafbb74b1fe3fc3dc) | `python3Packages.google-cloud-datastore: 2.1.3 -> 2.1.6`             | `2021-08-15 11:33:48Z` |
| [`62dabcbc`](https://github.com/NixOS/nixpkgs/commit/62dabcbcb3eee1496dfd9abf8d9fb64b3de89df8) | `python3Packages.google-cloud-dataproc: 2.4.0 -> 2.5.0`              | `2021-08-15 11:33:47Z` |
| [`f2147a5c`](https://github.com/NixOS/nixpkgs/commit/f2147a5cd35a84f0e8461f8cdceab23d26206db6) | `python3Packages.google-cloud-core: 1.7.0 -> 1.7.2`                  | `2021-08-15 11:33:46Z` |
| [`251b1c74`](https://github.com/NixOS/nixpkgs/commit/251b1c74786b740348fedc4b28a049c348af6968) | `python3Packages.google-cloud-container: 2.4.1 -> 2.7.1`             | `2021-08-15 11:33:45Z` |
| [`394634b1`](https://github.com/NixOS/nixpkgs/commit/394634b152ee1073be8d76ad24ad38518e021ad3) | `python3Packages.google-cloud-bigtable: 2.2.0 -> 2.3.3`              | `2021-08-15 11:33:44Z` |
| [`2841a1c3`](https://github.com/NixOS/nixpkgs/commit/2841a1c3ef08c71a803a54f45b46acabea5a020c) | `python3Packages.google-cloud-bigquery-logging: 0.1.0 -> 0.2.1`      | `2021-08-15 11:33:43Z` |
| [`6e02278f`](https://github.com/NixOS/nixpkgs/commit/6e02278fc92ae9061fd2b3446fc9b248de6a6af1) | `python3Packages.google-cloud-bigquery-datatransfer: 3.1.1 -> 3.3.1` | `2021-08-15 11:33:42Z` |
| [`91cd0b0e`](https://github.com/NixOS/nixpkgs/commit/91cd0b0e8e681c91f73754c7d9415aa3fb3819a3) | `python3Packages.google-cloud-bigquery: 2.20.0 -> 2.23.3`            | `2021-08-15 11:33:41Z` |
| [`17a421e1`](https://github.com/NixOS/nixpkgs/commit/17a421e1aa30b3373fb4fbe348409375783bc409) | `python3Packages.google-cloud-automl: 2.3.0 -> 2.4.2`                | `2021-08-15 11:33:41Z` |
| [`cdf773c8`](https://github.com/NixOS/nixpkgs/commit/cdf773c87c761fa992dec571f24daf60089daca9) | `python3Packages.google-cloud-asset: 2.2.0 -> 3.3.0`                 | `2021-08-15 11:33:40Z` |
| [`97ed018f`](https://github.com/NixOS/nixpkgs/commit/97ed018f9f5e67439c414b1b42ffc40d2ccaa545) | `python3Packages.proto-plus: 1.18.1 -> 1.19.0`                       | `2021-08-15 11:33:39Z` |
| [`f22452b8`](https://github.com/NixOS/nixpkgs/commit/f22452b8e8022c4ba276bf4459ef86bce1c95514) | `python3Packages.google-resumable-media: 1.3.1 -> 1.3.3`             | `2021-08-15 11:33:38Z` |
| [`76d50ba3`](https://github.com/NixOS/nixpkgs/commit/76d50ba35a7d1fe4cefc3a833d56c633701d5634) | `python3Packages.google-auth: 1.31.0 -> 1.34.0`                      | `2021-08-15 11:33:37Z` |
| [`5f2d1bf8`](https://github.com/NixOS/nixpkgs/commit/5f2d1bf8d93e2047a5ff6c99f4b9a70a50250602) | `python3Packages.google-auth-oauthlib: 0.4.4 -> 0.4.5`               | `2021-08-15 11:33:36Z` |
| [`13b62037`](https://github.com/NixOS/nixpkgs/commit/13b620376cf042b8ad966f43fde6f2ebfbaedb08) | `python3Packages.google-api-python-client: 2.9.0 -> 2.15.0`          | `2021-08-15 11:33:35Z` |
| [`24aaa059`](https://github.com/NixOS/nixpkgs/commit/24aaa059bc017a523b8955e8f950421092e42a57) | `python38Packages.fastecdsa: 2.1.5 -> 2.2.1`                         | `2021-08-15 07:24:14Z` |
| [`5e13c58f`](https://github.com/NixOS/nixpkgs/commit/5e13c58f78b685f1d9fd451160dfb1adc9c4ce07) | `nixos/mod_perl: add test`                                           | `2021-08-13 19:03:15Z` |
| [`e5b6d371`](https://github.com/NixOS/nixpkgs/commit/e5b6d371bea52f1602298279881abbd28a80d251) | `python38Packages.azure-servicebus: 7.3.1 -> 7.3.2`                  | `2021-08-13 15:00:09Z` |
| [`c4095d0e`](https://github.com/NixOS/nixpkgs/commit/c4095d0e4129dd7914a885a0f4088b2ff8f0b2c5) | `perlPackages.mod_perl2: fix build on perl-5.34.0`                   | `2021-08-13 13:16:35Z` |
| [`957f0485`](https://github.com/NixOS/nixpkgs/commit/957f0485dab604c493d7683b8a57c0679b19e35f) | `linux_5_12: remove`                                                 | `2021-08-12 05:30:46Z` |
| [`0542f4e3`](https://github.com/NixOS/nixpkgs/commit/0542f4e3b036b91fb4a697267544fcfb657480c5) | `enchant: Add nuspell support`                                       | `2021-08-09 00:21:18Z` |
| [`ce76ecf5`](https://github.com/NixOS/nixpkgs/commit/ce76ecf505269c13c48b54be32bc5efdbb221fbf) | `boost167: remove`                                                   | `2021-06-09 20:13:53Z` |
| [`aa3a8288`](https://github.com/NixOS/nixpkgs/commit/aa3a82886b6c61983821ce01b142e43aadd5e389) | `openvswitch: better integration with systemd`                       | `2020-11-13 20:08:56Z` |