### PR TITLE
feat(niv): update home-manager

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7ef3db3730d7bddad471372ed823c770634933a7",
-        "sha256": "181wkyrigfj0dians57yn80afi5jykkjw0v0xg3hgjw08rq127yi",
+        "rev": "72394f6d6b1cee26021c3e319fa249122ad33d82",
+        "sha256": "1hnkc81p50qq3zmk75bb132ks9w62mssy76xf2xamqlm6y0k0425",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/7ef3db3730d7bddad471372ed823c770634933a7.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/72394f6d6b1cee26021c3e319fa249122ad33d82.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixos-hardware": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                              | Timestamp              |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- | ---------------------- |
| [`72394f6d`](https://github.com/nix-community/home-manager/commit/72394f6d6b1cee26021c3e319fa249122ad33d82) | `fluidsynth: add sound service option`                      | `2021-08-17 22:38:29Z` |
| [`d11afee9`](https://github.com/nix-community/home-manager/commit/d11afee9735a1f9fba2358885fdd86318e214ccb) | `home-manager: allow remote builders for nix-build (#2268)` | `2021-08-17 20:53:44Z` |
| [`5569770d`](https://github.com/nix-community/home-manager/commit/5569770d1ef66cfacea2c7d116c156fabfb5310b) | `files: move dry run logic out of onChange hooks`           | `2021-08-17 20:14:32Z` |
| [`8d68dbd1`](https://github.com/nix-community/home-manager/commit/8d68dbd144f2bcb9d0c89f7e978f1fd55cb281fb) | `doc: Add an example for a git includes section (#2275)`    | `2021-08-17 20:12:00Z` |