### PR TITLE
feat(niv): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bf8c2f2e8c6b94f480a539851b1b2cf6e8770282",
-        "sha256": "0bx5kx2hn9xx1lb92lyg45k2x822k02sdrqjfgcf3xmi5bl8a4xn",
+        "rev": "7c38b03f742a657bf38e9579adeb608fc7cc5f1a",
+        "sha256": "060c7fhzhjzc06r8i3hm0dihcdxw3vl6sr5a6xl7mfwcpcpahnlq",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/bf8c2f2e8c6b94f480a539851b1b2cf6e8770282.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/7c38b03f742a657bf38e9579adeb608fc7cc5f1a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                       | Timestamp              |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- | ---------------------- |
| [`bbc3fbf6`](https://github.com/NixOS/nixpkgs/commit/bbc3fbf67cdd49f91002cff05d4ce31fdd57662b) | `python38Packages.webdavclient3: 3.14.5 -> 3.14.6`                   | `2021-08-18 20:18:00Z` |
| [`560a55a7`](https://github.com/NixOS/nixpkgs/commit/560a55a735b418b685882291a1312d6a26521103) | `python38Packages.jellyfish: 0.8.2 -> 0.8.8`                         | `2021-08-18 20:14:20Z` |
| [`cd94f4b2`](https://github.com/NixOS/nixpkgs/commit/cd94f4b26b49a75f0c26b28781f1dd694529dccf) | `python38Packages.micawber: 0.5.3 -> 0.5.4`                          | `2021-08-18 20:14:12Z` |
| [`893473a3`](https://github.com/NixOS/nixpkgs/commit/893473a3180ca3bf6d22d7fca3922fcf43e059e7) | `python3Packages.ujson: enable tests`                                | `2021-08-18 20:11:35Z` |
| [`7fc097da`](https://github.com/NixOS/nixpkgs/commit/7fc097dab8cd34b92eb3b7bcec39032793b42fe7) | `python3Packages.ujson: 4.0.2 -> 4.1.0`                              | `2021-08-18 20:11:35Z` |
| [`6e6c8b73`](https://github.com/NixOS/nixpkgs/commit/6e6c8b733815d809cba84421bb88647f37bf8cb6) | `s6-rc: fix cross builds that run s6-rc-compile`                     | `2021-08-18 20:09:19Z` |
| [`385b85ef`](https://github.com/NixOS/nixpkgs/commit/385b85ef36aaa49b039226dbfd4a6d41f6e52c8f) | `anytype: init at 0.18.59`                                           | `2021-08-18 19:39:15Z` |
| [`9f85f920`](https://github.com/NixOS/nixpkgs/commit/9f85f9201aa1fef33e016ab16613de6177a59fee) | `pythonPackages3.openapi-core: add missing mock dependency`          | `2021-08-18 18:54:20Z` |
| [`2f9cbba2`](https://github.com/NixOS/nixpkgs/commit/2f9cbba25140bc666f000e15fbf54890f56553c8) | `python3Packages.versioneer: add pythonImportsCheck`                 | `2021-08-18 18:53:40Z` |
| [`656343a7`](https://github.com/NixOS/nixpkgs/commit/656343a753b24764b759bc5d8b9aca5260831a1d) | `python3Packages.versioneer: 0.19 -> 0.20`                           | `2021-08-18 18:44:14Z` |
| [`9fc4bf50`](https://github.com/NixOS/nixpkgs/commit/9fc4bf504c8d050a0318b36a9172650e9c089cfb) | `python38Packages.pyscreenshot: 2.3 -> 3.0`                          | `2021-08-18 18:16:19Z` |
| [`755bda42`](https://github.com/NixOS/nixpkgs/commit/755bda423078d589da61fefea33a55a13a04db71) | `python38Packages.pyro-ppl: 1.6.0 -> 1.7.0`                          | `2021-08-18 18:11:55Z` |
| [`1f099b87`](https://github.com/NixOS/nixpkgs/commit/1f099b87f9530bcaf7847b20a8f609359a2fdef0) | `s6-rc: broaden platforms`                                           | `2021-08-18 17:33:31Z` |
| [`4a2482b3`](https://github.com/NixOS/nixpkgs/commit/4a2482b353e25625eddc282563a4c513f04d3139) | `python38Packages.pygit2: 1.6.0 -> 1.6.1`                            | `2021-08-18 17:16:06Z` |
| [`c93e3187`](https://github.com/NixOS/nixpkgs/commit/c93e3187472ed5ece810aa7a6fd277b3e7457857) | `moodle: update to 3.11.2`                                           | `2021-08-18 17:12:43Z` |
| [`cc927c65`](https://github.com/NixOS/nixpkgs/commit/cc927c650b5e3db9ca3edf1a1d91f4d6eeaa8e1b) | `nixos/moodle: revert to php74 for xmlrpc extension`                 | `2021-08-18 17:05:48Z` |
| [`aa045621`](https://github.com/NixOS/nixpkgs/commit/aa045621af26840816c7760f0e0f3d41e91dfaa8) | `python38Packages.ipyvuetify: 1.7.0 -> 1.8.1`                        | `2021-08-18 15:32:33Z` |
| [`e05fd1a5`](https://github.com/NixOS/nixpkgs/commit/e05fd1a5e1e628a0658ad02ae213ec1fe6e6a81b) | `python38Packages.hvplot: 0.7.2 -> 0.7.3`                            | `2021-08-18 14:38:51Z` |
| [`d9a8be0a`](https://github.com/NixOS/nixpkgs/commit/d9a8be0ac65f9591d1d8329a5c3f2ff338fab87b) | `python3Packages.pyfronius: 0.5.3 -> 0.6.0`                          | `2021-08-18 14:36:28Z` |
| [`4f885fe5`](https://github.com/NixOS/nixpkgs/commit/4f885fe507f7eaa892e64726236b27e59fc3f311) | `python38Packages.icecream: 2.1.0 -> 2.1.1`                          | `2021-08-18 14:36:18Z` |
| [`393d3ddd`](https://github.com/NixOS/nixpkgs/commit/393d3ddd3906806cb50d7b5c7e33077a0270719d) | `python38Packages.dpkt: 1.9.6 -> 1.9.7.1`                            | `2021-08-18 14:34:03Z` |
| [`99415722`](https://github.com/NixOS/nixpkgs/commit/994157221a8478c644c3f6ab82b062f4009340e0) | `python38Packages.geoalchemy2: 0.9.0 -> 0.9.3`                       | `2021-08-18 14:33:39Z` |
| [`5e888a4e`](https://github.com/NixOS/nixpkgs/commit/5e888a4e5775dc6e079074467ba76fc46d0ed082) | `python38Packages.django-ipware: 3.0.2 -> 3.0.7`                     | `2021-08-18 14:31:16Z` |
| [`6a06592f`](https://github.com/NixOS/nixpkgs/commit/6a06592f72702a50f8bb92e7fa946a7f4e634077) | `hottext: 1.3 -> 1.4`                                                | `2021-08-18 14:03:45Z` |
| [`d0326532`](https://github.com/NixOS/nixpkgs/commit/d0326532abb29955772e7fe03a104bf47ff82e25) | `stern: 1.19.0 -> 1.20.0`                                            | `2021-08-18 01:56:42Z` |
| [`2354e7fd`](https://github.com/NixOS/nixpkgs/commit/2354e7fd993635c38313d269be3c079223bf00ed) | `sentencepiece: 0.1.95 -> 0.1.96`                                    | `2021-08-17 23:05:33Z` |
| [`4a342e3f`](https://github.com/NixOS/nixpkgs/commit/4a342e3f5713d0b4b1dd2f4e113bcfe40077242f) | `qrcodegen: 1.6.0 -> 1.7.0`                                          | `2021-08-17 16:35:15Z` |
| [`3e81d05b`](https://github.com/NixOS/nixpkgs/commit/3e81d05bbb74ec9b065a29b6ae615302214de971) | `osu-lazer: 2021.720.0 -> 2021.815.0`                                | `2021-08-17 10:50:34Z` |
| [`c05fbdb0`](https://github.com/NixOS/nixpkgs/commit/c05fbdb06848718be97fe92b3ba7cca0c293f744) | `libffi: disable new static trampolines feature`                     | `2021-08-13 21:23:09Z` |
| [`f5db95a9`](https://github.com/NixOS/nixpkgs/commit/f5db95a96aef57c945d4741c2134104da1026b7d) | `mesa: 21.1.6 -> 21.1.7`                                             | `2021-08-13 09:15:59Z` |
| [`d7b8d5e1`](https://github.com/NixOS/nixpkgs/commit/d7b8d5e15a5740892193dc956f5916a1ccbbf255) | `Revert "automake: 1.16.3 -> 1.16.4"`                                | `2021-08-11 21:15:49Z` |
| [`e591a623`](https://github.com/NixOS/nixpkgs/commit/e591a6235d95318ad67c03d666dc8788c65025fc) | `cairo: add patch for CVE-2020-35492 (PR: #131949)`                  | `2021-07-31 13:44:32Z` |
| [`bd57a30d`](https://github.com/NixOS/nixpkgs/commit/bd57a30d1ba907783e73fe1d887bf62b8a7c1760) | `Revert "cmake: 3.19.7 -> 3.21.0"`                                   | `2021-07-30 08:21:40Z` |
| [`d5fde7fe`](https://github.com/NixOS/nixpkgs/commit/d5fde7feb6a9f9eec920d2926d6acc5587225fb5) | `lvm2: Remove dependency on thin-provisioning-tools`                 | `2021-07-29 08:57:40Z` |
| [`af1211eb`](https://github.com/NixOS/nixpkgs/commit/af1211ebc2d0ace416412c1aca5ba9ef030ba866) | `p11-kit: 0.23.22 -> 0.24.0`                                         | `2021-07-29 08:55:30Z` |
| [`364bb239`](https://github.com/NixOS/nixpkgs/commit/364bb239ab417d7b06556812643e265fc5fe81fa) | `mesa: 21.1.5 -> 21.1.6`                                             | `2021-07-29 08:54:36Z` |
| [`380301fe`](https://github.com/NixOS/nixpkgs/commit/380301fe4ae8d038ad5177e6346d29d7c387cd38) | `gtest: 1.10.0 -> 1.11.0`                                            | `2021-07-29 08:53:12Z` |
| [`29bbaa14`](https://github.com/NixOS/nixpkgs/commit/29bbaa1489e3e3ca79ae8a27f13316e399a0a564) | `cmake: 3.19.7 -> 3.21.0`                                            | `2021-07-29 08:52:18Z` |
| [`ea0b0b7d`](https://github.com/NixOS/nixpkgs/commit/ea0b0b7d1261929faeecd68da1cfa6fb4cd81702) | `libidn: 1.37 -> 1.38`                                               | `2021-07-29 08:51:54Z` |
| [`d4aeb963`](https://github.com/NixOS/nixpkgs/commit/d4aeb9634a64be5979422c9add366fc648d04f83) | `libffi: 3.3 -> 3.4.2`                                               | `2021-07-29 08:50:44Z` |
| [`caf6816d`](https://github.com/NixOS/nixpkgs/commit/caf6816da79bfa18ee50776c755ec57404aa54a6) | `aspell: fix buffer overflow in objstack`                            | `2021-07-29 08:50:09Z` |
| [`46306d29`](https://github.com/NixOS/nixpkgs/commit/46306d2971bae52201aa8acb8ad694ee1ce523e4) | `automake: 1.16.3 -> 1.16.4`                                         | `2021-07-29 08:49:24Z` |
| [`69762341`](https://github.com/NixOS/nixpkgs/commit/69762341e4a233beaadb12e0962585ecf8446c3f) | `gnupatch: replace name with pname&version`                          | `2021-07-29 08:48:34Z` |
| [`b2a9951e`](https://github.com/NixOS/nixpkgs/commit/b2a9951e485cc41a8a440397b807eb08a84d0f18) | `networkmanager: 1.32.4 -> 1.32.6`                                   | `2021-07-29 08:47:26Z` |
| [`f97fb96e`](https://github.com/NixOS/nixpkgs/commit/f97fb96ea06132a8a5be528d2151216c8de772e4) | `python3Packages.scipy: fix build on aarch64-darwin`                 | `2021-07-29 08:46:58Z` |
| [`9857ee54`](https://github.com/NixOS/nixpkgs/commit/9857ee54713d950a7d863518a3061dfb3230e994) | `gawk: replace name with pname&version`                              | `2021-07-27 21:02:17Z` |
| [`0901dfb2`](https://github.com/NixOS/nixpkgs/commit/0901dfb214d23c485f85a58f450d5d83409ffc61) | `stdenv/setup: force libtool to skip dep checks`                     | `2021-07-27 20:42:31Z` |
| [`051fcdbe`](https://github.com/NixOS/nixpkgs/commit/051fcdbe8b4070f4e6796cb5c27b0cc4456d2863) | `tools/{security/system}: replace name with pname&version`           | `2021-07-27 15:54:21Z` |
| [`3095193e`](https://github.com/NixOS/nixpkgs/commit/3095193e7e03202bb3330bd3624af9d661077eae) | `qtbase: format, cleanup, remove darwin from inputs`                 | `2021-07-27 13:17:41Z` |
| [`6042dd28`](https://github.com/NixOS/nixpkgs/commit/6042dd28cfba1dc948b5d601052c8ecd1584cd91) | `libgpgerror: fix cross-compilation`                                 | `2021-07-27 10:02:37Z` |
| [`f3861727`](https://github.com/NixOS/nixpkgs/commit/f3861727159d7a05ba46aa346f101389463f41e9) | `at-spi2-core: 2.40.2 -> 2.40.3`                                     | `2021-07-26 01:36:12Z` |
| [`2a21f96a`](https://github.com/NixOS/nixpkgs/commit/2a21f96a6d4b67c2efbcc88f6d115de30d0202a6) | `exodus: 21.1.29 -> 21.5.25`                                         | `2021-07-25 08:32:12Z` |
| [`83968375`](https://github.com/NixOS/nixpkgs/commit/8396837579e46a4342e82cf21ded097cefda3ee9) | `faustPhysicalModeling: 2.20.2 -> 2.30.5`                            | `2021-07-25 08:31:24Z` |
| [`135fa1bc`](https://github.com/NixOS/nixpkgs/commit/135fa1bce1bcfe44a565bf51b74a6ac89d9f4238) | `bctoolbox: 4.5.20 -> 5.0.0`                                         | `2021-07-25 08:28:43Z` |
| [`8dfa2b2e`](https://github.com/NixOS/nixpkgs/commit/8dfa2b2ef165901ca8da8bbacb16ac15320a6675) | `pythonPackages.python-dateutil: 2.8.1 -> 2.8.2`                     | `2021-07-25 08:22:50Z` |
| [`ebc065c7`](https://github.com/NixOS/nixpkgs/commit/ebc065c77b3f24ad8cfbbc2288253c75434d4967) | `gdu: 5.3.0 -> 5.4.0`                                                | `2021-07-24 18:23:58Z` |
| [`8726184b`](https://github.com/NixOS/nixpkgs/commit/8726184b8a793ab45b22b6afeb98742acb0b35d1) | `libedit: 20210522-3.1 -> 20210714-3.1`                              | `2021-07-24 13:10:42Z` |
| [`cebd3e95`](https://github.com/NixOS/nixpkgs/commit/cebd3e9576589df1b7ea8daf293947471257a7b6) | `libidn2: 2.3.1 -> 2.3.2`                                            | `2021-07-24 13:00:24Z` |
| [`ce14ca10`](https://github.com/NixOS/nixpkgs/commit/ce14ca10a66aef508dce88c2806e7ac0d00a9ebd) | `qt5: use xcbuild on darwin, cleanup`                                | `2021-07-22 19:59:02Z` |
| [`afb3563b`](https://github.com/NixOS/nixpkgs/commit/afb3563bdcdd0654ebcabd2046b0c82ef19a2783) | `qt5: don't use dontUseXcbuild in qtwebengine`                       | `2021-07-22 19:59:02Z` |
| [`ccd81415`](https://github.com/NixOS/nixpkgs/commit/ccd81415321f84f67c145b11bd8848aaf5ba6df5) | `gpxsee: 9.2 -> 9.3`                                                 | `2021-07-20 23:38:42Z` |
| [`1207e758`](https://github.com/NixOS/nixpkgs/commit/1207e7581f7bb863d0789c980930464d92d221cb) | `kernel: enable MOUSE_PS2_VMMOUSE`                                   | `2021-07-20 19:41:36Z` |
| [`615f760a`](https://github.com/NixOS/nixpkgs/commit/615f760af5c1e2def83b14b8be19de93eb897cab) | `git-chglog: 0.14.2 -> 0.15.0`                                       | `2021-07-09 19:57:04Z` |
| [`6edbb14e`](https://github.com/NixOS/nixpkgs/commit/6edbb14e811f09063beea8fd4e2fb8e32457f5bc) | `unbound: remove references to compile-time dependencies in outputs` | `2021-06-01 23:56:46Z` |