### PR TITLE
feat(niv): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7915d1e03f93f3072ab397448830d028202e5d3d",
-        "sha256": "0visf2s5hggc4dj4ci8gxkagd95dv77ab43b2fdp0cknisqvyzbs",
+        "rev": "56fadd63bdb77e16049d60d83d6b66c36d5ca8b0",
+        "sha256": "07f4anabq6x0kpgqalv91ki6m5dkrxn9hjm647khyljvx8ci6ad8",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/7915d1e03f93f3072ab397448830d028202e5d3d.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/56fadd63bdb77e16049d60d83d6b66c36d5ca8b0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                                  | Timestamp              |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ---------------------- |
| [`00037f74`](https://github.com/NixOS/nixpkgs/commit/00037f740333a18292326e9fd5c0163c91fe41de) | `darwin.binutils: fix wrapper of `as` when cross-compiling to aarch64-darwin (#134097)`                         | `2021-08-17 02:12:51Z` |
| [`5919a425`](https://github.com/NixOS/nixpkgs/commit/5919a4254607dd6a08c964aaaf0a180c6cd6214d) | `drawpile,drawpile-server-headless: 2.1.17 -> 2.1.19 (#134331)`                                                 | `2021-08-17 01:30:42Z` |
| [`50dd4a6c`](https://github.com/NixOS/nixpkgs/commit/50dd4a6cb2c8003d995459db7c9e8d8eee59cc08) | `beam-modules: deprecate phases`                                                                                | `2021-08-17 01:10:16Z` |
| [`ebdc6e2a`](https://github.com/NixOS/nixpkgs/commit/ebdc6e2aa9445b9cec42ef8b19e25d1cc07ec476) | `nodePackages: update`                                                                                          | `2021-08-17 01:05:30Z` |
| [`6353f880`](https://github.com/NixOS/nixpkgs/commit/6353f88074409cc53c5cc1ea2021d4b69445efd2) | `rust-analyzer: 2021-08-09 -> 2021-08-16`                                                                       | `2021-08-17 01:05:30Z` |
| [`2c090abe`](https://github.com/NixOS/nixpkgs/commit/2c090abeb03b77fa89aba77574444fa9541c1f0d) | `hqplayer-desktop: 4.12.2-36 -> 4.13.1-38`                                                                      | `2021-08-16 20:39:16Z` |
| [`0fe56e14`](https://github.com/NixOS/nixpkgs/commit/0fe56e14b6658d2e5c8629d34da1c653dabdba3f) | `hqplayerd: 4.25.0-64 -> 4.25.1-65`                                                                             | `2021-08-16 20:36:37Z` |
| [`024414f5`](https://github.com/NixOS/nixpkgs/commit/024414f501fdbed1489050fd11092889a4305da2) | `lisp-modules: use lib.makeSearchPath in shell.nix`                                                             | `2021-08-16 20:12:57Z` |
| [`b58fedc9`](https://github.com/NixOS/nixpkgs/commit/b58fedc98ea9eb6586d985e0975bd19d6db70fec) | `croc: 9.2.1 -> 9.3.0`                                                                                          | `2021-08-16 20:01:52Z` |
| [`8a8a949f`](https://github.com/NixOS/nixpkgs/commit/8a8a949ffdffa91b6de49310263e6406f101ca32) | `tlaplusToolbox: deprecate phases`                                                                              | `2021-08-16 19:54:44Z` |
| [`8ad1a785`](https://github.com/NixOS/nixpkgs/commit/8ad1a7859a426331672ff7f85f1832c17a3ecc85) | `tlaps: deprecate phases`                                                                                       | `2021-08-16 19:54:22Z` |
| [`75a35986`](https://github.com/NixOS/nixpkgs/commit/75a35986bf0765852789d8869ecb26f2ad3ff70c) | `sfm: 0.2 → 0.3.1`                                                                                              | `2021-08-16 19:27:44Z` |
| [`42dad213`](https://github.com/NixOS/nixpkgs/commit/42dad213cb77f19a188e7d1b849e0443a12b498c) | `vimPlugins.cmp_luasnip: init at 2021-08-16`                                                                    | `2021-08-16 19:24:35Z` |
| [`c3f09b3d`](https://github.com/NixOS/nixpkgs/commit/c3f09b3daf6d30d3baea0197cce4a5b7ed131093) | `vimPlugins.cmp-vsnip: init at 2021-08-13`                                                                      | `2021-08-16 19:24:35Z` |
| [`1455ef4f`](https://github.com/NixOS/nixpkgs/commit/1455ef4f4d983c21af2502702863140667599e20) | `vimPlugins.cmp-path: init at 2021-08-09`                                                                       | `2021-08-16 19:24:35Z` |
| [`5670287c`](https://github.com/NixOS/nixpkgs/commit/5670287c5b0029cb3f272a38bf16ad94e42cf46c) | `vimPlugins.cmp-nvim-lsp: init at 2021-08-16`                                                                   | `2021-08-16 19:24:35Z` |
| [`7a8c06b0`](https://github.com/NixOS/nixpkgs/commit/7a8c06b08dcbbe5916445d91dccf8e2bd36fa126) | `vimPlugins.cmp-emoji: init at 2021-08-09`                                                                      | `2021-08-16 19:24:35Z` |
| [`bd3687c3`](https://github.com/NixOS/nixpkgs/commit/bd3687c3de4a4ed62dd904378e4c6e18eb1ecece) | `vimPlugins.cmp-calc: init at 2021-08-08`                                                                       | `2021-08-16 19:24:35Z` |
| [`62cab46c`](https://github.com/NixOS/nixpkgs/commit/62cab46c8c0b07a4c0bf914480888380b3d65c6f) | `vimPlugins.cmp-buffer: init at 2021-08-11`                                                                     | `2021-08-16 19:24:35Z` |
| [`47514e07`](https://github.com/NixOS/nixpkgs/commit/47514e07470fd79bb8a34db8e6047dc3cd600dbb) | `vimPlugins.nvim-cmp: init at 2021-08-16`                                                                       | `2021-08-16 19:24:34Z` |
| [`4c7280d3`](https://github.com/NixOS/nixpkgs/commit/4c7280d387b373f3164e96509021522d7f31f6da) | `vimPlugins: update`                                                                                            | `2021-08-16 19:24:34Z` |
| [`b3b61f78`](https://github.com/NixOS/nixpkgs/commit/b3b61f78a08d2e9654889af971e39f1777c9ca83) | `freetype: format (#133165)`                                                                                    | `2021-08-16 18:54:29Z` |
| [`09911375`](https://github.com/NixOS/nixpkgs/commit/099113751e66899a620bb3e23875d421fc40804f) | `linuxPackages_4_14_hardened: fix eval`                                                                         | `2021-08-16 18:46:02Z` |
| [`a5341beb`](https://github.com/NixOS/nixpkgs/commit/a5341beb789c66ed24a11396dda28f2a1303768e) | `linux: drop `*_latest_hardened`-attributes in favor of versioned attributes`                                   | `2021-08-16 18:45:58Z` |
| [`874a5aa4`](https://github.com/NixOS/nixpkgs/commit/874a5aa449c7664b3fda113421f6a06fdc9cece9) | `rnix-lsp: remove unused argument`                                                                              | `2021-08-16 17:49:02Z` |
| [`5dc38fe3`](https://github.com/NixOS/nixpkgs/commit/5dc38fe346f0900c98b800ea4d2aaede0b140a0a) | `firefox-bin: custom policy setup via config.firefox.policies`                                                  | `2021-08-16 17:24:49Z` |
| [`575f35cf`](https://github.com/NixOS/nixpkgs/commit/575f35cf8ce786a9e642921120ced540b775196b) | `linux_xanmod: 5.13.10 -> 5.13.11`                                                                              | `2021-08-16 17:21:40Z` |
| [`6e01aa7c`](https://github.com/NixOS/nixpkgs/commit/6e01aa7ca639260aa4c8e652656f132fd5bfeb19) | `python38Packages.flowlogs_reader: 2.4.0 -> 3.1.0`                                                              | `2021-08-16 15:26:09Z` |
| [`71867a77`](https://github.com/NixOS/nixpkgs/commit/71867a77d995c7826cf406c88bd9efd05e795867) | `python38Packages.doc8: 0.8.1 -> 0.9.0`                                                                         | `2021-08-16 15:24:03Z` |
| [`58a02daa`](https://github.com/NixOS/nixpkgs/commit/58a02daa36fab8e12f00887df2bd480215e7a01c) | `python38Packages.gipc: 1.2.0 -> 1.3.0`                                                                         | `2021-08-16 15:23:43Z` |
| [`a64e6a25`](https://github.com/NixOS/nixpkgs/commit/a64e6a253b485bc61d00ba525419a826541568f4) | `python38Packages.bids-validator: 1.7.2 -> 1.8.0`                                                               | `2021-08-16 15:20:02Z` |
| [`b68618fc`](https://github.com/NixOS/nixpkgs/commit/b68618fc5612c12b8f8a8c39ed51edf825b9e2b6) | `python3Packages.pybids: mark broken`                                                                           | `2021-08-16 15:15:48Z` |
| [`40b2d9c8`](https://github.com/NixOS/nixpkgs/commit/40b2d9c84d6505899de0d1ab84a160ddb95c6313) | `python3.pkgs.typer: mark as broken`                                                                            | `2021-08-16 14:43:11Z` |
| [`655127e7`](https://github.com/NixOS/nixpkgs/commit/655127e717262dae6252ab6cc7f10ae321a555e7) | `maintainers: add j-hui`                                                                                        | `2021-08-16 14:36:05Z` |
| [`3a9a6863`](https://github.com/NixOS/nixpkgs/commit/3a9a6863a7d4e213ca36ce0c2b494564d05a9e3b) | `saleae-logic-2: init at 2.3.33`                                                                                | `2021-08-16 14:33:12Z` |
| [`e4c52747`](https://github.com/NixOS/nixpkgs/commit/e4c527476e8ae64dc2796effebf28d46d7c9fc69) | `mopidy-spotify: 4.0.1 -> 4.1.1`                                                                                | `2021-08-16 14:09:49Z` |
| [`81769efd`](https://github.com/NixOS/nixpkgs/commit/81769efdee8863924dff924c4225b2acb0a6d910) | `mopidy-iris: 3.54.0 -> 3.58.0`                                                                                 | `2021-08-16 13:57:11Z` |
| [`9c442240`](https://github.com/NixOS/nixpkgs/commit/9c442240bf1a5e603bfdc1e080cca3d4b0bf0614) | `nodePackages: update package set`                                                                              | `2021-08-16 13:49:09Z` |
| [`cd434db0`](https://github.com/NixOS/nixpkgs/commit/cd434db08e4f3c72eada7fb2085ced9aaa68ebd3) | `xmrig-mo: init at 6.14.1-mo1`                                                                                  | `2021-08-16 13:41:28Z` |
| [`f448b23f`](https://github.com/NixOS/nixpkgs/commit/f448b23f1bea906daf31caafce2f5a3ea42a82f2) | `opentelemetry-collector: remove unused input`                                                                  | `2021-08-16 13:37:50Z` |
| [`ce651d3a`](https://github.com/NixOS/nixpkgs/commit/ce651d3aab072231e04dfdb494ab19ca0bd5f9a4) | `rss2email: 3.13 -> 3.13.1 (#134087)`                                                                           | `2021-08-16 13:33:07Z` |
| [`8f37a4a3`](https://github.com/NixOS/nixpkgs/commit/8f37a4a310069a92428ffdd99a21b5b286719e05) | `pikchr: unstable-2021-04-07 -> unstable-2021-07-22`                                                            | `2021-08-16 13:14:44Z` |
| [`eec7d820`](https://github.com/NixOS/nixpkgs/commit/eec7d8209cfb7f9c9bbb2ee01ae72c3cb6809459) | `vimPlugins.lir-nvim: init at 2021-08-15`                                                                       | `2021-08-16 13:12:51Z` |
| [`d25bcbb2`](https://github.com/NixOS/nixpkgs/commit/d25bcbb2684dbd76dfa38a67efb8982765b118bf) | `python39Packages.google-cloud-bigquery: Fix tests`                                                             | `2021-08-16 13:03:27Z` |
| [`8d6faa6a`](https://github.com/NixOS/nixpkgs/commit/8d6faa6ac1f2af04985cf499cdb64cca3ff00ddc) | `python39Packages.google-cloud-datacatalog: init at 3.4.0`                                                      | `2021-08-16 13:03:27Z` |
| [`c5009da1`](https://github.com/NixOS/nixpkgs/commit/c5009da1b2740b29e58cc7e9414ca3ba765e91c0) | `haskellPackages: mark builds failing on hydra as broken`                                                       | `2021-08-16 12:47:04Z` |
| [`8e2afd69`](https://github.com/NixOS/nixpkgs/commit/8e2afd691f70225b508b118f06cd968e138db67a) | `Revert "signal-desktop: Add a Python wrapper to re-encrypt DBs"`                                               | `2021-08-16 12:42:04Z` |
| [`c010d0d2`](https://github.com/NixOS/nixpkgs/commit/c010d0d2d98b448e528d71bb8cd7a311dbc59091) | `python3Packages.zeroconf: 0.35.0 -> 0.35.1`                                                                    | `2021-08-16 12:21:45Z` |
| [`c5607372`](https://github.com/NixOS/nixpkgs/commit/c560737206632c0ce00c4eb3c0b319c8c2b542aa) | `standardnotes: 3.5.18 -> 3.8.18`                                                                               | `2021-08-16 12:14:19Z` |
| [`47aa1948`](https://github.com/NixOS/nixpkgs/commit/47aa19484c101b4146c5a6282807de2290f8f523) | `v4l2loopback: unstable-2020-04-22 -> unstable-2021-07-13`                                                      | `2021-08-16 12:12:41Z` |
| [`34be5801`](https://github.com/NixOS/nixpkgs/commit/34be58010795f34b551c2ccaa3db3c2743738677) | `gprolog: replace name with pname&version`                                                                      | `2021-08-16 12:06:42Z` |
| [`409dd0bf`](https://github.com/NixOS/nixpkgs/commit/409dd0bf58a376727fa8d2af0a99f4c00133439e) | `tree-sitter: update grammars`                                                                                  | `2021-08-16 12:05:07Z` |
| [`fb4e03fe`](https://github.com/NixOS/nixpkgs/commit/fb4e03fe68b9bffcbb73d5bcb4e57beee4d23d8f) | `python39Packages.grpc-google-iam-v1: deactivate tests, normalise name, adopt`                                  | `2021-08-16 12:04:29Z` |
| [`9c35ef5a`](https://github.com/NixOS/nixpkgs/commit/9c35ef5a23d54591dcf8d6634aba51fa6ddc4ce6) | `python39Packages.google-cloud-storage: Disable tests which require network`                                    | `2021-08-16 12:04:28Z` |
| [`74de2167`](https://github.com/NixOS/nixpkgs/commit/74de2167c4044950908aa147c182544eb7148006) | `python39Packages.google-cloud-resource-manager: Add missing depedencies, fix imports`                          | `2021-08-16 12:04:19Z` |
| [`2b98af6e`](https://github.com/NixOS/nixpkgs/commit/2b98af6e38f0b3edb2ddb0736866eb1c4e1ba172) | `python3Packages.furo: init at 2021.8.11b42`                                                                    | `2021-08-16 11:52:54Z` |
| [`5a01d3ac`](https://github.com/NixOS/nixpkgs/commit/5a01d3ac1f1ea31b9b2635eb2ae1d9f6cd860230) | `matrix-synapse: fix startup`                                                                                   | `2021-08-16 11:48:00Z` |
| [`d72d1fe1`](https://github.com/NixOS/nixpkgs/commit/d72d1fe1e53b1a6879093091e7039ba980cbc8da) | `v4l2loopback: Add bin output with utils`                                                                       | `2021-08-16 11:33:38Z` |
| [`c4d6dc8c`](https://github.com/NixOS/nixpkgs/commit/c4d6dc8c9b1cc102b4f3ea796a2df061a53c9405) | `home-assistant: 2021.8.6 -> 2021.8.7`                                                                          | `2021-08-16 11:02:42Z` |
| [`611182d3`](https://github.com/NixOS/nixpkgs/commit/611182d3cf8db1fd01c808a84c11b5624488d2d1) | `python3Packages.pymyq: 3.1.0 -> 3.1.2`                                                                         | `2021-08-16 11:02:41Z` |
| [`21eb8c5b`](https://github.com/NixOS/nixpkgs/commit/21eb8c5b37c6bcc18ecd2ebaeaf4a4fabe9c0f36) | `Revert "matrix-synapse: fix homeserver script"`                                                                | `2021-08-16 11:01:57Z` |
| [`7bb75b3c`](https://github.com/NixOS/nixpkgs/commit/7bb75b3c41a0f82de80641fb033eae57c7e36622) | `rshell: move the directory to pkgs/development/embedded/`                                                      | `2021-08-16 11:00:06Z` |
| [`832cdd28`](https://github.com/NixOS/nixpkgs/commit/832cdd2850ed1d646f681655d8db87123f6f656a) | `cc-tool: move the directory to pkgs/development/embedded/`                                                     | `2021-08-16 11:00:05Z` |
| [`4ed61ca8`](https://github.com/NixOS/nixpkgs/commit/4ed61ca8bcad6e4631ece7b892bddb390b0ca82b) | `uisp: move the directory to pkgs/development/embedded/`                                                        | `2021-08-16 11:00:05Z` |
| [`61b08400`](https://github.com/NixOS/nixpkgs/commit/61b0840054f5a375ef5bf929a61fb2ff8ae8236c) | `gputils: move the directory to pkgs/development/embedded/`                                                     | `2021-08-16 11:00:04Z` |
| [`fd49ef2d`](https://github.com/NixOS/nixpkgs/commit/fd49ef2d0ada0ba385090fc8bb0c89c4697cbf6b) | `bossa: move the directory to pkgs/development/embedded/`                                                       | `2021-08-16 11:00:04Z` |
| [`7a069de4`](https://github.com/NixOS/nixpkgs/commit/7a069de4684bcbdd3f2f12596acb9e778e7b909e) | `teensy-loader-cli: move the directory to pkgs/development/embedded/`                                           | `2021-08-16 11:00:04Z` |
| [`f60a6512`](https://github.com/NixOS/nixpkgs/commit/f60a6512a398f01841316559460132e25e6b4089) | `easypdkprog: move the directory to pkgs/development/embedded/`                                                 | `2021-08-16 11:00:03Z` |
| [`5a87ddfe`](https://github.com/NixOS/nixpkgs/commit/5a87ddfe6401560d8a788eaf2e913341560cf8b7) | `avrdude: move the directory to pkgs/development/embedded/`                                                     | `2021-08-16 11:00:03Z` |
| [`f46e3cbf`](https://github.com/NixOS/nixpkgs/commit/f46e3cbf67b6e2c6514df178f6bdbc5718f002e7) | `trellis: move the directory to pkgs/development/embedded/fpga/`                                                | `2021-08-16 11:00:02Z` |
| [`87c7e516`](https://github.com/NixOS/nixpkgs/commit/87c7e516bdc5601b17a2fad6c76a43d566251353) | `tinyprog: move the directory to pkgs/development/embedded/fpga/`                                               | `2021-08-16 11:00:02Z` |
| [`5e0993a3`](https://github.com/NixOS/nixpkgs/commit/5e0993a300ee6fd3a19a034b23e355705e41c1d6) | `apio: move the directory to pkgs/development/embedded/fpga/`                                                   | `2021-08-16 11:00:02Z` |
| [`864adb1a`](https://github.com/NixOS/nixpkgs/commit/864adb1a08cf2303569e4c8f9aa4fc306782704b) | `ecpdap: move the directory to pkgs/development/embedded/fpga/`                                                 | `2021-08-16 11:00:02Z` |
| [`48d9e57d`](https://github.com/NixOS/nixpkgs/commit/48d9e57d0f3a10a7f0fffff3a770140c7b494839) | `lattice-diamond: move the directory to pkgs/development/embedded/fpga/`                                        | `2021-08-16 11:00:01Z` |
| [`d8041d20`](https://github.com/NixOS/nixpkgs/commit/d8041d2084aa47ba254f1c5595fa3c594878e284) | `xc3sprog: move the directory to pkgs/development/embedded/`                                                    | `2021-08-16 11:00:00Z` |
| [`bef288e8`](https://github.com/NixOS/nixpkgs/commit/bef288e84ee964ad4e58e40eb16b10d914d4d54f) | `stm32cubemx: move the directory to pkgs/development/embedded/stm32/`                                           | `2021-08-16 11:00:00Z` |
| [`8eec22ea`](https://github.com/NixOS/nixpkgs/commit/8eec22ea678f25c3da08a7f7eef8eba28bc3a817) | `fujprog: move the directory to pkgs/development/embedded/fpga/`                                                | `2021-08-16 10:59:59Z` |
| [`0aafe24e`](https://github.com/NixOS/nixpkgs/commit/0aafe24e76fb8ca3e279d404dce550db6bf5ebdd) | `icestorm: move the directory to pkgs/development/embedded/fpga/`                                               | `2021-08-16 10:59:59Z` |
| [`6d250116`](https://github.com/NixOS/nixpkgs/commit/6d250116f7bd98947ff6ae428fff88434787890f) | `openfpgaloader: move the directory to pkgs/development/embedded/fpga/`                                         | `2021-08-16 10:59:59Z` |
| [`4c16ff4e`](https://github.com/NixOS/nixpkgs/commit/4c16ff4e4a09ab13cccecbe081e21822b250b835) | `stm32flash: move the directory to pkgs/development/embedded/stm32/`                                            | `2021-08-16 10:59:58Z` |
| [`5194c358`](https://github.com/NixOS/nixpkgs/commit/5194c3580c22d3eb9ee9ed52cfc74db4b30edd5b) | `inav: move the directory to pkgs/development/embedded/stm32/`                                                  | `2021-08-16 10:59:58Z` |
| [`0fc65824`](https://github.com/NixOS/nixpkgs/commit/0fc6582466599de0589af3b13140f356d3454ccb) | `betaflight: move the directory to pkgs/development/embedded/stm32/`                                            | `2021-08-16 10:59:57Z` |
| [`1b76de82`](https://github.com/NixOS/nixpkgs/commit/1b76de8268ece6622d8bf19c634b456c0a2ca79a) | `blackmagic: move the directory to pkgs/development/embedded/`                                                  | `2021-08-16 10:59:57Z` |
| [`08d9ac46`](https://github.com/NixOS/nixpkgs/commit/08d9ac46db3304a6f10b015d04839c3b1d13aa36) | `platformio: move the directory to pkgs/development/embedded/`                                                  | `2021-08-16 10:59:57Z` |
| [`9f62ba08`](https://github.com/NixOS/nixpkgs/commit/9f62ba081e3f0d87227939c3453296fd65746842) | `arduino-ci, arduino-cli, arduino-core, arduino-mk, ino: move arduino/ directory to pkgs/development/embedded/` | `2021-08-16 10:59:56Z` |
| [`ff1c9635`](https://github.com/NixOS/nixpkgs/commit/ff1c9635cb0dae77bc88866b20980a736e254495) | `openocd: move the directory to pkgs/development/embedded/`                                                     | `2021-08-16 10:59:56Z` |
| [`803abbf2`](https://github.com/NixOS/nixpkgs/commit/803abbf2bc053bf512fd9ab1d0ad6f2d5ff5bcda) | `lowdown: fix musl build`                                                                                       | `2021-08-16 10:36:59Z` |
| [`d3ec7e0c`](https://github.com/NixOS/nixpkgs/commit/d3ec7e0c3d62661f2d499f196aae43fa56a08614) | `haskellPackages.readline: fix Setup.hs to work with Cabal 3`                                                   | `2021-08-16 09:03:08Z` |
| [`40fc8794`](https://github.com/NixOS/nixpkgs/commit/40fc8794bc28f53f85a3774713f4ea0d5e23ea7c) | `python3Packages.googlemaps: 4.4.5 -> 4.5.3`                                                                    | `2021-08-16 07:56:44Z` |
| [`d48423d9`](https://github.com/NixOS/nixpkgs/commit/d48423d936e4fdf54ec7a202bf5cffb37f6e9151) | `python3Packages.pyezviz: 0.1.8.9 -> 0.1.9.1`                                                                   | `2021-08-16 06:38:02Z` |
| [`569a0b60`](https://github.com/NixOS/nixpkgs/commit/569a0b60635ef0c5017d5fce188af9b947a38b80) | `arpa2cm: 0.5 -> 0.9.0`                                                                                         | `2021-08-16 06:20:34Z` |
| [`d6fb49d8`](https://github.com/NixOS/nixpkgs/commit/d6fb49d8c297eebefab57e76105f9d68bef40221) | `qview: fix build on darwin, support extra formats`                                                             | `2021-08-16 05:29:59Z` |
| [`48a47c96`](https://github.com/NixOS/nixpkgs/commit/48a47c969a69e69ebc19f68c0d1dcbde1feca9cb) | `pounce: 2.3 -> 2.4`                                                                                            | `2021-08-16 03:23:24Z` |
| [`2ae15bde`](https://github.com/NixOS/nixpkgs/commit/2ae15bde0a32ce47b981f6cea3df82419c29ab93) | `vimPlugins.vim-ReplaceWithSameIndentRegister: init at 2020-06-17`                                              | `2021-08-15 21:16:57Z` |
| [`e3344c5d`](https://github.com/NixOS/nixpkgs/commit/e3344c5ddca9716226fd1bb4220413612b7ced01) | `vimPlugins.vim-ReplaceWithRegister: init at 2021-07-05`                                                        | `2021-08-15 21:16:57Z` |
| [`671dfb2f`](https://github.com/NixOS/nixpkgs/commit/671dfb2fd94a5da7ffafa7c1f3e10fa424af3dde) | `vimPlugins: update`                                                                                            | `2021-08-15 21:16:57Z` |
| [`ae41d2a1`](https://github.com/NixOS/nixpkgs/commit/ae41d2a1d7a669a2950c658003fd60e11c4781f1) | `xdotool: 3.20160805.1 → 3.20210804.2`                                                                          | `2021-08-15 19:28:37Z` |
| [`54dfcbf4`](https://github.com/NixOS/nixpkgs/commit/54dfcbf48ced466da46babe99a2beed4984d1a54) | `python3Packages.locationsharinglib: 4.1.6 -> 4.1.8`                                                            | `2021-08-15 19:21:57Z` |
| [`59e806a7`](https://github.com/NixOS/nixpkgs/commit/59e806a7c2ce5972678a88ce33ff5de0c053847d) | `python3Packages.rokuecp: 0.8.1 -> 0.8.2`                                                                       | `2021-08-15 17:13:41Z` |
| [`ff93bb9b`](https://github.com/NixOS/nixpkgs/commit/ff93bb9b2947145d31aabece0f8b0ab3ac720d37) | `vimPlugins.refactoring-nvim: init at 2021-08-15`                                                               | `2021-08-15 17:10:04Z` |
| [`6604a19d`](https://github.com/NixOS/nixpkgs/commit/6604a19d527af585454a35897009169b35698065) | `vimPlugins: update`                                                                                            | `2021-08-15 17:09:24Z` |
| [`3f1cb5c1`](https://github.com/NixOS/nixpkgs/commit/3f1cb5c13e277e6875ad33cc51b361be60bad5c0) | `nsd: 4.3.5 -> 4.3.7`                                                                                           | `2021-08-15 17:00:31Z` |
| [`cf5bad50`](https://github.com/NixOS/nixpkgs/commit/cf5bad503c391b2669aa4d059737f58c756296c1) | `python3Packages.apprise: 0.9.3 -> 0.9.4`                                                                       | `2021-08-15 16:54:26Z` |
| [`fa59f712`](https://github.com/NixOS/nixpkgs/commit/fa59f712180256c4ba3b5937a252d37242e2c58e) | `openxr-loader: 1.0.14 -> 1.0.18`                                                                               | `2021-08-15 16:51:03Z` |
| [`4f489fa6`](https://github.com/NixOS/nixpkgs/commit/4f489fa6ed1ca245324a974b965075ef343a0ead) | `python3Packages.aiomusiccast: 0.8.2 -> 0.9.1`                                                                  | `2021-08-15 16:49:07Z` |
| [`4e2ec502`](https://github.com/NixOS/nixpkgs/commit/4e2ec502f7978dc3fc1070960f5d65b5c4688538) | `opentelemetry-collector: 0.26.0 -> 0.31.0`                                                                     | `2021-08-15 16:42:53Z` |
| [`14b7ad41`](https://github.com/NixOS/nixpkgs/commit/14b7ad41b54395a9ec4204e84400ff125b12eb27) | `obsidian: 0.12.3 -> 0.12.12`                                                                                   | `2021-08-15 13:29:15Z` |
| [`b40971db`](https://github.com/NixOS/nixpkgs/commit/b40971db7fc3431661cb8f8238051289ebebc33d) | `ballerburg: include desktop file and icon`                                                                     | `2021-08-15 13:25:17Z` |
| [`6d6f1cc6`](https://github.com/NixOS/nixpkgs/commit/6d6f1cc6acd3c0fda1e0d6655ba41ad8312e12f6) | `oapi-codegen: 1.6.0 -> 1.8.2`                                                                                  | `2021-08-15 13:23:45Z` |
| [`0d79c10f`](https://github.com/NixOS/nixpkgs/commit/0d79c10f2eb16288fa042fbef171893411186723) | `python3Packages.desktop-notifier: 3.3.0 -> 3.3.1`                                                              | `2021-08-15 13:10:46Z` |
| [`0be2c36a`](https://github.com/NixOS/nixpkgs/commit/0be2c36a4aff742ad8b8baf6bd0ffbb47216ce48) | `marwaita-manjaro: 2.0 -> 10.3`                                                                                 | `2021-08-15 12:49:10Z` |
| [`3ff76853`](https://github.com/NixOS/nixpkgs/commit/3ff768534f10049a52c58fed3ed9cbf1789fbec4) | `mustache-go: 1.2.0 -> 1.2.2`                                                                                   | `2021-08-15 11:32:59Z` |
| [`66d1cb3c`](https://github.com/NixOS/nixpkgs/commit/66d1cb3c4df2974ed94cf57e6deb6cf57b7621ed) | `dasel: 1.18.0 -> 1.19.0`                                                                                       | `2021-08-15 03:11:04Z` |
| [`1c244c9d`](https://github.com/NixOS/nixpkgs/commit/1c244c9d71e1a00017f86fc4ff22a7e379cd80a8) | `uftrace: 0.9.4 -> 0.10`                                                                                        | `2021-08-14 17:01:46Z` |
| [`70cba623`](https://github.com/NixOS/nixpkgs/commit/70cba6232567692b01816f1f4830105393483b5f) | `xterm: 367 -> 368`                                                                                             | `2021-08-14 11:18:05Z` |
| [`dca4f328`](https://github.com/NixOS/nixpkgs/commit/dca4f328194d8778b9b58adde2ab07e82d3fd596) | `graphene-hardened-malloc: 2 -> 8`                                                                              | `2021-08-14 10:52:11Z` |
| [`caf71499`](https://github.com/NixOS/nixpkgs/commit/caf714998277a47003692dce701585a3c46dce6c) | `joystickwake: 0.2.4 -> 0.2.5`                                                                                  | `2021-08-14 10:29:05Z` |
| [`c0053ee3`](https://github.com/NixOS/nixpkgs/commit/c0053ee33031801a2bcc285be4fd2a371f98d709) | `istioctl: 1.10.3 -> 1.11.0`                                                                                    | `2021-08-14 10:09:40Z` |
| [`b1af5179`](https://github.com/NixOS/nixpkgs/commit/b1af5179bcb4eea65be050a6233492e3e0c355ef) | `cinnamon.xapps: 2.0.6 -> 2.2.3`                                                                                | `2021-08-14 09:55:31Z` |
| [`e6e0adac`](https://github.com/NixOS/nixpkgs/commit/e6e0adacca4e652d1ca48fa1a5e2a406b026faea) | `cinnamon.xviewer: 2.8.3 -> 3.0.2`                                                                              | `2021-08-14 09:50:35Z` |
| [`f06fee42`](https://github.com/NixOS/nixpkgs/commit/f06fee4262571c4a09871c1fb5d511e6f5b02d9f) | `wtf: 0.36.0 -> 0.38.0`                                                                                         | `2021-08-14 07:10:30Z` |
| [`d7ae8cf1`](https://github.com/NixOS/nixpkgs/commit/d7ae8cf1fed9604736ed4b5fe87859a930b68e48) | `factorio: 1.1.36 → 1.1.37`                                                                                     | `2021-08-14 05:02:43Z` |
| [`6c38bb6d`](https://github.com/NixOS/nixpkgs/commit/6c38bb6d5d34b53bd98cfa6936a1d56c43368782) | `kubernetes: fix breakage introduced by upgrade to 1.22`                                                        | `2021-08-13 16:55:03Z` |
| [`1ba3f792`](https://github.com/NixOS/nixpkgs/commit/1ba3f7927f9a8a982994ff6bdf1adc3949812128) | `nixos/testing: only create `nixos-run-vms` for `nixos-build-vms(8)``                                           | `2021-08-13 15:39:49Z` |
| [`9261db9d`](https://github.com/NixOS/nixpkgs/commit/9261db9db4f3f333897ad6a0152811054c4ae25e) | `cargo-kcov: ensure kcov is in PATH`                                                                            | `2021-08-13 09:10:36Z` |
| [`327f53d8`](https://github.com/NixOS/nixpkgs/commit/327f53d8ea96c3b580140b66ab9a6632add611df) | `whirlpool-gui: deprecate phases`                                                                               | `2021-08-12 21:55:12Z` |
| [`e1ec5acd`](https://github.com/NixOS/nixpkgs/commit/e1ec5acd3137d3af247f9a938d9cc086d8111377) | `nixos/test-driver: start interactive mode if `testScript` is empty`                                            | `2021-08-12 21:01:03Z` |
| [`260d9cc7`](https://github.com/NixOS/nixpkgs/commit/260d9cc7e10e477a60d11e9b44d80fd76a4492ae) | `nixos/testing: re-add nixos-run-vms script`                                                                    | `2021-08-12 20:50:29Z` |
| [`7cd5d178`](https://github.com/NixOS/nixpkgs/commit/7cd5d178fc6fd403907bfe00f502337c162d7607) | `tools: replace name with pname&version`                                                                        | `2021-08-12 19:47:47Z` |
| [`4444860f`](https://github.com/NixOS/nixpkgs/commit/4444860f074e4530c25217a528748786f9334308) | `matrix-synapse: fix homeserver script`                                                                         | `2021-08-12 00:24:42Z` |
| [`d2c9385b`](https://github.com/NixOS/nixpkgs/commit/d2c9385b6bb0fd21c12f57f6581f2150fd3ccc88) | `canon-cups-ufr2: deprecate phases`                                                                             | `2021-08-11 22:13:02Z` |
| [`22f7e083`](https://github.com/NixOS/nixpkgs/commit/22f7e0839e6a944374da7fbd72d77ab28b9e3efd) | `gusb: 0.3.5 -> 0.3.7`                                                                                          | `2021-08-11 15:56:09Z` |
| [`e46127fb`](https://github.com/NixOS/nixpkgs/commit/e46127fb1c9df914010c28d1241a5ae69e891429) | `python3Packages.subprocess-tee: init at 0.3.2`                                                                 | `2021-08-11 15:06:58Z` |
| [`078285c6`](https://github.com/NixOS/nixpkgs/commit/078285c64535f7c9a8f7f550fa80af9d15107553) | `containerd_1_4: init at 1.4.9`                                                                                 | `2021-08-11 10:53:10Z` |
| [`2d1b5aa1`](https://github.com/NixOS/nixpkgs/commit/2d1b5aa1fe72ef401a91e2e8408a939be5c1b238) | `haskell.compiler.ghcHEAD: increase Hydra timeout because Darwin builds were timing out`                        | `2021-08-11 04:21:02Z` |
| [`0a44a61f`](https://github.com/NixOS/nixpkgs/commit/0a44a61f39281de0942ebdf7e4b2dc22b46a51b9) | `openssl-1.0.2u: Add patch for darwin64-arm64`                                                                  | `2021-08-10 23:34:31Z` |
| [`d143d589`](https://github.com/NixOS/nixpkgs/commit/d143d589e78e14e6cb1cd8fac1cd2ea102ec10fd) | `haskellPackages: regenerate package set based on current config`                                               | `2021-08-10 20:21:42Z` |
| [`0ad7297b`](https://github.com/NixOS/nixpkgs/commit/0ad7297beaf0b19f96e5068180072eb4f8a4b24f) | `all-cabal-hashes: 2021-08-07T10:52:35Z -> 2021-08-10T19:15:27Z`                                                | `2021-08-10 20:19:49Z` |
| [`6f434ed4`](https://github.com/NixOS/nixpkgs/commit/6f434ed48ce3ea9f5458bd58c81c68472a6103fb) | `matrix-synapse: 1.39.0 -> 1.40.0`                                                                              | `2021-08-10 14:10:02Z` |
| [`87173025`](https://github.com/NixOS/nixpkgs/commit/871730254ea55aa1c43f7f2ea666b2a6ed5db946) | `docker: 20.10.7 -> 20.10.8`                                                                                    | `2021-08-04 22:38:24Z` |
| [`268e92bd`](https://github.com/NixOS/nixpkgs/commit/268e92bde00ab6aa3bbd81403125281f854e7185) | `maintainers: add putchar`                                                                                      | `2021-07-18 19:59:11Z` |