### PR TITLE
feat(niv): update nixos-hardware

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "d2d9a58a5c03ea15b401c186508c171c07f9c4f1",
-        "sha256": "0bhfp0dyr8rhra8h4lbw6bg1j97ss8v3xmam94rg3dg7107zn8q2",
+        "rev": "de40acde6c056a7c5f3c9ad4dca0c172fa35d207",
+        "sha256": "14c5jjf0791dxy9bpsnqmrzph1nafzqk7ffvlpm0pw3gbs073rl2",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixos-hardware/archive/d2d9a58a5c03ea15b401c186508c171c07f9c4f1.tar.gz",
+        "url": "https://github.com/NixOS/nixos-hardware/archive/de40acde6c056a7c5f3c9ad4dca0c172fa35d207.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                           | Timestamp              |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- | ---------------------- |
| [`ad1114ee`](https://github.com/NixOS/nixos-hardware/commit/ad1114ee372a52aa0b4934f72835bd14a212a642) | `raspberry-pi/4: fix usage of mkDefault in audio module` | `2021-08-23 17:50:37Z` |