### PR TITLE
feat(niv): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5edf5b60c3d8f82b5fc5e73e822b6f7460584945",
-        "sha256": "0gbb07mhbn9m8askxsy87h9737sr45qhnrjhkkix3jl136my2ppz",
+        "rev": "dcc8b48d58ffaab7086f7ee03b3ca0536e5558be",
+        "sha256": "04cns2w8dhymlz64vaq1qs1mcn15dwz4d95x80rcszbx0l51b8lw",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5edf5b60c3d8f82b5fc5e73e822b6f7460584945.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/dcc8b48d58ffaab7086f7ee03b3ca0536e5558be.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                     | Timestamp              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ---------------------- |
| [`70b7560f`](https://github.com/NixOS/nixpkgs/commit/70b7560f9387b12d03260dabb475b9933f845fba) | `enum4linux-ng: 1.0.0 -> 1.0.1`                                    | `2021-08-24 03:59:26Z` |
| [`e369479c`](https://github.com/NixOS/nixpkgs/commit/e369479c1411e0812fbcaf5ced9f194a6a0cecf2) | `disfetch: 2.13 -> 2.14`                                           | `2021-08-24 03:35:36Z` |
| [`75b6f0cb`](https://github.com/NixOS/nixpkgs/commit/75b6f0cb363d1b938671f535677bc88d6074ec8d) | `cpufetch: 0.98 -> 1.00`                                           | `2021-08-24 02:36:16Z` |
| [`fb7f2f03`](https://github.com/NixOS/nixpkgs/commit/fb7f2f03e9ee4df056197106d85feeff16c2722e) | `chezmoi: 2.1.5 -> 2.1.6`                                          | `2021-08-24 01:58:34Z` |
| [`2b81dc4f`](https://github.com/NixOS/nixpkgs/commit/2b81dc4fb65326d41258ee3920cefa13d1825d3c) | `python-packages.nix: fix alphabetical order`                      | `2021-08-23 23:01:01Z` |
| [`3f4ce46a`](https://github.com/NixOS/nixpkgs/commit/3f4ce46a4702940cb7d1d12349c0407576225605) | `lib: optimize setAttrByPath and cleaup imports`                   | `2021-08-23 22:04:47Z` |
| [`d18866b1`](https://github.com/NixOS/nixpkgs/commit/d18866b1c2cd86fde5586b38a5574e55748c62f7) | `nasc: 0.7.5 -> 0.8.0`                                             | `2021-08-23 21:23:52Z` |
| [`d7f344b5`](https://github.com/NixOS/nixpkgs/commit/d7f344b5b086addc69f5d1cb87d30b48057f4000) | `podman: add gvproxy to darwin wrapper`                            | `2021-08-23 20:59:20Z` |
| [`928cee38`](https://github.com/NixOS/nixpkgs/commit/928cee3856c23e4380e8e9f8e7511cb50b474d77) | `gvproxy: init at 0.1.0`                                           | `2021-08-23 20:59:20Z` |
| [`99a3addb`](https://github.com/NixOS/nixpkgs/commit/99a3addb2bab7b0acaaf5488ce95369ce51e32c7) | `podman: 3.2.3 -> 3.3.0`                                           | `2021-08-23 20:59:20Z` |
| [`fa80ed69`](https://github.com/NixOS/nixpkgs/commit/fa80ed695b44e91cb69ea087ef614cbb1a310286) | `nixos/paperless-ng: allow using postgresql via a unix socket`     | `2021-08-23 20:44:36Z` |
| [`241a422f`](https://github.com/NixOS/nixpkgs/commit/241a422f46d00621e3134799baf53c4b0995e1ef) | `sublime-music: 0.11.12 -> 0.11.13`                                | `2021-08-23 20:26:03Z` |
| [`72dfe22c`](https://github.com/NixOS/nixpkgs/commit/72dfe22cbdd5b8f43f3160fa6b34c25d9b9ffd5f) | `android-studio: 2020.3.1.22 -> 2020.3.1.23`                       | `2021-08-23 19:31:14Z` |
| [`811af99f`](https://github.com/NixOS/nixpkgs/commit/811af99f75f55097207020678d4dd0ec479040ca) | `unixODBC: Add additional URL`                                     | `2021-08-23 19:23:59Z` |
| [`094fbf06`](https://github.com/NixOS/nixpkgs/commit/094fbf06263d767e72d23a81e033f18b83ef2213) | `sx-go: init at 0.4.0`                                             | `2021-08-23 19:05:14Z` |
| [`691cdc68`](https://github.com/NixOS/nixpkgs/commit/691cdc680c3d63493cdf7f55487afba1dd891e97) | `yubico-pam: unstable-2019-07-01 -> 2.27`                          | `2021-08-23 18:06:30Z` |
| [`d4afb739`](https://github.com/NixOS/nixpkgs/commit/d4afb739713c2a15068be0c6d9b72dbde0678d26) | `kernels: remove manually declared kernelTests`                    | `2021-08-23 17:58:55Z` |
| [`0a43b6d5`](https://github.com/NixOS/nixpkgs/commit/0a43b6d5e9cbc1414eb32be7c2ade406cf2bc8f4) | `kernel/generic: add kernelTests automatically`                    | `2021-08-23 17:57:49Z` |
| [`a3f6ff6d`](https://github.com/NixOS/nixpkgs/commit/a3f6ff6d48c42397fa716a8357c7b8be704fd61f) | `nixosTests.kernel-generic: add myself as maintainer`              | `2021-08-23 17:57:49Z` |
| [`457653d9`](https://github.com/NixOS/nixpkgs/commit/457653d99c31bc8e558bcbd38c7d23ed9fa8fb97) | `nixosTests.kernel-generic: expose test-making functions`          | `2021-08-23 17:57:49Z` |
| [`2b52f2b7`](https://github.com/NixOS/nixpkgs/commit/2b52f2b762fc664c04b691ca3f355477f4f65414) | `nixosTests.kernel-generic: simplify`                              | `2021-08-23 17:57:46Z` |
| [`48f0ae53`](https://github.com/NixOS/nixpkgs/commit/48f0ae5331e786a8ad42b7276f9801bacb7de8d6) | `hqplayerd: 4.25.2 -> 4.25.2-66`                                   | `2021-08-23 17:31:55Z` |
| [`df723cf9`](https://github.com/NixOS/nixpkgs/commit/df723cf939a9cc1aace7cc85c053248546baf78d) | `changetower: init at 1.0`                                         | `2021-08-23 17:10:08Z` |
| [`36773ed0`](https://github.com/NixOS/nixpkgs/commit/36773ed064e7fa16426650356149a7abd7e19094) | `cargo-release: 0.16.3 -> 0.17.0`                                  | `2021-08-23 17:00:32Z` |
| [`3c3b6eec`](https://github.com/NixOS/nixpkgs/commit/3c3b6eec5fdf1b855edc297cdaaca4e62b18b2b3) | `cargo-release: fix license`                                       | `2021-08-23 16:57:10Z` |
| [`6a611f20`](https://github.com/NixOS/nixpkgs/commit/6a611f202c6ed2445b098c3f6ac0ca300f710847) | `notify: 0.0.2 -> 1.0.0`                                           | `2021-08-23 16:30:58Z` |
| [`6a142920`](https://github.com/NixOS/nixpkgs/commit/6a14292010747a5b766d1584a0b46211bc2c0dfd) | `cudatext: 1.139.5 → 1.142.0`                                      | `2021-08-23 15:48:35Z` |
| [`58773298`](https://github.com/NixOS/nixpkgs/commit/587732986177509e99fa54c529f3fe65a2bc3eb4) | `python39Packages.sunpy: fully use pytestCheckHook`                | `2021-08-23 15:33:05Z` |
| [`a6ca2c5d`](https://github.com/NixOS/nixpkgs/commit/a6ca2c5d01bdccf82eaf4b1607ef6f3e634e1d83) | `python3Packages.pynacl: fix cross compilation`                    | `2021-08-23 13:34:53Z` |
| [`3e1c1d30`](https://github.com/NixOS/nixpkgs/commit/3e1c1d30b62c8c52a9e8d36dd9d716a4b8bab1fb) | `cargo-embed: fix darwin build`                                    | `2021-08-23 13:31:03Z` |
| [`a8628d80`](https://github.com/NixOS/nixpkgs/commit/a8628d80d86406073c6fa492645a787541d9a9f6) | `cargo-embed: nixpkgs-fmt`                                         | `2021-08-23 13:31:03Z` |
| [`8b1dae8b`](https://github.com/NixOS/nixpkgs/commit/8b1dae8b3c176bb52e2504d6e7881985218f1009) | `zulu: 11.41.23 -> 11.50.19`                                       | `2021-08-23 12:56:56Z` |
| [`ab4f3c81`](https://github.com/NixOS/nixpkgs/commit/ab4f3c81c80b837d4250120c9a10edb9d2362ee6) | `vouch-proxy: init at 0.32.0`                                      | `2021-08-23 12:38:19Z` |
| [`adfe9464`](https://github.com/NixOS/nixpkgs/commit/adfe94641884918670fa21bf33d101c67614cc2e) | `routinator: 0.9.0 -> 0.10.0`                                      | `2021-08-23 12:18:38Z` |
| [`00ace5a4`](https://github.com/NixOS/nixpkgs/commit/00ace5a483888385e61f0a796b5623e200da8d07) | `cargo-flash: fix darwin build`                                    | `2021-08-23 12:11:43Z` |
| [`e69ba1da`](https://github.com/NixOS/nixpkgs/commit/e69ba1da47292ed38ebf2183b9f1b1511f259d2d) | `ofono: fix config loading directory properly`                     | `2021-08-23 12:08:41Z` |
| [`19c8cd36`](https://github.com/NixOS/nixpkgs/commit/19c8cd36017290e2850af5203c665cb73492ce36) | `yle-dl: 20210502 -> 20210808`                                     | `2021-08-23 11:34:05Z` |
| [`e6032fe1`](https://github.com/NixOS/nixpkgs/commit/e6032fe1336df625de5a52d6c4a9a677f8fe554a) | `python39Packages.exdown: 0.8.6 -> 0.9.0`                          | `2021-08-23 10:55:00Z` |
| [`02977f08`](https://github.com/NixOS/nixpkgs/commit/02977f089ade2fdcd2461a81d914008149d9ba51) | `perlPackages.Appcpm: 0.997000 -> 0.997006`                        | `2021-08-23 10:53:55Z` |
| [`5bac2684`](https://github.com/NixOS/nixpkgs/commit/5bac268430fd301a733da9e9defbc2de9ad9903f) | `dt-schema: 2021.2.1 -> 2021.7`                                    | `2021-08-23 10:50:30Z` |
| [`22371fd6`](https://github.com/NixOS/nixpkgs/commit/22371fd67fa5e2f4ff096d8ddb7463970f309f5b) | `dtc: 1.6.0 -> 1.6.1`                                              | `2021-08-23 10:45:14Z` |
| [`5e37ccce`](https://github.com/NixOS/nixpkgs/commit/5e37ccce7d55dc87c498c7e10ebd953d9772d07f) | `prometheus-knot-exporter: 2020-01-30 -> 2021-08-21`               | `2021-08-23 10:29:22Z` |
| [`0a7426b9`](https://github.com/NixOS/nixpkgs/commit/0a7426b93128f903566cece50e8a757012ab78a5) | `sozu: 0.11.56 -> 0.13.6`                                          | `2021-08-23 10:11:28Z` |
| [`381e0dfb`](https://github.com/NixOS/nixpkgs/commit/381e0dfb09f5f3c32e4488fc63a936087b96ead6) | `zulu: fix build on darwin`                                        | `2021-08-23 10:08:53Z` |
| [`b2a7ed4a`](https://github.com/NixOS/nixpkgs/commit/b2a7ed4afc4758f3503f8dc565c462d2a7812620) | `python38Packages.pygmt: 0.4.0 -> 0.4.1`                           | `2021-08-23 09:21:48Z` |
| [`7ab49190`](https://github.com/NixOS/nixpkgs/commit/7ab49190f32ebaf8dfce02edef3b17356345138f) | `gpxsee: 9.3 → 9.5`                                                | `2021-08-23 09:14:55Z` |
| [`e7e8eecf`](https://github.com/NixOS/nixpkgs/commit/e7e8eecf588ba400f3a525d55af242bbd322536d) | `python38Packages.param: 1.10.1 -> 1.11.1`                         | `2021-08-23 09:12:25Z` |
| [`da5e1cf9`](https://github.com/NixOS/nixpkgs/commit/da5e1cf9a1625adff979d00df97ad787c5c9f2da) | `python38Packages.pandas-datareader: 0.9.0 -> 0.10.0`              | `2021-08-23 08:57:00Z` |
| [`84a14ffe`](https://github.com/NixOS/nixpkgs/commit/84a14ffef64347f7980cd56b35648c9622c40634) | `crowdin-cli: 3.6.4 -> 3.6.5`                                      | `2021-08-23 08:56:47Z` |
| [`2d043248`](https://github.com/NixOS/nixpkgs/commit/2d043248cea3244ef748e390e7cbe77eff5ed379) | `zsh-nix-shell: 0.1.0 -> 0.4.0`                                    | `2021-08-23 08:54:45Z` |
| [`2c293576`](https://github.com/NixOS/nixpkgs/commit/2c2935765ee718dcad94feb5143433220fe5f7e4) | `zef: 0.11.9 -> 0.11.10`                                           | `2021-08-23 08:43:32Z` |
| [`a9fd2952`](https://github.com/NixOS/nixpkgs/commit/a9fd2952250df634c636673469eb51223c9ccddc) | `python38Packages.phonenumbers: 8.12.29 -> 8.12.30`                | `2021-08-23 08:39:58Z` |
| [`be66efdf`](https://github.com/NixOS/nixpkgs/commit/be66efdf863be972f08263e863c0bb1156ae1b42) | `runc: 1.0.1 -> 1.0.2`                                             | `2021-08-23 08:39:06Z` |
| [`1b52b5c7`](https://github.com/NixOS/nixpkgs/commit/1b52b5c718a75f30f9ab7af172165d6027cba3b7) | `z-lua: 1.8.12 -> 1.8.13`                                          | `2021-08-23 08:35:17Z` |
| [`b94e2685`](https://github.com/NixOS/nixpkgs/commit/b94e26857a2cc5faae2ad9c3885323f2a6e87bf3) | `astroid: remove unused input`                                     | `2021-08-23 08:33:10Z` |
| [`c63277bd`](https://github.com/NixOS/nixpkgs/commit/c63277bd75c38adf8d008be3ba65464091669297) | `python38Packages.google-re2: 0.1.20210601 -> 0.2.20210801`        | `2021-08-23 08:32:04Z` |
| [`369c3172`](https://github.com/NixOS/nixpkgs/commit/369c3172744545e7a2fe2b43c9affff50b202e2d) | `ytcc: 2.2.0 -> 2.3.0`                                             | `2021-08-23 08:30:44Z` |
| [`5bb77e3a`](https://github.com/NixOS/nixpkgs/commit/5bb77e3ad96139efe668e81baea2ca064485f4d2) | `zoom-us: 5.7.29123.0808 -> 5.7.31792.0820`                        | `2021-08-23 08:27:44Z` |
| [`3ed727aa`](https://github.com/NixOS/nixpkgs/commit/3ed727aadff3b663d5e7ffec0dd11df17f9a2a41) | `xkbmon: 0.3 -> 0.4`                                               | `2021-08-23 08:16:43Z` |
| [`71c47ca2`](https://github.com/NixOS/nixpkgs/commit/71c47ca2449a3632e8093c9c4f4036a7b31eec59) | `cryptop: add setuptools to fix crash`                             | `2021-08-23 08:14:46Z` |
| [`6b086631`](https://github.com/NixOS/nixpkgs/commit/6b086631c6093721c0a710d6903161a9820ae108) | `workcraft: 3.3.2 -> 3.3.5`                                        | `2021-08-23 08:01:40Z` |
| [`59af7f0a`](https://github.com/NixOS/nixpkgs/commit/59af7f0a2b2123968e9b983759567f5f118ffb5d) | `apparmor: Fix cups-client typo`                                   | `2021-08-23 07:50:15Z` |
| [`e32cc5f9`](https://github.com/NixOS/nixpkgs/commit/e32cc5f93aeecf39f6d2e5e225e12d3f8718ab3e) | `wasabiwallet: 1.1.12.5 -> 1.1.12.9`                               | `2021-08-23 07:46:06Z` |
| [`430a043a`](https://github.com/NixOS/nixpkgs/commit/430a043a187872d8b065c073839997719b564611) | `CODEOWNERS: update the list of maintainers of the R packages`     | `2021-08-23 07:30:48Z` |
| [`f2393771`](https://github.com/NixOS/nixpkgs/commit/f2393771a62c8df6ade9691202fecc47f301b1e5) | `python3Packages.aws-sam-translator: enable tests`                 | `2021-08-23 07:30:12Z` |
| [`a73fc504`](https://github.com/NixOS/nixpkgs/commit/a73fc504b7925222bdbfe6e6256328b90b7b4714) | `verifast: 19.12 -> 21.04`                                         | `2021-08-23 07:29:27Z` |
| [`1ebfe953`](https://github.com/NixOS/nixpkgs/commit/1ebfe953724806e582eeb71cdd42d2e3fe6df6ae) | `cramfsswap: 1.4.1 -> 1.4.2, cleanup`                              | `2021-08-23 07:27:25Z` |
| [`522bd705`](https://github.com/NixOS/nixpkgs/commit/522bd705076d36d6624ec7da1918564f617f08ed) | `vendir: 0.18.0 -> 0.22.0`                                         | `2021-08-23 07:05:25Z` |
| [`42c1592e`](https://github.com/NixOS/nixpkgs/commit/42c1592e2e43c167b768ebf043dea2073b0c22b1) | `vaultwarden-vault: 2.19.0 -> 2.21.1`                              | `2021-08-23 06:43:37Z` |
| [`8d5baa5c`](https://github.com/NixOS/nixpkgs/commit/8d5baa5c27ad33a31d3412838b19ce610ae2902f) | `gitlab-runner: 14.1.0 -> 14.2.0`                                  | `2021-08-23 06:32:14Z` |
| [`f28a7c49`](https://github.com/NixOS/nixpkgs/commit/f28a7c499a41a5fb7d438b79b9db02ed8143f110) | `unused: 0.2.2 -> 0.2.3`                                           | `2021-08-23 06:28:00Z` |
| [`f6b87124`](https://github.com/NixOS/nixpkgs/commit/f6b87124bf4eb28682b2b625d763213e1cd5e797) | `gnome.mutter: 40.1 -> 40.4`                                       | `2021-08-23 06:26:34Z` |
| [`e1732c5f`](https://github.com/NixOS/nixpkgs/commit/e1732c5f6a64c2cfc53f25c7610ed28e39d904da) | `python3Packages.python-box: 5.4.0 -> 5.4.1`                       | `2021-08-23 06:10:06Z` |
| [`e75485b9`](https://github.com/NixOS/nixpkgs/commit/e75485b96348298791b8b327ad7643a7c9a0e043) | `tt-rss-theme-feedly: 2.5.0 -> 2.8.2`                              | `2021-08-23 06:09:55Z` |
| [`924fb026`](https://github.com/NixOS/nixpkgs/commit/924fb0265749af937f4c5010d0a8283cf37d4206) | `python38Packages.pycurl: 7.43.0.6 -> 7.44.1`                      | `2021-08-23 05:52:47Z` |
| [`a41f7a04`](https://github.com/NixOS/nixpkgs/commit/a41f7a04eb89af6e3fd6df69180aff7dc9f83024) | `traefik: 2.5.0 -> 2.5.1`                                          | `2021-08-23 05:52:25Z` |
| [`da1d0c80`](https://github.com/NixOS/nixpkgs/commit/da1d0c8056856b456d823ae472989b40ba3d9e92) | `python38Packages.scikit-hep-testdata: 0.4.4 -> 0.4.6`             | `2021-08-23 05:36:32Z` |
| [`50aa54e6`](https://github.com/NixOS/nixpkgs/commit/50aa54e678356db28a55f12abb5eb353e491b9dc) | `tf2pulumi: 0.10.0 -> 0.11.1`                                      | `2021-08-23 05:26:15Z` |
| [`ba00a926`](https://github.com/NixOS/nixpkgs/commit/ba00a9268f03a400588ed452a55b3f7e7dcbad0d) | `temporal: 1.11.3 -> 1.11.4`                                       | `2021-08-23 05:19:14Z` |
| [`18c29fb6`](https://github.com/NixOS/nixpkgs/commit/18c29fb695b40e88ac35a6e4ade74d55168808a2) | `tempo: 0.5.0 -> 1.0.1`                                            | `2021-08-23 05:13:50Z` |
| [`1f60d793`](https://github.com/NixOS/nixpkgs/commit/1f60d793f701d67579ba8a4c6020ec155f1f72b2) | `tabula-java: 1.0.4 -> 1.0.5`                                      | `2021-08-23 04:55:03Z` |
| [`58ee90db`](https://github.com/NixOS/nixpkgs/commit/58ee90db4c233e6bfc26e88d4ea42eb9e9e7fbf0) | `syncplay: 1.6.7 -> 1.6.9`                                         | `2021-08-23 04:46:57Z` |
| [`42183d1c`](https://github.com/NixOS/nixpkgs/commit/42183d1c8842d4984f4dc774a9650f3074bb6e21) | `python38Packages.tinydb: 4.5.0 -> 4.5.1`                          | `2021-08-23 04:42:27Z` |
| [`43af21f6`](https://github.com/NixOS/nixpkgs/commit/43af21f67c97b11d6fd35b843a64b58c156de23d) | `swego: 0.94 -> 0.97`                                              | `2021-08-23 04:36:01Z` |
| [`67b60dd9`](https://github.com/NixOS/nixpkgs/commit/67b60dd9bf5a187df44b4b5af925129d095ec530) | `songrec: 0.1.8 -> 0.1.9`                                          | `2021-08-23 03:44:39Z` |
| [`aaaf20a9`](https://github.com/NixOS/nixpkgs/commit/aaaf20a97d12e6ded8ba13b0bc259efc1f75bf6d) | `smcroute: 2.4.4 -> 2.5.1`                                         | `2021-08-23 03:33:05Z` |
| [`f1e24b16`](https://github.com/NixOS/nixpkgs/commit/f1e24b164bb8776cd9b58826157f83874c04fa37) | `skaffold: 1.20.0 -> 1.30.0`                                       | `2021-08-23 03:25:50Z` |
| [`d01c68c1`](https://github.com/NixOS/nixpkgs/commit/d01c68c1230932f269b52e7de68312e25ba59494) | `sish: 1.1.5 -> 1.1.6`                                             | `2021-08-23 03:20:35Z` |
| [`d56b0736`](https://github.com/NixOS/nixpkgs/commit/d56b0736c1a4a6e8a2e3bf680e8f79d9c3f6253c) | `perlPackages.Modulecpmfile: init at 0.002`                        | `2021-08-23 02:57:02Z` |
| [`ff93e340`](https://github.com/NixOS/nixpkgs/commit/ff93e34005d46ab97c121d23c0cd9be11e26b489) | `perlPackages.CPAN02PackagesSearch: init at 0.001`                 | `2021-08-23 02:50:54Z` |
| [`ae5219a9`](https://github.com/NixOS/nixpkgs/commit/ae5219a9411b080d6b5f8b210fb0ef7bd2b96c4c) | `radiotray-ng: 0.2.7 -> 0.2.8`                                     | `2021-08-23 02:06:14Z` |
| [`8f27e517`](https://github.com/NixOS/nixpkgs/commit/8f27e517a23a808289b79a6c954945ea6c8efc94) | `rabbitmq-server: 3.9.3 -> 3.9.4`                                  | `2021-08-23 01:14:16Z` |
| [`2def3f8c`](https://github.com/NixOS/nixpkgs/commit/2def3f8cb109dbaacc109330144e8f550d641460) | `octoprint.python.pkgs.bedlevelvisualizer: 0.1.15 -> 1.1.0`        | `2021-08-23 00:00:31Z` |
| [`9a9480f3`](https://github.com/NixOS/nixpkgs/commit/9a9480f381220e53fd2d778c94dd589dbb749f99) | `octoprint.python.pkgs.costestimation: 3.2.0 -> 3.3.0`             | `2021-08-23 00:00:27Z` |
| [`5b6b10f7`](https://github.com/NixOS/nixpkgs/commit/5b6b10f7ae4157349eb2bd23be001899ee572b61) | `octoprint.python.pkgs.curaenginelegacy: 1.1.1 -> 1.1.2`           | `2021-08-22 23:55:14Z` |
| [`dd7f6fc1`](https://github.com/NixOS/nixpkgs/commit/dd7f6fc16bf7d66e97df67310ae88ca6311044c8) | `octoprint.python.pkgs.displaylayerprogress: 1.24.0 -> 1.26.0`     | `2021-08-22 23:55:14Z` |
| [`8a1a19a2`](https://github.com/NixOS/nixpkgs/commit/8a1a19a219fd0eee59a744cf541867c587c8a53b) | `octoprint.python.pkgs.gcodeeditor: 0.2.9 -> 0.2.12`               | `2021-08-22 23:55:13Z` |
| [`f9386665`](https://github.com/NixOS/nixpkgs/commit/f93866652b77ab9a13989f8520b0d85af3fd7d1a) | `octoprint.python.pkgs.marlingcodedocumentation: 0.11.0 -> 0.13.0` | `2021-08-22 23:55:13Z` |
| [`7c0061f1`](https://github.com/NixOS/nixpkgs/commit/7c0061f1dc2cf751e166f547bb46b39d4cc19f68) | `octoprint.python.pkgs.mqtt: 0.8.7 -> 0.8.10`                      | `2021-08-22 23:55:13Z` |
| [`d630a8dc`](https://github.com/NixOS/nixpkgs/commit/d630a8dcec9e571eeeaf60a2fddbcd5eb8673e7f) | `octoprint.python.pkgs.printtimegenius: 2.2.6 -> 2.2.8`            | `2021-08-22 23:55:13Z` |
| [`0d5c1cad`](https://github.com/NixOS/nixpkgs/commit/0d5c1cadfa7ce36cf29a9769e11b3f4fd6ce4ab7) | `octoprint.python.pkgs.psucontrol: 0.1.9 -> 1.0.6`                 | `2021-08-22 23:55:12Z` |
| [`47fea985`](https://github.com/NixOS/nixpkgs/commit/47fea9853b24a68e872fc3c6801e1d78929b2d89) | `octoprint.python.pkgs.simpleemergencystop: 1.0.3 -> 1.0.5`        | `2021-08-22 23:55:12Z` |
| [`c94b2d6f`](https://github.com/NixOS/nixpkgs/commit/c94b2d6f8f7deda6bdd37c8633cf57075111affd) | `octoprint.python.pkgs.telegram: 1.6.4 -> 1.6.5`                   | `2021-08-22 23:55:12Z` |
| [`623ad8a9`](https://github.com/NixOS/nixpkgs/commit/623ad8a9b677a03d95debe6ad90ad7f1c8765c92) | `octoprint.python.pkgs.touchui: 0.3.16 -> 0.3.18`                  | `2021-08-22 23:55:12Z` |
| [`2d801b4d`](https://github.com/NixOS/nixpkgs/commit/2d801b4d1d1b3652cdf3381d035b2140a86ff499) | `octoprint.python.pkgs.octoklipper: 0.3.2 -> 0.3.8.3`              | `2021-08-22 23:55:12Z` |
| [`505106bc`](https://github.com/NixOS/nixpkgs/commit/505106bc4b71803aa425364f4ea2617eb706fa5d) | `octoprint.python.pkgs.octoprint-dashboard: 1.15.2 -> 1.18.3`      | `2021-08-22 23:55:11Z` |
| [`fe6d9366`](https://github.com/NixOS/nixpkgs/commit/fe6d9366c9e5425ee828b8436870f18868cd3d23) | `octoprint: 1.5.3 -> 1.6.1`                                        | `2021-08-22 23:55:11Z` |
| [`9f99f6f7`](https://github.com/NixOS/nixpkgs/commit/9f99f6f7bf82214b81032bf50181a9e70bd18417) | `python3Packages.zipstream-new: init at 1.1.8`                     | `2021-08-22 23:55:11Z` |
| [`9ec7deee`](https://github.com/NixOS/nixpkgs/commit/9ec7deee8bcfb04225f9f618b85232d8a5b64506) | `python3Packages.immutabledict: init at 2.1.0`                     | `2021-08-22 23:55:11Z` |
| [`51a14e33`](https://github.com/NixOS/nixpkgs/commit/51a14e3340e38fe2568d9f92beb0ca418dc42a64) | `maestral-gui: Add pythonImportsCheck`                             | `2021-08-22 21:31:14Z` |
| [`48c07975`](https://github.com/NixOS/nixpkgs/commit/48c079758a4b4d2a50966715571f2d7c9b53c06c) | `python3Packages.maestral: Add tests`                              | `2021-08-22 21:31:14Z` |
| [`5d8e6ff9`](https://github.com/NixOS/nixpkgs/commit/5d8e6ff9560ffb221da3819dd23d4c42fc64bb1f) | `meh: 2015-04-11 -> 2018-10-22 (#135299)`                          | `2021-08-22 21:10:39Z` |
| [`06bc3335`](https://github.com/NixOS/nixpkgs/commit/06bc3335d6debc11ffc003fc5d5d2dfa44fcf1b5) | `polkadot: 0.9.9 -> 0.9.9-1 (#135226)`                             | `2021-08-22 20:52:23Z` |
| [`a313d290`](https://github.com/NixOS/nixpkgs/commit/a313d2907daa27aff4e8d973e20eb652c9b804ce) | `hyprspace: 0.1.5 -> 0.1.6`                                        | `2021-08-22 20:50:32Z` |
| [`cb7d80dc`](https://github.com/NixOS/nixpkgs/commit/cb7d80dcaf926a38e80044c29a8210e69f27bb80) | `buildGo{Module,Package}: warn if buildFlags is used`              | `2021-08-22 20:41:14Z` |
| [`e52facaf`](https://github.com/NixOS/nixpkgs/commit/e52facaf7575ce3e520b8081523cad96e6fd36a1) | `grocy: 3.1.0 -> 3.1.1`                                            | `2021-08-22 20:04:29Z` |
| [`31dd75c7`](https://github.com/NixOS/nixpkgs/commit/31dd75c7e724b0960a5d4706970e47bdf61d0f9a) | `commitlint: init at 13.1.0`                                       | `2021-08-22 19:57:52Z` |
| [`02ac43e5`](https://github.com/NixOS/nixpkgs/commit/02ac43e5ed8839d3e2e1be175b74c0d0baddfcd7) | `terracognita: 0.7.1 -> 0.7.2`                                     | `2021-08-22 19:43:30Z` |
| [`cb88fc70`](https://github.com/NixOS/nixpkgs/commit/cb88fc7036ddf2100c8dd55dec0c09b57fffc9ce) | `texmaker: 5.1.0 -> 5.1.1`                                         | `2021-08-22 19:32:18Z` |