### PR TITLE
feat(niv): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6bb9ad36c526261a05587c261c5fe9ebbc010ef6",
-        "sha256": "12s4nbzhdvc99j1azlg6adqvvd0xzm0xd6xaxy09w1dq50i9klzy",
+        "rev": "bf8c2f2e8c6b94f480a539851b1b2cf6e8770282",
+        "sha256": "0bx5kx2hn9xx1lb92lyg45k2x822k02sdrqjfgcf3xmi5bl8a4xn",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/6bb9ad36c526261a05587c261c5fe9ebbc010ef6.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/bf8c2f2e8c6b94f480a539851b1b2cf6e8770282.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                         | Timestamp              |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ---------------------- |
| [`229ff549`](https://github.com/NixOS/nixpkgs/commit/229ff549e611d33d6b8ef2c6a2ce8879e9e75545) | `lib: inherit mkImageMediaOverride`                                    | `2021-08-18 12:21:16Z` |
| [`01aa0b98`](https://github.com/NixOS/nixpkgs/commit/01aa0b98b1815c7fa7d71c0aa2901c6660f49bc6) | `python38Packages.hcloud: 1.13.0 -> 1.16.0`                            | `2021-08-18 12:01:39Z` |
| [`4063d283`](https://github.com/NixOS/nixpkgs/commit/4063d283c1aa91503c52f1bb69e75b13660a70f1) | `python38Packages.fontparts: 0.9.10 -> 0.9.11`                         | `2021-08-18 11:33:45Z` |
| [`d14ea149`](https://github.com/NixOS/nixpkgs/commit/d14ea1499b7a3e373bf53dd4aa631a9352344564) | `xidel: 0.9.6 -> 0.9.8, refactor`                                      | `2021-08-18 11:10:08Z` |
| [`4d322f3e`](https://github.com/NixOS/nixpkgs/commit/4d322f3e582eff69def505b03e68192559819b01) | `erlang-ls: add updateScript`                                          | `2021-08-18 10:58:23Z` |
| [`4082c9b8`](https://github.com/NixOS/nixpkgs/commit/4082c9b89b0726e40268998106cc36a540626022) | `signal-cli: 0.8.1 -> 0.8.5`                                           | `2021-08-18 10:33:51Z` |
| [`d6afe91d`](https://github.com/NixOS/nixpkgs/commit/d6afe91d212141da31b1c0b7fc3bb2bd94bc72a8) | `friture: unstable-2020-02-16 -> 0.47 (#133781)`                       | `2021-08-18 10:00:51Z` |
| [`f787c0b1`](https://github.com/NixOS/nixpkgs/commit/f787c0b1304643dc2037791b637f4527bb4077c5) | `rPackages.rsvg: fix build`                                            | `2021-08-18 05:59:19Z` |
| [`637bb5d0`](https://github.com/NixOS/nixpkgs/commit/637bb5d08591bc329b2a2f85e8c386add2e5ec57) | `Update package version to fix build`                                  | `2021-08-18 05:42:58Z` |
| [`cebb6630`](https://github.com/NixOS/nixpkgs/commit/cebb66308668299b89f897e38ea469d31f271e31) | `Clarify specific GPL license`                                         | `2021-08-18 05:42:23Z` |
| [`a07505d5`](https://github.com/NixOS/nixpkgs/commit/a07505d5181dcde3a6e0a817af16905dc04bc32e) | `Reverse conditional in meta.broken`                                   | `2021-08-18 05:41:30Z` |
| [`c5c4d360`](https://github.com/NixOS/nixpkgs/commit/c5c4d360a974a0301260a77ba62a78c5f9f59209) | `python38Packages.google-cloud-storage: 1.41.1 -> 1.42.0`              | `2021-08-18 05:29:11Z` |
| [`a9c1f98e`](https://github.com/NixOS/nixpkgs/commit/a9c1f98ecbe355d3293d9cf91bf586a66d479bda) | `python38Packages.google-cloud-speech: 2.6.0 -> 2.7.0`                 | `2021-08-18 05:27:36Z` |
| [`4d3044bf`](https://github.com/NixOS/nixpkgs/commit/4d3044bf5bcb16144ace6746a26512eb2678890b) | `python38Packages.google-cloud-runtimeconfig: 0.32.3 -> 0.32.4`        | `2021-08-18 05:27:25Z` |
| [`40bcd7db`](https://github.com/NixOS/nixpkgs/commit/40bcd7dbb3ca5fdc97b14f5d043c4de39cdd5c7b) | `symfony-cli: 4.25.4 -> 4.25.5`                                        | `2021-08-18 02:40:36Z` |
| [`77a51be0`](https://github.com/NixOS/nixpkgs/commit/77a51be0f27800fe6340ee26b7fee4f858dc5ccd) | `waybar: expose rfkillSupport`                                         | `2021-08-18 01:17:36Z` |
| [`a7194641`](https://github.com/NixOS/nixpkgs/commit/a71946413efbaf63520621057a001fd1c6b29a62) | `waybar: explicitly enable layer-shell and manpages`                   | `2021-08-18 01:17:24Z` |
| [`358aafb6`](https://github.com/NixOS/nixpkgs/commit/358aafb69371e6e6b8d603084aa71351052c9602) | `waybar: remove deprecated -Dout meson option`                         | `2021-08-18 01:17:07Z` |
| [`2eda9b76`](https://github.com/NixOS/nixpkgs/commit/2eda9b76765f77a406713b861981242729dcff6a) | `waybar: remove unnecessary cmake nativeBuildDep`                      | `2021-08-18 01:16:49Z` |
| [`2715dcfa`](https://github.com/NixOS/nixpkgs/commit/2715dcfafa47fb082172023eba68613d272fa0e6) | `spaceship-prompt: 3.12.25 -> 3.14.0`                                  | `2021-08-18 01:16:17Z` |
| [`027b2ac2`](https://github.com/NixOS/nixpkgs/commit/027b2ac2eb415d4efc49a044b596f01c5d0125ae) | `firefox-bin: 91.0 -> 91.0.1`                                          | `2021-08-18 00:54:09Z` |
| [`ab44b4de`](https://github.com/NixOS/nixpkgs/commit/ab44b4dea728b10916311a590e0cca2351d08c51) | `firefox-esr-78: 78.12.0esr -> 78.13.0esr`                             | `2021-08-18 00:52:56Z` |
| [`2ad22bbb`](https://github.com/NixOS/nixpkgs/commit/2ad22bbb52ddadb275e4889ed0f960a24ed47aab) | `firefox-esr-91: 91.0esr -> 91.0.1esr`                                 | `2021-08-18 00:51:04Z` |
| [`010a3169`](https://github.com/NixOS/nixpkgs/commit/010a3169667ed0bfff8c092dd707c1d619f0d0c5) | `firefox: 91.0 -> 91.0.1`                                              | `2021-08-18 00:49:45Z` |
| [`decfdc78`](https://github.com/NixOS/nixpkgs/commit/decfdc78c258e6336778c1636ed838e8f903748a) | `smenu: 0.9.17 -> 0.9.18`                                              | `2021-08-18 00:41:40Z` |
| [`8674bceb`](https://github.com/NixOS/nixpkgs/commit/8674bcebc438928f7807787a3b83d0ee07732b6a) | `sleuthkit: 4.10.2 -> 4.11.0`                                          | `2021-08-18 00:37:04Z` |
| [`ffb81836`](https://github.com/NixOS/nixpkgs/commit/ffb8183623c8a0a8fb5c003c3095408d5caa94cf) | `singularity: 3.8.0 -> 3.8.1`                                          | `2021-08-18 00:25:25Z` |
| [`616efcc7`](https://github.com/NixOS/nixpkgs/commit/616efcc7d5671e6a4e7333f99272c5309233e1ec) | `simdjson: 0.9.2 -> 0.9.7`                                             | `2021-08-18 00:11:51Z` |
| [`976a346a`](https://github.com/NixOS/nixpkgs/commit/976a346a398a0c2b02396eeab8068936af71ae1f) | `emacs.pkgs.ada-mode: add myself as maintainer`                        | `2021-08-18 00:00:44Z` |
| [`c33d5412`](https://github.com/NixOS/nixpkgs/commit/c33d5412c5db285ed4b58e65c98aa138a0db05a4) | `emacs.pkgs.urweb-mode: init at 20200209`                              | `2021-08-17 23:58:42Z` |
| [`06132441`](https://github.com/NixOS/nixpkgs/commit/06132441e7be4f863eb8c361a73f4307c3222e7d) | `golangci-lint: 1.41.1 -> 1.42.0`                                      | `2021-08-17 23:57:53Z` |
| [`df36e5cf`](https://github.com/NixOS/nixpkgs/commit/df36e5cf583f0a5d870a50b01d8c1980c44762b5) | `shutter: 0.97 -> 0.98`                                                | `2021-08-17 23:39:49Z` |
| [`40cdfffe`](https://github.com/NixOS/nixpkgs/commit/40cdfffeee784a26030e0c79fb451dd5d54a3d04) | `sequeler: 0.8.0 -> 0.8.2`                                             | `2021-08-17 23:16:43Z` |
| [`b6d9b4bd`](https://github.com/NixOS/nixpkgs/commit/b6d9b4bd22a3822910308cd18455de0cfcc26051) | `sdrangel: 6.8.0 -> 6.16.2`                                            | `2021-08-17 22:51:46Z` |
| [`4f330baa`](https://github.com/NixOS/nixpkgs/commit/4f330baab4b63ee5fdb9edfa4c07db12fdfaf245) | `sd-local: 1.0.31 -> 1.0.32`                                           | `2021-08-17 22:41:33Z` |
| [`0374a6c0`](https://github.com/NixOS/nixpkgs/commit/0374a6c0b07087e2afb10b35438439e912dbd2c7) | `scream: 3.7 -> 3.8`                                                   | `2021-08-17 22:30:46Z` |
| [`d636273a`](https://github.com/NixOS/nixpkgs/commit/d636273a4c1023b34b818422ae0e2d3b2fae39f1) | `maintainers/team-list: add iog`                                       | `2021-08-17 22:28:13Z` |
| [`919ee684`](https://github.com/NixOS/nixpkgs/commit/919ee684333ca6849cda2affa6a38a001c3d9363) | `usbutils: switch to pname + version`                                  | `2021-08-17 22:28:01Z` |
| [`303c7078`](https://github.com/NixOS/nixpkgs/commit/303c70783cdaa197db233c4b957256ef17f69216) | `gopls: 0.7.0 -> 0.7.1 (#134506)`                                      | `2021-08-17 22:27:54Z` |
| [`4826412f`](https://github.com/NixOS/nixpkgs/commit/4826412f318352b6c609b332390c6c0dc2c640ea) | `netcdf: 4.7.4 -> 4.8.0`                                               | `2021-08-17 22:11:43Z` |
| [`2dc3f91d`](https://github.com/NixOS/nixpkgs/commit/2dc3f91d062f5c56c7e010895767e6c8391ab3d0) | `sameboy: 0.14.2 -> 0.14.5`                                            | `2021-08-17 22:11:37Z` |
| [`7bec7538`](https://github.com/NixOS/nixpkgs/commit/7bec753807d1de28608e0274b0fb699910f74c75) | `s3ql: 3.7.2 -> 3.7.3`                                                 | `2021-08-17 22:03:17Z` |
| [`c7cf4945`](https://github.com/NixOS/nixpkgs/commit/c7cf494518899cd4c2cc4ebab7f9d9c563f47fa2) | `gpgme: fix failing patch downloads.`                                  | `2021-08-17 21:55:30Z` |
| [`c2269136`](https://github.com/NixOS/nixpkgs/commit/c2269136e7da34f33191365e18d97986710df216) | `sqlfluff: 0.6.2 -> 0.6.3`                                             | `2021-08-17 21:41:33Z` |
| [`aa82df08`](https://github.com/NixOS/nixpkgs/commit/aa82df08084084f0ad3f4a295154d9fae0c4797a) | `s2n-tls: 1.0.1 -> 1.0.16`                                             | `2021-08-17 21:08:49Z` |
| [`c11b48f7`](https://github.com/NixOS/nixpkgs/commit/c11b48f7cc623cbcb9c6fc841e725571fed7d8bc) | `rx: 0.4.0 -> 0.5.2`                                                   | `2021-08-17 21:04:11Z` |
| [`44eb5edf`](https://github.com/NixOS/nixpkgs/commit/44eb5edf0504be209f9fcb588b15422b8ddd823d) | `ruplacer: 0.4.1 -> 0.6.2`                                             | `2021-08-17 20:58:17Z` |
| [`b343c570`](https://github.com/NixOS/nixpkgs/commit/b343c57041a66598243cecc2c1909e7229b69fb8) | `rssguard: 3.9.1 -> 3.9.2`                                             | `2021-08-17 20:51:48Z` |
| [`d04492ed`](https://github.com/NixOS/nixpkgs/commit/d04492edf4964f99ffe216ff78f6c7cccf3c423c) | `whatsapp-for-linux: 1.1.5 -> 1.2.0`                                   | `2021-08-17 20:37:23Z` |
| [`6a1364e3`](https://github.com/NixOS/nixpkgs/commit/6a1364e37d590702138ac74b05467ceb7e3b7a8e) | `tracy: 0.7.7 -> 0.7.8`                                                | `2021-08-17 20:32:46Z` |
| [`56480130`](https://github.com/NixOS/nixpkgs/commit/5648013042a50bf01bfc0bc3cf5d7de619463a60) | `ugrep: 3.3 -> 3.3.7`                                                  | `2021-08-17 20:08:45Z` |
| [`5cf380c3`](https://github.com/NixOS/nixpkgs/commit/5cf380c34024590dda7bfb46b284b5bacd0d9d85) | `rlwrap: 0.45 -> 0.45.2`                                               | `2021-08-17 19:50:13Z` |
| [`3f394f5d`](https://github.com/NixOS/nixpkgs/commit/3f394f5d4b9712dccc9ae7d96b8697336189ca0b) | `vultr-cli: 2.4.1 -> 2.7.0`                                            | `2021-08-17 19:39:37Z` |
| [`90783821`](https://github.com/NixOS/nixpkgs/commit/90783821ed79ca9c488b1069074b4fa8ff55c6d3) | `resvg: 0.14.0 -> 0.15.0`                                              | `2021-08-17 19:36:42Z` |
| [`17a8902c`](https://github.com/NixOS/nixpkgs/commit/17a8902c2f2647332685f3d215cabf57065cb93f) | `ultimatestunts: 0.7.6.1 -> 0.7.7.1`                                   | `2021-08-17 19:28:13Z` |
| [`6018f8ef`](https://github.com/NixOS/nixpkgs/commit/6018f8ef212c58871384989ed71e7acbb4ac7351) | `trompeloeil: 40 -> 41`                                                | `2021-08-17 19:21:13Z` |
| [`39522c52`](https://github.com/NixOS/nixpkgs/commit/39522c52cced95891f41fba08659f2061546820a) | `urh: 2.9.1 -> 2.9.2`                                                  | `2021-08-17 18:58:49Z` |
| [`63706f6f`](https://github.com/NixOS/nixpkgs/commit/63706f6feec371aed1047ad738fcbb573e72cf0a) | `python3Packages.dash: 1.20.0 -> 1.21.0`                               | `2021-08-17 18:56:50Z` |
| [`d014662e`](https://github.com/NixOS/nixpkgs/commit/d014662e6b441c1d59669d6c8a1a58a40bf161f4) | `python3Packages.dash-table: 4.11.3 -> 4.12.0`                         | `2021-08-17 18:56:50Z` |
| [`cef0475f`](https://github.com/NixOS/nixpkgs/commit/cef0475f8d7deddf76f982fa441c0ddaa7ed5406) | `python3Packages.dash-html-components: 1.1.3 -> 1.1.4`                 | `2021-08-17 18:56:50Z` |
| [`04c94cc5`](https://github.com/NixOS/nixpkgs/commit/04c94cc5444ff223fc84ba9827fec4c1fe000326) | `python3Packages.dash-core-components: 1.16.0 -> 1.17.1`               | `2021-08-17 18:56:50Z` |
| [`09bbf793`](https://github.com/NixOS/nixpkgs/commit/09bbf7937e65c5e752358559fb42a62391c0de82) | `visualvm: 2.0.7 -> 2.1`                                               | `2021-08-17 18:53:51Z` |
| [`e886ecd4`](https://github.com/NixOS/nixpkgs/commit/e886ecd41646f9ad242f9c960d257f2940d6523e) | `uptimed: 0.4.3 -> 0.4.4`                                              | `2021-08-17 18:49:02Z` |
| [`76b99c11`](https://github.com/NixOS/nixpkgs/commit/76b99c11bc5aac47e37a1dc6ba9ed0507a706e05) | `reproc: 14.2.2 -> 14.2.3`                                             | `2021-08-17 18:45:16Z` |
| [`7db99613`](https://github.com/NixOS/nixpkgs/commit/7db99613d983359578f40d82b8e9aff7e2e256ab) | `renderizer: 2.0.12 -> 2.0.13`                                         | `2021-08-17 18:40:15Z` |
| [`3c8bfff9`](https://github.com/NixOS/nixpkgs/commit/3c8bfff92c29713c471ca77e384e99b4202b8380) | `rednotebook: 2.21 -> 2.22`                                            | `2021-08-17 18:24:17Z` |
| [`bd5bf1d6`](https://github.com/NixOS/nixpkgs/commit/bd5bf1d6e1fdb2541ca1cbf4bc6ff84f22659f62) | `recode: 3.7.8 -> 3.7.9`                                               | `2021-08-17 18:16:58Z` |
| [`d8be0ee3`](https://github.com/NixOS/nixpkgs/commit/d8be0ee34f56d8b01c776bc756603558d963b166) | `libreddit: 0.14.9 -> 0.14.14`                                         | `2021-08-17 18:11:03Z` |
| [`42641652`](https://github.com/NixOS/nixpkgs/commit/42641652b605bcb9c15e6929dfd8329823bfa825) | `flyctl: 0.0.231 -> 0.0.232`                                           | `2021-08-17 18:10:59Z` |
| [`e702ca2d`](https://github.com/NixOS/nixpkgs/commit/e702ca2de5faae6c06d992035967f8f6fea8964b) | `react-native-debugger: 0.11.7 -> 0.12.1`                              | `2021-08-17 18:10:36Z` |
| [`efd0d98c`](https://github.com/NixOS/nixpkgs/commit/efd0d98cd72d9052a82c66eea317c28d9c66c8bf) | `jackett: 0.18.537 -> 0.18.545`                                        | `2021-08-17 18:09:16Z` |
| [`a02cbb51`](https://github.com/NixOS/nixpkgs/commit/a02cbb5162c82aea904c33c84ae7d253d0efc6d5) | `python38Packages.django-jinja: 2.8.0 -> 2.9.0`                        | `2021-08-17 18:08:34Z` |
| [`523a68ee`](https://github.com/NixOS/nixpkgs/commit/523a68ee89222b96f01f230f5f0d336fbad446d6) | `python38Packages.gspread: 3.7.0 -> 4.0.1`                             | `2021-08-17 18:03:12Z` |
| [`f840a155`](https://github.com/NixOS/nixpkgs/commit/f840a1559ed03dab1539ac8841257fde8292b9fa) | `nats-server: 2.2.1 -> 2.3.4`                                          | `2021-08-17 18:01:08Z` |
| [`5f799659`](https://github.com/NixOS/nixpkgs/commit/5f7996595882262cd741547d594620439b4af821) | `mubeng: 0.4.5 -> 0.5.2`                                               | `2021-08-17 18:00:22Z` |
| [`87f4f2f1`](https://github.com/NixOS/nixpkgs/commit/87f4f2f1032d3f6fee2fd00d95c24052a661ee08) | `namecoin: nc0.20.1 -> nc0.21.1`                                       | `2021-08-17 18:00:06Z` |
| [`0b137d54`](https://github.com/NixOS/nixpkgs/commit/0b137d54707b2a0ebac067e9e3362f6743c5eb3d) | `multus-cni: 3.7.1 -> 3.7.2`                                           | `2021-08-17 17:59:33Z` |
| [`1a9b9970`](https://github.com/NixOS/nixpkgs/commit/1a9b997088ca4785329b34c2ed9dc4ae57d44b1a) | `mpdevil: 1.1.1 -> 1.3.0`                                              | `2021-08-17 17:57:57Z` |
| [`71768829`](https://github.com/NixOS/nixpkgs/commit/717688295b205467aa3e5797c626c73285c194f6) | `mxt-app: 1.32 -> 1.33`                                                | `2021-08-17 17:57:49Z` |
| [`3d639aec`](https://github.com/NixOS/nixpkgs/commit/3d639aec264891e618fcec304b8a8a2d8ce75991) | `pdal: 2.2.0 -> 2.3.0`                                                 | `2021-08-17 17:56:57Z` |
| [`4f81a22f`](https://github.com/NixOS/nixpkgs/commit/4f81a22f45437d7827497763821d89392e6a0c72) | `cloudcompare: Allow building with `pdal` 2.3.0`                       | `2021-08-17 17:56:57Z` |
| [`94d15b60`](https://github.com/NixOS/nixpkgs/commit/94d15b60723477f3d70646ecc5a7a3aa8adfb60d) | `nats-streaming-server: 0.21.1 -> 0.22.1`                              | `2021-08-17 17:56:20Z` |
| [`67219e4b`](https://github.com/NixOS/nixpkgs/commit/67219e4bb020e6cd674c9ee3def96e063b2f9bf7) | `nfpm: 2.3.1 -> 2.6.0`                                                 | `2021-08-17 17:54:12Z` |
| [`c5422e77`](https://github.com/NixOS/nixpkgs/commit/c5422e77efadd050e0e5566fc8862e344adc77b8) | `nfdump: 1.6.22 -> 1.6.23`                                             | `2021-08-17 17:54:02Z` |
| [`ba19c898`](https://github.com/NixOS/nixpkgs/commit/ba19c8982c70645cf458a7578ef07a1b4ff75c3a) | `rabbitmq-server: Add myself as maintainer`                            | `2021-08-17 17:53:16Z` |
| [`e3da6fac`](https://github.com/NixOS/nixpkgs/commit/e3da6faca4a3a11a92e3d7c0535c8ae6a4f6f3d6) | `python38Packages.hvac: 0.10.14 -> 0.11.0`                             | `2021-08-17 17:52:46Z` |
| [`660b4ef9`](https://github.com/NixOS/nixpkgs/commit/660b4ef9b4b759a03de9033423dacfff4b2d6731) | `python3Packages.binwalk: 2.3.1 -> 2.3.2`                              | `2021-08-17 17:51:29Z` |
| [`d327f21b`](https://github.com/NixOS/nixpkgs/commit/d327f21b1e77cf6c4111f6c14ecd7620a896cfc5) | `minijail: enableParallelBuilding`                                     | `2021-08-17 17:42:41Z` |
| [`a9e551a6`](https://github.com/NixOS/nixpkgs/commit/a9e551a6f808a4c64ae1eaf5697ed9646825d100) | `opensm: 3.3.23 -> 3.3.24`                                             | `2021-08-17 17:41:56Z` |
| [`643f3985`](https://github.com/NixOS/nixpkgs/commit/643f3985cfeaddca6189d5284f2704490e51d912) | `nuraft: 1.2.0 -> 1.3.0`                                               | `2021-08-17 17:41:53Z` |
| [`5bc28eea`](https://github.com/NixOS/nixpkgs/commit/5bc28eea131531212f08ae251ae88a6811a789ba) | `openapi-generator-cli: 5.1.0 -> 5.2.0`                                | `2021-08-17 17:39:55Z` |
| [`4cc8b0c6`](https://github.com/NixOS/nixpkgs/commit/4cc8b0c6f6aeb9619da2c63dc888f4c967c512e0) | `minijail: 16 -> 17`                                                   | `2021-08-17 17:39:06Z` |
| [`f1a43921`](https://github.com/NixOS/nixpkgs/commit/f1a4392196153042e918daae55498afd978772bd) | `openimagedenoise: 1.4.0 -> 1.4.1`                                     | `2021-08-17 17:38:58Z` |
| [`ee198625`](https://github.com/NixOS/nixpkgs/commit/ee1986256792528be2c55ff440945916c5ff34b7) | `nvtop: 1.1.0 -> 1.2.2`                                                | `2021-08-17 17:38:02Z` |
| [`d9543806`](https://github.com/NixOS/nixpkgs/commit/d9543806d6eeff70d983c27af8391658421d3db1) | `operator-sdk: 1.10.0 -> 1.11.0`                                       | `2021-08-17 17:35:53Z` |
| [`d1355cb7`](https://github.com/NixOS/nixpkgs/commit/d1355cb7bebfcc92c903037d8f2fd86dafb0d67f) | `orcania: 2.2.0 -> 2.2.1`                                              | `2021-08-17 17:34:07Z` |
| [`73b3e147`](https://github.com/NixOS/nixpkgs/commit/73b3e147ea0b5fcbdc3ccda6d50c35634a132d56) | `openhantek6022: 3.2.3 -> 3.2.4`                                       | `2021-08-17 17:33:56Z` |
| [`c9fc7516`](https://github.com/NixOS/nixpkgs/commit/c9fc751673898ee095d2c873c136e1a5505d5551) | `nixos/navidrome: init module and test`                                | `2021-08-17 17:32:25Z` |
| [`5dd7c7a0`](https://github.com/NixOS/nixpkgs/commit/5dd7c7a079e0b0c9799c5275714de5699fb0ffc3) | `monotone: fix key encryption`                                         | `2021-08-17 17:27:34Z` |
| [`10d15c07`](https://github.com/NixOS/nixpkgs/commit/10d15c0775a4367a3663f1bc9b74f5fd90bd0104) | `helmfile: fix wrong sha256 of sources`                                | `2021-08-17 17:23:27Z` |
| [`ee73c398`](https://github.com/NixOS/nixpkgs/commit/ee73c398d987822a7458858e67a684bd6e60aa66) | `rdkafka: 1.6.1 -> 1.7.0`                                              | `2021-08-17 17:08:42Z` |
| [`6ca6cc20`](https://github.com/NixOS/nixpkgs/commit/6ca6cc20447e2094bd8e5427e28eb3ccbf418d2c) | `rabbitmq-server: 3.9.1 -> 3.9.3`                                      | `2021-08-17 16:58:55Z` |
| [`d51d1bfa`](https://github.com/NixOS/nixpkgs/commit/d51d1bfa26fe40a3649ee82f074b75f96eaf43b4) | `python3Packages.solax: 0.2.7 -> 0.2.8`                                | `2021-08-17 16:50:25Z` |
| [`925fc9c7`](https://github.com/NixOS/nixpkgs/commit/925fc9c700b112ce2c77d53d013adef147d30a63) | `uclibc: 1.0.37 -> 1.0.38`                                             | `2021-08-17 16:41:55Z` |
| [`e5b2a40a`](https://github.com/NixOS/nixpkgs/commit/e5b2a40a7609f687c9b84dcd8c083d8f4202d4a3) | `usbutils: 013 -> 014`                                                 | `2021-08-17 16:25:26Z` |
| [`12ff4b79`](https://github.com/NixOS/nixpkgs/commit/12ff4b79e48d9c4aa5660d2ec7ce52a21806d8e4) | `discourse: update.py: Remove native platforms in plugin lock files..` | `2021-08-17 16:21:27Z` |
| [`04e6b03f`](https://github.com/NixOS/nixpkgs/commit/04e6b03fa91603c7f1961cfcdcf5880c91fe6b05) | `discourse.mkDiscoursePlugin: Handle repos with `gems` directories`    | `2021-08-17 16:21:21Z` |
| [`f8096460`](https://github.com/NixOS/nixpkgs/commit/f8096460bd15d4f13a01cfddf0a30798921fdb42) | `discourse.plugins: Make the updater able to package plugins`          | `2021-08-17 16:21:15Z` |
| [`4197b6dd`](https://github.com/NixOS/nixpkgs/commit/4197b6dd146c395f1caec3b086334a2b0eff623a) | `discourse.plugins.discourse-github: Update`                           | `2021-08-17 16:21:10Z` |
| [`443b318e`](https://github.com/NixOS/nixpkgs/commit/443b318ee9c614d480a2ecb0120b52806d6fbb3b) | `discourse: Change the path to the auto generated plugin assets`       | `2021-08-17 16:21:03Z` |
| [`6fd5a40c`](https://github.com/NixOS/nixpkgs/commit/6fd5a40ccaf0b4da1362803a387bf46d381dd66a) | `discourse.tests: Test the appropriate discourse package`              | `2021-08-17 16:20:55Z` |
| [`ac532514`](https://github.com/NixOS/nixpkgs/commit/ac532514c580d7e84f7678c6acf944698948aa5b) | `qogir-theme: 2021-06-25 -> 2021-08-02`                                | `2021-08-17 16:18:17Z` |
| [`bb14315d`](https://github.com/NixOS/nixpkgs/commit/bb14315d51a1c35304dfd82ff5c1faeaaf2c450c) | `discourse: Remove leftover link to unused plugins directory`          | `2021-08-17 16:17:56Z` |
| [`6f265273`](https://github.com/NixOS/nixpkgs/commit/6f2652735817e22c55de3b6e137faf7cdbc3fd2a) | `discourse.plugins.discourse-data-explorer: Update`                    | `2021-08-17 16:17:50Z` |