### PR TITLE
feat(niv): update home-manager

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "72f3bc6fa461a2899a06c87c137c7135e410e387",
-        "sha256": "19346841har81bgj4vfb2ks222846ng185fcdhrwygxj6m3kbw5v",
+        "rev": "ad0fc085c7b954d5813a950cf0db7143e6b049e3",
+        "sha256": "1m5fprdnbl38hfvj65m67nqpajjs3ngz92flx9zfzwpkj8nhvcvf",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/72f3bc6fa461a2899a06c87c137c7135e410e387.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/ad0fc085c7b954d5813a950cf0db7143e6b049e3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixos-hardware": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                           | Timestamp              |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- | ---------------------- |
| [`ad0fc085`](https://github.com/nix-community/home-manager/commit/ad0fc085c7b954d5813a950cf0db7143e6b049e3) | `git-sync: add module`                                   | `2021-08-16 22:00:38Z` |
| [`5ed3a41a`](https://github.com/nix-community/home-manager/commit/5ed3a41afa705aa821a69c174e5060024b20c5e2) | `htop: use dummy package in tests`                       | `2021-08-16 21:31:59Z` |
| [`2c3a968f`](https://github.com/nix-community/home-manager/commit/2c3a968f57867bef8ff311d4e993a6e4116b0b1c) | `htop: make self code owner of tests too`                | `2021-08-16 21:20:33Z` |
| [`e60dca7b`](https://github.com/nix-community/home-manager/commit/e60dca7bb3e34817f237f9f97124e64a2afa0455) | `htop: fix htoprc when fields is not explicitly set`     | `2021-08-16 21:20:32Z` |
| [`447f80f6`](https://github.com/nix-community/home-manager/commit/447f80f67648d956c453aafa873d0026c5563454) | `htop: verify htoprc contents for example settings test` | `2021-08-16 21:20:31Z` |
| [`e4553546`](https://github.com/nix-community/home-manager/commit/e4553546cce35e8bd33916e194cbcf7c8c648c8a) | `htop: let htop program use its default settings`        | `2021-08-16 21:20:31Z` |
| [`7226c2db`](https://github.com/nix-community/home-manager/commit/7226c2db468043e52f0a0ebdfde1b369ed2d6db8) | `htop: add self as maintainer`                           | `2021-08-16 21:20:30Z` |
| [`6eb88173`](https://github.com/nix-community/home-manager/commit/6eb88173e969e0b575ff8e09785070e2e9e35d81) | `htop: remove deprecated options and definitions`        | `2021-08-16 21:20:29Z` |