### PR TITLE
feat(niv): update home-manager

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bf6b85136b47ab1a76df4a90ea4850871147494a",
-        "sha256": "11ssh8w6cy9mh233sc8a3sw4fkkj1z9fkqfsiljc404kb7p4jrhl",
+        "rev": "f6d1cad6ba228b81bf7045f1124aa99dfdcf3daa",
+        "sha256": "0s8nlgrf16bz2bhnk0xrzvivagq55cifxf2p545c7n4zj9ryfkkp",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/bf6b85136b47ab1a76df4a90ea4850871147494a.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/f6d1cad6ba228b81bf7045f1124aa99dfdcf3daa.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixos-hardware": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                    | Timestamp              |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- | ---------------------- |
| [`f6d1cad6`](https://github.com/nix-community/home-manager/commit/f6d1cad6ba228b81bf7045f1124aa99dfdcf3daa) | `[nixos] Fix race condition with user units (#2286)`              | `2021-08-22 02:14:40Z` |
| [`c5b30691`](https://github.com/nix-community/home-manager/commit/c5b3069145806965ff2bf3807cf273a5a36dc23c) | `i3/sway: allow empty criterias using a value of 'true' (#2277)`  | `2021-08-22 00:41:06Z` |
| [`4367119c`](https://github.com/nix-community/home-manager/commit/4367119ca3e295513a71eafe839296410a73dbf0) | `local gpg-agent acting as ssh-agent should yield (#667) (#2253)` | `2021-08-21 05:43:41Z` |