### PR TITLE
feat(niv): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7c38b03f742a657bf38e9579adeb608fc7cc5f1a",
-        "sha256": "060c7fhzhjzc06r8i3hm0dihcdxw3vl6sr5a6xl7mfwcpcpahnlq",
+        "rev": "5edf5b60c3d8f82b5fc5e73e822b6f7460584945",
+        "sha256": "0gbb07mhbn9m8askxsy87h9737sr45qhnrjhkkix3jl136my2ppz",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/7c38b03f742a657bf38e9579adeb608fc7cc5f1a.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5edf5b60c3d8f82b5fc5e73e822b6f7460584945.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                    | Timestamp              |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | ---------------------- |
| [`9820600c`](https://github.com/NixOS/nixpkgs/commit/9820600cdc148aa5d966b667accb3df32d523161) | `Revert "python38Packages.pytest-mpl: 0.12 -> 0.13"`                              | `2021-08-19 23:01:38Z` |
| [`05cf40db`](https://github.com/NixOS/nixpkgs/commit/05cf40db67c92fcded1a8faa7a6786476c6e8d97) | `poetry2nix: 1.17.1 -> 1.19.0`                                                    | `2021-08-19 22:49:52Z` |
| [`06d67bb2`](https://github.com/NixOS/nixpkgs/commit/06d67bb2c65f136d20aea6b9675ba754463fe481) | `squid: 4.15 -> 4.16`                                                             | `2021-08-19 19:55:55Z` |
| [`f2805860`](https://github.com/NixOS/nixpkgs/commit/f280586090efb7fa3c1913869d4d096fdeca781b) | `swaybg: support cross-compilation`                                               | `2021-08-19 19:53:35Z` |
| [`707f01f5`](https://github.com/NixOS/nixpkgs/commit/707f01f51f161573efe61e567e39a76c7b72da8e) | `vimPlugins: update`                                                              | `2021-08-19 19:13:44Z` |
| [`92160177`](https://github.com/NixOS/nixpkgs/commit/92160177a5128a532b41d3560b03d63799674a1a) | `vimPlugins.gruvbox-nvim: fix owner`                                              | `2021-08-19 19:13:00Z` |
| [`6bd94ff7`](https://github.com/NixOS/nixpkgs/commit/6bd94ff7b8aafe36574883a5055f8387410d61e2) | `vimPlugins.glow-nvim: fix owner`                                                 | `2021-08-19 19:12:35Z` |
| [`98f344f0`](https://github.com/NixOS/nixpkgs/commit/98f344f0da6fd9fab5dda98bb0269af8f2b61f7f) | `onlykey-cli: update 1.2.2 -> 1.2.5`                                              | `2021-08-19 19:02:38Z` |
| [`d136766c`](https://github.com/NixOS/nixpkgs/commit/d136766caa50ddca210491230884365bf485457a) | `python3Packages.onlykey-solo-python: init at 0.0.28`                             | `2021-08-19 19:00:41Z` |
| [`e46317b5`](https://github.com/NixOS/nixpkgs/commit/e46317b5f2bc2c9233903f6ec91b780ee53422e6) | `esphome: 1.20.4 -> 2021.8.0`                                                     | `2021-08-19 18:31:07Z` |
| [`c1437121`](https://github.com/NixOS/nixpkgs/commit/c1437121aa58952da0322f508f990056e76a8fae) | `python38Packages.sacn: 1.7.0 -> 1.8.1`                                           | `2021-08-19 18:29:36Z` |
| [`dafefaad`](https://github.com/NixOS/nixpkgs/commit/dafefaad16e72141beba1c7e9ba9d11b8d619e89) | `python38Packages.pysaml2: 6.5.2 -> 7.0.1`                                        | `2021-08-19 17:34:52Z` |
| [`c2bc610d`](https://github.com/NixOS/nixpkgs/commit/c2bc610de00817761a6c7cc85270a9a9f217b847) | `closurecompiler: 20200719 -> 20210808`                                           | `2021-08-19 17:33:13Z` |
| [`b3dcb191`](https://github.com/NixOS/nixpkgs/commit/b3dcb1918449143930d49f0c35186e51b29c1077) | `qt5.qtserialbus: 5.15 (#134711)`                                                 | `2021-08-19 17:31:05Z` |
| [`eab59e25`](https://github.com/NixOS/nixpkgs/commit/eab59e25335ca84670eac573d659208fdeb126bc) | `python38Packages.quantities: 0.12.4 -> 0.12.5`                                   | `2021-08-19 17:25:57Z` |
| [`6c6f1144`](https://github.com/NixOS/nixpkgs/commit/6c6f114460a7a6a9fb6145c2f8f15364ad1a2d84) | `python38Packages.pynamodb: 5.0.3 -> 5.1.0`                                       | `2021-08-19 17:17:20Z` |
| [`b0d19a07`](https://github.com/NixOS/nixpkgs/commit/b0d19a0777aaf46941abacd17a6309946d8df3e0) | `python38Packages.pdf2image: 1.15.1 -> 1.16.0`                                    | `2021-08-19 17:15:16Z` |
| [`63b8b522`](https://github.com/NixOS/nixpkgs/commit/63b8b5227f3ee6033b28a37a5abd78f99ba467ea) | `python38Packages.py3status: 3.37 -> 3.38`                                        | `2021-08-19 17:13:08Z` |
| [`b3c1aa69`](https://github.com/NixOS/nixpkgs/commit/b3c1aa694849d9cf22d79517c7ce8556d66e8f86) | `python38Packages.ptpython: 3.0.17 -> 3.0.19`                                     | `2021-08-19 17:12:55Z` |
| [`560703eb`](https://github.com/NixOS/nixpkgs/commit/560703eb03af407647ffac0befe366d94e60844e) | `vimPlugins.tagalong-vim: init at 2021-06-28 (#134586)`                           | `2021-08-19 16:49:49Z` |
| [`e08ba4eb`](https://github.com/NixOS/nixpkgs/commit/e08ba4eb7c981cfb9d448f7e714e945b926ea725) | `python38Packages.qrcode: 6.1 -> 7.3`                                             | `2021-08-19 16:45:17Z` |
| [`7d70d523`](https://github.com/NixOS/nixpkgs/commit/7d70d523469cb79e240f38411bcb06e69763e784) | `Keep the patch for 7.1.x fresh`                                                  | `2021-08-19 16:34:45Z` |
| [`da3e6504`](https://github.com/NixOS/nixpkgs/commit/da3e6504941a8162f08a9b1e99914d807deada71) | `salt: 3003.1 -> 3003.2`                                                          | `2021-08-19 16:28:05Z` |
| [`5097d9b1`](https://github.com/NixOS/nixpkgs/commit/5097d9b1089a9fde525e7f1175e5cd1198bfdeed) | `awscli2: 2.2.14 -> 2.2.30`                                                       | `2021-08-19 16:06:29Z` |
| [`f3c17463`](https://github.com/NixOS/nixpkgs/commit/f3c17463a181847bb1c084871926ff5e7252b7b0) | `Let's keep kde-open5`                                                            | `2021-08-19 16:06:29Z` |
| [`cc00012c`](https://github.com/NixOS/nixpkgs/commit/cc00012c97920ae49e6565375c2386f707a22db0) | `Let's keep kde-open5 in default.nix`                                             | `2021-08-19 16:06:19Z` |
| [`eaa6024c`](https://github.com/NixOS/nixpkgs/commit/eaa6024ce06fc35a4c3a24d201f1160199e9fc78) | `vimPlugins.cmp-nvim-lua: init at 2021-08-17`                                     | `2021-08-19 16:01:19Z` |
| [`33d54b70`](https://github.com/NixOS/nixpkgs/commit/33d54b702c6eaff26c50b2fa56c07a99844ea90a) | `ipinfo: 2.0.2 -> 2.1.1`                                                          | `2021-08-19 15:59:51Z` |
| [`97c65680`](https://github.com/NixOS/nixpkgs/commit/97c65680ada754d1d179e833edf1699ffa55a1b0) | `python3Packages.stevedore: 3.3.0 -> 3.4.0`                                       | `2021-08-19 15:44:36Z` |
| [`9a56307e`](https://github.com/NixOS/nixpkgs/commit/9a56307ead90c95307b56886d9eda6ce74f62a40) | `iosevka: 7.2.4 → 10.0.0`                                                         | `2021-08-19 15:34:50Z` |
| [`d8c9c038`](https://github.com/NixOS/nixpkgs/commit/d8c9c038e676bd144dc2f6ac92667af1d6ba46f7) | `v4l2loopback: Fix issue with buildEnv using bin output`                          | `2021-08-19 15:24:49Z` |
| [`d0f1a392`](https://github.com/NixOS/nixpkgs/commit/d0f1a3922aa5af94e783151e0baf28282dbb0bdb) | `ftxui: init at unstable-2021-08-13`                                              | `2021-08-19 15:16:50Z` |
| [`b3685e1f`](https://github.com/NixOS/nixpkgs/commit/b3685e1fa7f0b7b356a9efd685e6367246d8a2ef) | `libvisio2svg: init at 0.5.5`                                                     | `2021-08-19 14:58:58Z` |
| [`89e61c98`](https://github.com/NixOS/nixpkgs/commit/89e61c9812eb849797cda3e373e85e57fc353186) | `libemf2svg: init at 1.1.0`                                                       | `2021-08-19 14:58:42Z` |
| [`1875fba4`](https://github.com/NixOS/nixpkgs/commit/1875fba4c4fefdc0f283c53d42c817a969133679) | `palemoon: 29.4.0 -> 29.4.0.1`                                                    | `2021-08-19 14:48:55Z` |
| [`58c3c45d`](https://github.com/NixOS/nixpkgs/commit/58c3c45d7345f51cdc49891edf4249565dac71f9) | `python38Packages.pytest-mpl: 0.12 -> 0.13`                                       | `2021-08-19 14:47:29Z` |
| [`fe139fe2`](https://github.com/NixOS/nixpkgs/commit/fe139fe20025453445164bfd34af7457c6a9e1c8) | `amdvlk: 2021.Q3.2 -> 2021.Q3.4`                                                  | `2021-08-19 13:42:08Z` |
| [`158ad86b`](https://github.com/NixOS/nixpkgs/commit/158ad86b1a74c70d36b5ff9d8732cf2f057c9116) | `vimPlugins.vis: init at 2013-04-26`                                              | `2021-08-19 13:27:49Z` |
| [`4d97e027`](https://github.com/NixOS/nixpkgs/commit/4d97e027b1fd25fc7edd3cff2325e169d77b225c) | `vimPlugins.vim-gh-line: init at 2021-03-25`                                      | `2021-08-19 13:25:26Z` |
| [`6b6a24e9`](https://github.com/NixOS/nixpkgs/commit/6b6a24e9883e98abf30c8ce2cc22da327bee26f6) | `vimPlugins: update`                                                              | `2021-08-19 13:20:17Z` |
| [`5dba6be9`](https://github.com/NixOS/nixpkgs/commit/5dba6be968a9d1d1be26f6e4dbad16b960336468) | `scalafmt: 2.7.5 → 3.0.0`                                                         | `2021-08-19 13:09:11Z` |
| [`629f88f3`](https://github.com/NixOS/nixpkgs/commit/629f88f3af556743e26265a6accd9bde7262275c) | `PULL_REQUEST_TEMPLATE.md: Improve platform checkboxes`                           | `2021-08-19 13:01:59Z` |
| [`c0238e11`](https://github.com/NixOS/nixpkgs/commit/c0238e110a1d3af399cb654a3a0f7ba45fbdf39d) | `knot-resolver: 5.4.0 -> 5.4.1`                                                   | `2021-08-19 12:58:08Z` |
| [`ccb652c5`](https://github.com/NixOS/nixpkgs/commit/ccb652c538c6b09381ac27e948fff3e5f31b1696) | `xrestop: 0.4 -> 0.5; clarify license; adopt`                                     | `2021-08-19 12:42:06Z` |
| [`5390478d`](https://github.com/NixOS/nixpkgs/commit/5390478d5a5f3c8cc1cfc886b6750df1dfe30dc5) | `terragrunt: 0.31.3 -> 0.31.5`                                                    | `2021-08-19 12:41:04Z` |
| [`518bd4f6`](https://github.com/NixOS/nixpkgs/commit/518bd4f6bb6449305db56feea5ec266bea9be51e) | `python38Packages.bond-api: 0.1.12 -> 0.1.13`                                     | `2021-08-19 12:30:02Z` |
| [`dd39ec87`](https://github.com/NixOS/nixpkgs/commit/dd39ec87f41db66ae4b9cb68e40cea811f863ebc) | `mautrix-telegram: 2021-08-12 -> 0.10.1`                                          | `2021-08-19 12:25:56Z` |
| [`3b27d83f`](https://github.com/NixOS/nixpkgs/commit/3b27d83fa51b7f06a31c096a49ec1620fac9cbda) | `nixos/v2ray: update reference links`                                             | `2021-08-19 11:53:45Z` |
| [`028b39fc`](https://github.com/NixOS/nixpkgs/commit/028b39fcf8d2735e468df9b49f4aab511fccbbc1) | `iperf2: 2.0.13 -> 2.1.4`                                                         | `2021-08-19 10:40:05Z` |
| [`b86e886f`](https://github.com/NixOS/nixpkgs/commit/b86e886f996d37f5e61d804e044fd35f8bf15b28) | `exploitdb: 2021-08-17 -> 2021-08-19`                                             | `2021-08-19 10:39:42Z` |
| [`bc831445`](https://github.com/NixOS/nixpkgs/commit/bc8314451c002c2cbe51426ad49c3a5f5609c320) | `vscode: fix updateScript`                                                        | `2021-08-19 10:30:37Z` |
| [`d4cc8ca3`](https://github.com/NixOS/nixpkgs/commit/d4cc8ca3d315a6af39f78bfc60c024686ba47dc5) | `tar2ext4: correct `meta.platforms` is already configured by `buildGoModule``     | `2021-08-19 10:27:54Z` |
| [`d5c8e7bd`](https://github.com/NixOS/nixpkgs/commit/d5c8e7bdf9a863351145eb9c1900715668110d46) | `python38Packages.defcon: 0.8.1 -> 0.9.0`                                         | `2021-08-19 10:20:54Z` |
| [`a1e6c9b8`](https://github.com/NixOS/nixpkgs/commit/a1e6c9b848d93d927d8bfa97627426a0b8636423) | `Correct relative path to xdg-open-brief.patch`                                   | `2021-08-19 09:23:26Z` |
| [`6714723b`](https://github.com/NixOS/nixpkgs/commit/6714723bfaba81b96543818f248b4c07d11cb2d9) | `sage: fix icon location in the kernel definition`                                | `2021-08-19 09:20:35Z` |
| [`32cc33e1`](https://github.com/NixOS/nixpkgs/commit/32cc33e129012209115ccf8b4c0ba9a8eb811596) | `nextpnr: 2021.08.06 -> 2021.08.16`                                               | `2021-08-19 09:16:32Z` |
| [`5540e1b0`](https://github.com/NixOS/nixpkgs/commit/5540e1b0dd5f264ca9dc7f70687cfb6c34fb55e4) | `yosys-bluespec: 2021.01.17 -> 2021.08.19`                                        | `2021-08-19 09:16:32Z` |
| [`0cfbb590`](https://github.com/NixOS/nixpkgs/commit/0cfbb5906603c779e573116c37cc56cfc6f54e34) | `yosys: 0.9+4272 -> 0.9+4276`                                                     | `2021-08-19 09:16:32Z` |
| [`68e256c0`](https://github.com/NixOS/nixpkgs/commit/68e256c0cee465ed12bf0168f6068dcc6c9a363e) | `Define patches, don't add to it`                                                 | `2021-08-19 09:08:09Z` |
| [`f4cb0cac`](https://github.com/NixOS/nixpkgs/commit/f4cb0cace0e00bafe0ac8e8daa0985b6ee240a78) | `polkadot: 0.9.8 -> 0.9.9`                                                        | `2021-08-19 09:06:04Z` |
| [`2834fea8`](https://github.com/NixOS/nixpkgs/commit/2834fea828e632b4152b7f14b74d729eacceec66) | `chromiumBeta: 93.0.4577.42 -> 93.0.4577.51`                                      | `2021-08-19 09:00:48Z` |
| [`7efb6066`](https://github.com/NixOS/nixpkgs/commit/7efb6066ac9a569342f937248e939822c142c3ea) | `Drop xdg-open stuff from default.nix as it is overriden from src-still`          | `2021-08-19 08:59:00Z` |
| [`4b518247`](https://github.com/NixOS/nixpkgs/commit/4b5182477cded7e336c23171b51350c1bb4d2dd1) | `libreoffice: xdg-open-brief.patch not needed for 7.2`                            | `2021-08-19 08:51:44Z` |
| [`db20bd96`](https://github.com/NixOS/nixpkgs/commit/db20bd963b77a53cc22b52fe0b01071ffe747f33) | `python3Packages.platformdirs: init at 2.2.0`                                     | `2021-08-19 08:02:01Z` |
| [`12558b99`](https://github.com/NixOS/nixpkgs/commit/12558b99db6ae5ded91b9a00bb469ee3149df372) | `python3Packages.zeep: 4.0.0 -> 4.1.0`                                            | `2021-08-19 08:01:00Z` |
| [`3afbd979`](https://github.com/NixOS/nixpkgs/commit/3afbd979398a0d0622d402bd5b20a6d2603a1577) | `python3Packages.dsmr-parser: 0.29 -> 0.30`                                       | `2021-08-19 07:57:59Z` |
| [`165d455d`](https://github.com/NixOS/nixpkgs/commit/165d455db5da729524fe411cced28f650cdac947) | `python3Packages.pywemo: 0.6.6 -> 0.6.7`                                          | `2021-08-19 07:53:21Z` |
| [`08c12556`](https://github.com/NixOS/nixpkgs/commit/08c12556a62be4a2107d3f386a186f8be7db6e59) | `python3Packages.chalice: enable tests`                                           | `2021-08-19 07:47:30Z` |
| [`808125ff`](https://github.com/NixOS/nixpkgs/commit/808125fff694e4eb4c73952d501e975778ffdacd) | `deluge-1_x: Remove older version of Deluge (#134448)`                            | `2021-08-19 07:18:18Z` |
| [`8992ae0c`](https://github.com/NixOS/nixpkgs/commit/8992ae0cff94de1c44215b37dbe2e063217df684) | `pymol: 2.3.0 -> 2.5.0`                                                           | `2021-08-19 07:16:38Z` |
| [`0a7d031e`](https://github.com/NixOS/nixpkgs/commit/0a7d031e61ff4572eb65b311df5f6cf7e218a032) | `python38Packages.pyodbc: 4.0.30 -> 4.0.31`                                       | `2021-08-19 06:43:14Z` |
| [`6d7d236d`](https://github.com/NixOS/nixpkgs/commit/6d7d236d26f6ce9a83c149562bd908cfabbab065) | `python38Packages.mautrix: 0.10.3 -> 0.10.4`                                      | `2021-08-19 06:38:59Z` |
| [`0efa6187`](https://github.com/NixOS/nixpkgs/commit/0efa6187e5a6aa61c24b71a4ba798a65ab0f6c15) | `python38Packages.chalice: 1.23.0 -> 1.24.2`                                      | `2021-08-19 04:42:32Z` |
| [`75df9a28`](https://github.com/NixOS/nixpkgs/commit/75df9a286f50591a0e7cec79a4b3eabd6856ccbf) | `vimPlugins.kommentary: init at 2021-08-17`                                       | `2021-08-19 04:06:20Z` |
| [`1f78eae9`](https://github.com/NixOS/nixpkgs/commit/1f78eae9bda5e14b721fbec18fe926c7f03e0adc) | `wal-g: 1.0 -> 1.1`                                                               | `2021-08-19 02:50:31Z` |
| [`08a5803d`](https://github.com/NixOS/nixpkgs/commit/08a5803d08bb8880996d69ffaf859a4c83b07fa7) | `vimPlugins.telescope-project-nvim: init at 2021-08-03`                           | `2021-08-19 02:42:02Z` |
| [`f9248137`](https://github.com/NixOS/nixpkgs/commit/f92481372906bdecadd9c815fc5e435dda17f852) | `electron_13: 13.1.9 -> 13.2.0`                                                   | `2021-08-19 02:37:51Z` |
| [`eab36fab`](https://github.com/NixOS/nixpkgs/commit/eab36fabf6168f8fdbb2b835ce3ab689b9902ab1) | `config.hardware.onlykey: update the udev rules for onlykey`                      | `2021-08-19 02:25:42Z` |
| [`1f9e0192`](https://github.com/NixOS/nixpkgs/commit/1f9e0192603f335e2bf29e7bb2a67acd5c4cb3c9) | `config.hardware.onlykey: move the module into its own folder`                    | `2021-08-19 02:25:40Z` |
| [`18c1b519`](https://github.com/NixOS/nixpkgs/commit/18c1b519b34de145f40dd440285c89ffa9a71223) | `python3Packages.pycm: clean up checkPhase`                                       | `2021-08-19 01:44:10Z` |
| [`f695cbef`](https://github.com/NixOS/nixpkgs/commit/f695cbef93ca9c1a5a06e099af49069919dc96c2) | `python38Packages.somajo: 2.1.3 -> 2.1.4`                                         | `2021-08-19 01:35:20Z` |
| [`a2df7bb8`](https://github.com/NixOS/nixpkgs/commit/a2df7bb8834e585e144eb7c04d3ca41d734bc70f) | `jdk: fix manpage symlink on darwin`                                              | `2021-08-19 00:14:04Z` |
| [`0499ef07`](https://github.com/NixOS/nixpkgs/commit/0499ef0777c3c6693514e5016c30114a9f166415) | `python3Packages.requests-cache: 0.7.3 -> 0.7.4`                                  | `2021-08-18 23:13:32Z` |
| [`98af4435`](https://github.com/NixOS/nixpkgs/commit/98af443596bfd936025e8058d7f6557c7310e518) | `cataclysm-dda: 0.F -> 0.F-1`                                                     | `2021-08-18 23:06:38Z` |
| [`8f506f4d`](https://github.com/NixOS/nixpkgs/commit/8f506f4de0ebb2d7a097851ba5b448491e00c2a3) | `ethtool: 5.4 -> 5.13`                                                            | `2021-08-18 22:48:21Z` |
| [`87098c66`](https://github.com/NixOS/nixpkgs/commit/87098c66b8af7755408574f2cce7cc885c2417db) | `hydrus: 450 -> 451`                                                              | `2021-08-18 22:43:43Z` |
| [`8d9a7e36`](https://github.com/NixOS/nixpkgs/commit/8d9a7e368fc5206d35cc5f218fa78e08dcb1647e) | `tabnine: 3.5.37 -> 3.5.49`                                                       | `2021-08-18 22:41:59Z` |
| [`0f783d55`](https://github.com/NixOS/nixpkgs/commit/0f783d556f770818d9400cfa613af64404488c97) | `kubernetes-helm-wrapped: fix wrapper`                                            | `2021-08-18 22:26:05Z` |
| [`99bdddc7`](https://github.com/NixOS/nixpkgs/commit/99bdddc7e1d82710a25142474ea5d14d54ed40bf) | `sonobuoy: 0.50.0 -> 0.53.2`                                                      | `2021-08-18 22:12:57Z` |
| [`8dbeed75`](https://github.com/NixOS/nixpkgs/commit/8dbeed753fe0110cb4dcdc3ca4be3a920170dadf) | `python3Packages.angrop: 9.0.9438 -> 9.0.9506`                                    | `2021-08-18 22:10:48Z` |
| [`e6f3a389`](https://github.com/NixOS/nixpkgs/commit/e6f3a38970d8ef51f707b8f40126b4262735060f) | `python3Packages.angr: 9.0.9438 -> 9.0.9506`                                      | `2021-08-18 22:10:44Z` |
| [`1d1638b0`](https://github.com/NixOS/nixpkgs/commit/1d1638b0341777bbac9b4fc40422122f6595673c) | `python3Packages.cle: 9.0.9438 -> 9.0.9506`                                       | `2021-08-18 22:10:38Z` |
| [`ec812ef3`](https://github.com/NixOS/nixpkgs/commit/ec812ef3b20b5f55590070385655efaf65b4a04a) | `python3Packages.claripy: 9.0.9438 -> 9.0.9506`                                   | `2021-08-18 22:10:34Z` |
| [`f4428795`](https://github.com/NixOS/nixpkgs/commit/f44287955f3e2e0f19f226b632338601385155c1) | `python3Packages.pyvex: 9.0.9438 -> 9.0.9506`                                     | `2021-08-18 22:10:29Z` |
| [`f5f14e38`](https://github.com/NixOS/nixpkgs/commit/f5f14e384f963912d29620c3b4e45677102b3d8c) | `python3Packages.ailment: 9.0.9438 -> 9.0.9506`                                   | `2021-08-18 22:10:22Z` |
| [`70011955`](https://github.com/NixOS/nixpkgs/commit/70011955a31acde4891d5b12673d0f43ca7b1f68) | `python3Packages.archinfo: 9.0.9438 -> 9.0.9506`                                  | `2021-08-18 22:10:17Z` |
| [`4b3374e6`](https://github.com/NixOS/nixpkgs/commit/4b3374e63e144c0431aeb582832c0aeb4cc8b60d) | `python3Packages.gcsfs: 2021.06.0 -> 2021.07.0`                                   | `2021-08-18 21:57:35Z` |
| [`157ebb2b`](https://github.com/NixOS/nixpkgs/commit/157ebb2b743e4485f084c19f2b5ee88b299e4957) | `python38Packages.pycm: 3.1 -> 3.2`                                               | `2021-08-18 21:56:42Z` |
| [`c86a0737`](https://github.com/NixOS/nixpkgs/commit/c86a0737c193d880010ae41e34ae2981fcc5948e) | `mpvScripts.mpv-playlistmanager unstable-2021-03-09 → unstable-2021-08-17`        | `2021-08-18 21:41:59Z` |
| [`1c654ee0`](https://github.com/NixOS/nixpkgs/commit/1c654ee011c7fc6118b77e745ff9dd95adec5f62) | `otpauth: init at 0.3.4`                                                          | `2021-08-18 21:29:38Z` |
| [`6dd3bfff`](https://github.com/NixOS/nixpkgs/commit/6dd3bfff7af4ab458a262d0950eb012b9acfd31a) | `luaformatter: combine with duplicate package lua-format, remove submodule usage` | `2021-08-18 21:23:09Z` |
| [`df7232c7`](https://github.com/NixOS/nixpkgs/commit/df7232c70587155970ff8fa75ce89737291bf6d0) | `matrix-appservice-irc: add update script`                                        | `2021-08-18 20:51:50Z` |
| [`f38c807c`](https://github.com/NixOS/nixpkgs/commit/f38c807c61e4577f9dbb1afdf4eeb422447f5904) | `linux_xanmod: 5.13.11 -> 5.13.12`                                                | `2021-08-18 20:41:14Z` |
| [`98b571b8`](https://github.com/NixOS/nixpkgs/commit/98b571b8ea33130c19faa39ab9b31dccf8d08479) | `python3Packages.nplusone: fix build`                                             | `2021-08-18 20:34:16Z` |
| [`e4db1c88`](https://github.com/NixOS/nixpkgs/commit/e4db1c88471229f71aa529ff388e490e087f2cfe) | `linux_zen: add update script`                                                    | `2021-08-18 20:24:28Z` |
| [`27edf4cc`](https://github.com/NixOS/nixpkgs/commit/27edf4ccb48ca48375064d5fc964b8ad9b7c0578) | `linuxPackages_zen: 5.13.9 -> 5.13.10-zen1`                                       | `2021-08-18 20:24:15Z` |
| [`5a2fd669`](https://github.com/NixOS/nixpkgs/commit/5a2fd66948917c155a565a6d58bafbf055b1e990) | `terraform_1_0: 1.0.4 -> 1.0.5 #`                                                 | `2021-08-18 20:22:19Z` |
| [`8a4a84c8`](https://github.com/NixOS/nixpkgs/commit/8a4a84c83a62b1f8d5a0c94d0ea411ad7ee5825f) | `signal-desktop: 5.13.1 -> 5.14.0`                                                | `2021-08-18 20:08:52Z` |
| [`a7832a7f`](https://github.com/NixOS/nixpkgs/commit/a7832a7fc94a1e9a57ff20c2f82c38694565d62b) | `archivy: fix runtime`                                                            | `2021-08-18 19:10:38Z` |
| [`896be093`](https://github.com/NixOS/nixpkgs/commit/896be09342e39444fdcbac110008ef1f2985302b) | `zathura-pdf-mupdf: 0.3.6 -> 0.3.7`                                               | `2021-08-18 17:39:11Z` |