### PR TITLE
feat(niv): update nixos-hardware

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "566f4da36652b1fe404346aafcd2cd02fecf7d43",
-        "sha256": "1rsigxljk9cmxnscwq8hcybkh7rs8a0gyf8zk3hjn0683rwclqjf",
+        "rev": "878f629005b003fe39c9e619b074e0ff7d9ed0e2",
+        "sha256": "12zl4hjylsd74ml2nzaqdn099yli86441maa9ybw94sq9hchx585",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixos-hardware/archive/566f4da36652b1fe404346aafcd2cd02fecf7d43.tar.gz",
+        "url": "https://github.com/NixOS/nixos-hardware/archive/878f629005b003fe39c9e619b074e0ff7d9ed0e2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                    | Timestamp              |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- | ---------------------- |
| [`22f1a185`](https://github.com/NixOS/nixos-hardware/commit/22f1a185cf2ce57e7334b6a44aaad19c5fedc770) | `xps-13-9310: fix evaluation`                     | `2021-08-18 15:53:34Z` |
| [`eb385fad`](https://github.com/NixOS/nixos-hardware/commit/eb385fad1e6dcbe4289ff88b0095ac0791931677) | `lenovo/thinkpad/e495: use native acpi backlight` | `2021-08-18 09:58:49Z` |