### PR TITLE
feat(niv): update home-manager

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a5c609b4b1cd4e1381ac8ea1b7d5b0792ebde0a3",
-        "sha256": "0q8iq96sfrr8vxw36208bx2nbqx3r0i9s5hh75dxd5psc6p84vl4",
+        "rev": "bf6b85136b47ab1a76df4a90ea4850871147494a",
+        "sha256": "11ssh8w6cy9mh233sc8a3sw4fkkj1z9fkqfsiljc404kb7p4jrhl",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/a5c609b4b1cd4e1381ac8ea1b7d5b0792ebde0a3.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/bf6b85136b47ab1a76df4a90ea4850871147494a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixos-hardware": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                       | Timestamp              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- | ---------------------- |
| [`bf6b8513`](https://github.com/nix-community/home-manager/commit/bf6b85136b47ab1a76df4a90ea4850871147494a) | `neomutt: Allow named mailboxes (#2212)`             | `2021-08-19 04:33:53Z` |
| [`1a6df903`](https://github.com/nix-community/home-manager/commit/1a6df903e320eb848c02a343141a11afefe4a73f) | `home-manager: add command line argument `--impure`` | `2021-08-18 22:07:49Z` |
| [`49a03303`](https://github.com/nix-community/home-manager/commit/49a03303e120e06935151801cbfd70a209cf5371) | `fish: provide different examples`                   | `2021-08-18 21:51:33Z` |