### PR TITLE
feat(niv): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "56fadd63bdb77e16049d60d83d6b66c36d5ca8b0",
-        "sha256": "07f4anabq6x0kpgqalv91ki6m5dkrxn9hjm647khyljvx8ci6ad8",
+        "rev": "6bb9ad36c526261a05587c261c5fe9ebbc010ef6",
+        "sha256": "12s4nbzhdvc99j1azlg6adqvvd0xzm0xd6xaxy09w1dq50i9klzy",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/56fadd63bdb77e16049d60d83d6b66c36d5ca8b0.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/6bb9ad36c526261a05587c261c5fe9ebbc010ef6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                       | Timestamp              |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- | ---------------------- |
| [`26e1c41f`](https://github.com/NixOS/nixpkgs/commit/26e1c41f93659fc9f12537e4c26112e09fcc9c48) | `caddy: 2.4.1 -> 2.4.3`                                              | `2021-08-17 13:44:50Z` |
| [`7f972a2f`](https://github.com/NixOS/nixpkgs/commit/7f972a2f9505b8514a3e945837227333d491d947) | `emacs/agda2-mode: deprecate phases (#133523)`                       | `2021-08-17 13:00:12Z` |
| [`58c1ab91`](https://github.com/NixOS/nixpkgs/commit/58c1ab9158216fe13ec1cd7f7384d32fdaeea3a0) | `coqPackages.addition-chains: init at 0.4`                           | `2021-08-17 12:44:10Z` |
| [`ff96901d`](https://github.com/NixOS/nixpkgs/commit/ff96901dbd04d4f70f3e5ef52b24a8f0c9227529) | `coqPackages.hydra-battles: 0.3 -> 0.4`                              | `2021-08-17 12:44:10Z` |
| [`98e23395`](https://github.com/NixOS/nixpkgs/commit/98e23395453a69115a27fda26baa41f24d3c0c63) | `coqPackages.gaia: init at 1.11 and 1.12`                            | `2021-08-17 12:44:10Z` |
| [`90654cce`](https://github.com/NixOS/nixpkgs/commit/90654cce7d17ea5485efd5489673bb34f7578d45) | `coqPackages.mkCoqDerivation: fix useDune2`                          | `2021-08-17 12:38:47Z` |
| [`c1821209`](https://github.com/NixOS/nixpkgs/commit/c1821209d8b70e1e73f9d4f73d5c41a537b6d572) | `osslsigncode: drop libgsf from buildInputs`                         | `2021-08-17 12:34:49Z` |
| [`8bc87152`](https://github.com/NixOS/nixpkgs/commit/8bc8715275ab32ad68f3babda74cf2e99c660a84) | `osslsigncode: 2.1 -> 2.2`                                           | `2021-08-17 10:45:25Z` |
| [`c6ef9315`](https://github.com/NixOS/nixpkgs/commit/c6ef93153307bfa77e5609718b9e50d0806b0095) | `notejot: 3.0.4 -> 3.1.0`                                            | `2021-08-17 10:09:44Z` |
| [`75ab21bf`](https://github.com/NixOS/nixpkgs/commit/75ab21bf877c81c7bbe664201aed4680a76d2ad9) | `headscale: 0.6.0 -> 0.6.1`                                          | `2021-08-17 09:47:25Z` |
| [`22719ca7`](https://github.com/NixOS/nixpkgs/commit/22719ca7de0b005426aae093e85e4abe91318fe6) | `nixos/caddy: add resume option`                                     | `2021-08-17 09:46:29Z` |
| [`c40a9d12`](https://github.com/NixOS/nixpkgs/commit/c40a9d125c69e60cb9c401f04847f4e57de670f1) | `libopus: disable tests on armv7l`                                   | `2021-08-17 09:35:45Z` |
| [`c6f73e4b`](https://github.com/NixOS/nixpkgs/commit/c6f73e4badf4429e9f25340db3c86ea7acf1c4a5) | `samba: fix build hanging on armv7l configure phase`                 | `2021-08-17 09:35:39Z` |
| [`ec6dee00`](https://github.com/NixOS/nixpkgs/commit/ec6dee00ecfe25065e658f35eee78ad517b8a605) | `fetch-rebar-deps: phases deprecation fix`                           | `2021-08-17 09:35:25Z` |
| [`7f37347f`](https://github.com/NixOS/nixpkgs/commit/7f37347f5eb6fab3cca0cc25454b741d8f73be8f) | `fetch-hex: deprecate phases fix`                                    | `2021-08-17 09:35:25Z` |
| [`aa4e76df`](https://github.com/NixOS/nixpkgs/commit/aa4e76dfb90966409e6e7bb84db124857c8ed3b3) | `catgirl: 1.9 -> 1.9a`                                               | `2021-08-17 09:04:52Z` |
| [`1c476a2b`](https://github.com/NixOS/nixpkgs/commit/1c476a2b6dda4bef88270f0285cac5363712c980) | `chromium: 92.0.4515.131 -> 92.0.4515.159`                           | `2021-08-17 08:26:07Z` |
| [`a1fdebce`](https://github.com/NixOS/nixpkgs/commit/a1fdebcef0befd3c81955e5a3d11292a819f84fc) | `chromium: Document the main gn build flags`                         | `2021-08-17 08:24:35Z` |
| [`e701bc3b`](https://github.com/NixOS/nixpkgs/commit/e701bc3bfbc82e3e6bd3321c3999a085cb6fba1c) | `nixos-generators: 1.3.0 -> 1.4.0`                                   | `2021-08-17 06:51:27Z` |
| [`17a9d592`](https://github.com/NixOS/nixpkgs/commit/17a9d5926cefda015270cf4afb94df43d4672b56) | `coreutils: disable tests on armv7l`                                 | `2021-08-17 06:36:22Z` |
| [`b1868a82`](https://github.com/NixOS/nixpkgs/commit/b1868a829689c8da19b79f6c023dc04bbdc6887c) | `elan: 1.0.6 -> 1.0.7`                                               | `2021-08-17 03:53:13Z` |
| [`5e2ef472`](https://github.com/NixOS/nixpkgs/commit/5e2ef472932615c52440f9be3b956f57eaf389bd) | `disfetch: 2.10 -> 2.12`                                             | `2021-08-17 03:28:00Z` |
| [`7364241a`](https://github.com/NixOS/nixpkgs/commit/7364241a6a060a9180c0b77ac5f627af0d80837c) | `gcc: update powerpc-specific configuration`                         | `2021-08-17 02:42:10Z` |
| [`565db308`](https://github.com/NixOS/nixpkgs/commit/565db308762cc1f5fc6df155e0981327b229acec) | `pkgsStatic: fix musleabi* adapter`                                  | `2021-08-17 01:52:22Z` |
| [`1c8fa088`](https://github.com/NixOS/nixpkgs/commit/1c8fa088197bfba0664c2af7576cdea7709432f0) | `python3Packages.pyvicare: 2.6 -> 2.7`                               | `2021-08-16 22:40:00Z` |
| [`11497605`](https://github.com/NixOS/nixpkgs/commit/11497605b41138a78b4d63cb2fb9d7422d993217) | `cmark: fix libcmark.pc paths`                                       | `2021-08-16 22:17:29Z` |
| [`6c496185`](https://github.com/NixOS/nixpkgs/commit/6c496185e341da785af6983fdddc6c1dd7d576a3) | `python3Packages.slither-analyzer: 0.8.0 -> 0.8.1`                   | `2021-08-16 22:15:42Z` |
| [`da0ae5e2`](https://github.com/NixOS/nixpkgs/commit/da0ae5e221930495865178ade7940b026163cf4c) | `python3Packages.crytic-compile: 0.2.0 -> 0.2.1`                     | `2021-08-16 22:15:33Z` |
| [`1ccced59`](https://github.com/NixOS/nixpkgs/commit/1ccced5932f904a71965b50f052d487643e22875) | `python3Packages.zeroconf: 0.35.1 -> 0.36.0`                         | `2021-08-16 22:08:47Z` |
| [`c977af0b`](https://github.com/NixOS/nixpkgs/commit/c977af0b0228a92c817d4e1f0a2122c608b0580a) | `cmark: fix tests on darwin`                                         | `2021-08-16 22:05:40Z` |
| [`84f5f4f8`](https://github.com/NixOS/nixpkgs/commit/84f5f4f84cfc186e205a87a58593309b3535f024) | `python3Packages.simplisafe-python: 11.0.3 -> 11.0.4`                | `2021-08-16 22:03:12Z` |
| [`9c3de9dd`](https://github.com/NixOS/nixpkgs/commit/9c3de9dd586506a7694fc9f19d459ad381239e34) | `python3Packages.pre-commit: 2.13.0 -> 2.14.0`                       | `2021-08-16 21:59:26Z` |
| [`6275972e`](https://github.com/NixOS/nixpkgs/commit/6275972e4ff184ead9dae76a94cb9ac37b8c89e5) | `python3Packages.pymeteireann: 0.3 -> 2021.8.0`                      | `2021-08-16 19:20:41Z` |
| [`a37965f7`](https://github.com/NixOS/nixpkgs/commit/a37965f7c5d26938774677e97b9f6c9e35bce701) | `nixos: fix release notes about linux_latest version`                | `2021-08-16 17:32:04Z` |
| [`ac7a14a9`](https://github.com/NixOS/nixpkgs/commit/ac7a14a9f037ef8c0a289cb81cd2edb4b74a3802) | `python3Packages.aiotractive: 0.5.1 -> 0.5.2`                        | `2021-08-16 17:17:51Z` |
| [`97ae49d7`](https://github.com/NixOS/nixpkgs/commit/97ae49d708fce32a838e9b4359a319596dc29cd9) | `python3Packages.growattserver: 1.0.1 -> 1.0.2`                      | `2021-08-16 17:04:42Z` |
| [`fcc699a0`](https://github.com/NixOS/nixpkgs/commit/fcc699a051598d1f4e7a11a4281159dae91ebb9e) | `crowdin-cli: init at 3.6.4`                                         | `2021-08-15 20:24:58Z` |
| [`1e481a00`](https://github.com/NixOS/nixpkgs/commit/1e481a0061fd644313dcfeb8592b0d4f4e2ee42b) | `python3Packages.spotipy: 2.18.0 -> 2.19.0`                          | `2021-08-15 17:05:07Z` |
| [`012a9df9`](https://github.com/NixOS/nixpkgs/commit/012a9df9a17e056ebb9b861554814cb6c046a932) | `python3Packages.smart-meter-texas: 0.4.3 -> 0.4.4`                  | `2021-08-15 16:57:43Z` |
| [`5937fc0f`](https://github.com/NixOS/nixpkgs/commit/5937fc0f8c4cb45f5458a48b3ed987bd8062bf75) | `misc: replace name with pname&version`                              | `2021-08-15 14:33:00Z` |
| [`d857340c`](https://github.com/NixOS/nixpkgs/commit/d857340c8e16a1c080832bbf3566c86fc718c1cf) | `nixos/installer: simplify and document wifi setup`                  | `2021-08-15 10:08:32Z` |
| [`d1434fd8`](https://github.com/NixOS/nixpkgs/commit/d1434fd8960cce9afcbf545e34c80dde5c2b8e6b) | `wireless-regdb: 2021.04.21 -> 2021.07.14`                           | `2021-08-14 06:24:20Z` |
| [`1bf40576`](https://github.com/NixOS/nixpkgs/commit/1bf40576bc6aa03bdeecbc86daedcb31177b418c) | `xplayer: 2.4.0 -> 2.4.2`                                            | `2021-08-14 06:08:13Z` |
| [`0fbf6afa`](https://github.com/NixOS/nixpkgs/commit/0fbf6afa4d8ddec6f637a3f0f363f7c3ef3b4c12) | `thunderbird-bin: 78.13.0 -> 91.0`                                   | `2021-08-13 05:57:57Z` |
| [`e6702107`](https://github.com/NixOS/nixpkgs/commit/e670210728a841542aaa1519b93211d419375861) | `pulumi-bin: 3.9.0 -> 3.10.0`                                        | `2021-08-12 20:40:27Z` |
| [`090f33f7`](https://github.com/NixOS/nixpkgs/commit/090f33f788749b9d2a9105ff17d6e1e5ff36019b) | `nixos/geth: Change default to snap sync`                            | `2021-08-03 13:13:02Z` |
| [`3802c496`](https://github.com/NixOS/nixpkgs/commit/3802c4962e54dd6110092a2ba3feee1d2ebf5a9e) | `stage-1: create temporary secrets directory in /tmp and not in cwd` | `2019-11-19 19:48:02Z` |