### PR TITLE
feat(niv): update nixos-hardware

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "878f629005b003fe39c9e619b074e0ff7d9ed0e2",
-        "sha256": "12zl4hjylsd74ml2nzaqdn099yli86441maa9ybw94sq9hchx585",
+        "rev": "d2d9a58a5c03ea15b401c186508c171c07f9c4f1",
+        "sha256": "0bhfp0dyr8rhra8h4lbw6bg1j97ss8v3xmam94rg3dg7107zn8q2",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixos-hardware/archive/878f629005b003fe39c9e619b074e0ff7d9ed0e2.tar.gz",
+        "url": "https://github.com/NixOS/nixos-hardware/archive/d2d9a58a5c03ea15b401c186508c171c07f9c4f1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                         | Timestamp              |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------ | ---------------------- |
| [`d2d9a58a`](https://github.com/NixOS/nixos-hardware/commit/d2d9a58a5c03ea15b401c186508c171c07f9c4f1) | `remove systemd-boot from hardware profiles (#307)`    | `2021-08-21 08:22:25Z` |
| [`e45d775c`](https://github.com/NixOS/nixos-hardware/commit/e45d775c9358381243c292f3fde8c9f89744b2d8) | `raspberry-pi/4: Include tsched=0 fix in audio module` | `2021-08-19 21:57:05Z` |
| [`6f10c889`](https://github.com/NixOS/nixos-hardware/commit/6f10c889c0c0144a76086bae609bad2383e0ac07) | `Init Lenovo ThinkPad E14`                             | `2021-08-19 10:15:46Z` |