### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f28c62759ba771c8f6a26d4ae41214c62d7a6529",
-        "sha256": "1n6hvvzjy1yqywjql2sni20zbl04pv7gqzfy8crj8d5spc2494vg",
+        "rev": "ce38fecabe49a76fcd08d03e7562b44b97109aa7",
+        "sha256": "08fxc7dh8pgf07515lpjnm19k3md7dss9qnnmlqdhb8v1rk0fi4m",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/f28c62759ba771c8f6a26d4ae41214c62d7a6529.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/ce38fecabe49a76fcd08d03e7562b44b97109aa7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                    | Timestamp              |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- | ---------------------- |
| [`85a2af3c`](https://github.com/NixOS/nixpkgs/commit/85a2af3c76af1d7cad3336423cd63b32d36c5c56) | `python3Packages.awslambdaric: 1.2.0 -> 1.2.2`                    | `2021-08-25 05:14:40Z` |
| [`ad338549`](https://github.com/NixOS/nixpkgs/commit/ad338549c519b4703f6122b426193483dda3b313) | `python38Packages.azure-mgmt-servicebus: 6.0.0 -> 7.0.0`          | `2021-08-25 05:11:43Z` |
| [`68658a5b`](https://github.com/NixOS/nixpkgs/commit/68658a5b0e620e033e34baabc986ea90d818d8d7) | `python38Packages.pythondialog: 3.5.1 -> 3.5.2`                   | `2021-08-25 05:11:31Z` |
| [`9de4dc9e`](https://github.com/NixOS/nixpkgs/commit/9de4dc9e48028bbcc63ce409d8c015f4e9617c5e) | `python38Packages.pyfronius: 0.6.2 -> 0.6.3`                      | `2021-08-25 05:11:10Z` |
| [`0cc67d77`](https://github.com/NixOS/nixpkgs/commit/0cc67d775fba1af56eea9420c81e524f94376564) | `ccache: 4.3 -> 4.4 (#135527)`                                    | `2021-08-25 01:02:32Z` |
| [`a2b179a3`](https://github.com/NixOS/nixpkgs/commit/a2b179a3dc2242a4fd8bb2d69c477653bcb1b0e6) | `Update doc/languages-frameworks/javascript.section.md`           | `2021-08-25 00:02:06Z` |
| [`dabd16e7`](https://github.com/NixOS/nixpkgs/commit/dabd16e7f2401d36dbd0cc1b017b58b7d10fe0d0) | `Adding dependency override example`                              | `2021-08-25 00:02:06Z` |
| [`e89b36e4`](https://github.com/NixOS/nixpkgs/commit/e89b36e4cb63712fee149336db88a3a81fdf1038) | `Adding tips/searching section`                                   | `2021-08-25 00:02:06Z` |
| [`1b76da0c`](https://github.com/NixOS/nixpkgs/commit/1b76da0cad8f55550173de48a119a5cda3d2a75c) | `Minor corrections`                                               | `2021-08-25 00:02:06Z` |
| [`4431c8f9`](https://github.com/NixOS/nixpkgs/commit/4431c8f98e6270aca2e64cb010d08b0e8ff7f6b1) | `python3Packages.censys: 2.0.3 -> 2.0.5`                          | `2021-08-24 21:56:01Z` |
| [`749caaef`](https://github.com/NixOS/nixpkgs/commit/749caaef5bd6cfd2c843a4f2e9fc2d29952d2109) | `nixos/postfixadmin: fix eval & pin to PHP 7.4`                   | `2021-08-24 21:50:31Z` |
| [`52a65021`](https://github.com/NixOS/nixpkgs/commit/52a6502174b2d7cbdd29abf3c0faa2418b2c0cae) | `postfixadmin: stdenv.lib -> lib`                                 | `2021-08-24 21:50:31Z` |
| [`13a5d7dc`](https://github.com/NixOS/nixpkgs/commit/13a5d7dc23969053764af01bbd1ee905a55a15e1) | `release-notes: add postfixadmin module addition`                 | `2021-08-24 21:50:27Z` |
| [`9dabe2df`](https://github.com/NixOS/nixpkgs/commit/9dabe2df7247c2241e35cda861fc1d71fd9ce38a) | `postfixadmin: 3.3.9 -> 3.3.10`                                   | `2021-08-24 21:46:07Z` |
| [`8a0b6a42`](https://github.com/NixOS/nixpkgs/commit/8a0b6a42ee1b1199512a806d9c22617d7e09aeb1) | `postfixadmin: fix db owner`                                      | `2021-08-24 21:46:07Z` |
| [`862dd4ef`](https://github.com/NixOS/nixpkgs/commit/862dd4ef5800e12f175fa62a0d0f7b337e00561e) | `postfixadmin: review additions`                                  | `2021-08-24 21:46:06Z` |
| [`0eafc74d`](https://github.com/NixOS/nixpkgs/commit/0eafc74d503ffb6973676cb225d73c09c0fc1a39) | `postfixadmin: init at 3.3.9`                                     | `2021-08-24 21:46:06Z` |
| [`f62080e7`](https://github.com/NixOS/nixpkgs/commit/f62080e77bd36ddc3bbd94fc3e7d7bbdc4949d7c) | `python3Packages.plugwise: 0.12.0 -> 0.13.1`                      | `2021-08-24 21:20:01Z` |
| [`be85d393`](https://github.com/NixOS/nixpkgs/commit/be85d39388962a80d5225cc7b8e1fcdcc89f8095) | `python3Packages.fastapi: 0.68.0 -> 0.68.1`                       | `2021-08-24 21:02:18Z` |
| [`8b11f1a5`](https://github.com/NixOS/nixpkgs/commit/8b11f1a56f812765167aef4f283e26f99763d8c1) | `python3Packages.catalogue: 2.0.4 -> 2.0.6`                       | `2021-08-24 20:47:51Z` |
| [`9bec0bea`](https://github.com/NixOS/nixpkgs/commit/9bec0bea0ab80d3fc16829be95303dfd1d3b98fd) | `python3Packages.pybase64: switch to pytestCheckHook`             | `2021-08-24 20:26:55Z` |
| [`8440a517`](https://github.com/NixOS/nixpkgs/commit/8440a5175474f816b070f8b9bff3fb6e252c1e94) | `fluxcd: fix manifest hash`                                       | `2021-08-24 20:22:02Z` |
| [`f9dfb94b`](https://github.com/NixOS/nixpkgs/commit/f9dfb94bd2da77266824945ee621769cc97b9088) | `vpcs: remove myself as maintainer`                               | `2021-08-24 20:02:56Z` |
| [`d0dad3f5`](https://github.com/NixOS/nixpkgs/commit/d0dad3f519117db63fa2f101c47c7c8e206a294a) | `chromiumBeta: 93.0.4577.51 -> 93.0.4577.58`                      | `2021-08-24 19:58:07Z` |
| [`c55292c8`](https://github.com/NixOS/nixpkgs/commit/c55292c8739cb1c059262983133a09e7ebb65ec4) | `yalc: init at 1.0.0-pre.53`                                      | `2021-08-24 19:40:58Z` |
| [`4bb4bcc3`](https://github.com/NixOS/nixpkgs/commit/4bb4bcc30c7f481581ef462ed7b1dcca71693717) | `services.zfs.expandOnBoot: support expanding pools on boot`      | `2021-08-24 19:01:08Z` |
| [`6495d318`](https://github.com/NixOS/nixpkgs/commit/6495d3187dcec6876307da0874fe39566c650ac5) | `zola: 0.14.0 -> 0.14.1`                                          | `2021-08-24 18:56:41Z` |
| [`93ff5295`](https://github.com/NixOS/nixpkgs/commit/93ff529590ab250521d60fab91da66917bd5b09d) | `regexploit: init at 1.0.0`                                       | `2021-08-24 18:41:53Z` |
| [`016e8cf7`](https://github.com/NixOS/nixpkgs/commit/016e8cf78c8009f65d81fbd6c32b00803f3b1f3c) | `acpi_call: 1.2.1 -> 1.2.2`                                       | `2021-08-24 18:26:28Z` |
| [`0107caf1`](https://github.com/NixOS/nixpkgs/commit/0107caf17f822521b27f02e25aa363b69b85b2fa) | `python3Packages.dependency-injector: 4.34.0 -> 4.35.3`           | `2021-08-24 18:15:31Z` |
| [`c8ec6204`](https://github.com/NixOS/nixpkgs/commit/c8ec6204fe53cada5c5cc7ba5a210065745e37bd) | `ly: change maintainer to vidister`                               | `2021-08-24 17:54:47Z` |
| [`b6a5c45c`](https://github.com/NixOS/nixpkgs/commit/b6a5c45cc1f506a422ff237c44687fdff2f42bc1) | `radare2: link to upstream makefile for vector35-arch-arm64 hash` | `2021-08-24 17:41:34Z` |
| [`c9c30507`](https://github.com/NixOS/nixpkgs/commit/c9c30507bcb7f65be90853031fb4a5539d783f6d) | `python38Packages.pooch: 1.4.0 -> 1.5.1`                          | `2021-08-24 17:01:48Z` |
| [`2f1030b3`](https://github.com/NixOS/nixpkgs/commit/2f1030b3ade598afa5594bb519b49216561bbd10) | `matrix-synapse: 1.40.0 -> 1.41.0`                                | `2021-08-24 16:49:50Z` |
| [`517b0b0d`](https://github.com/NixOS/nixpkgs/commit/517b0b0d05f228de89781485b8f6362600731175) | `vpcs: 0.8.1 -> 0.8.2`                                            | `2021-08-24 16:41:27Z` |
| [`1a23b140`](https://github.com/NixOS/nixpkgs/commit/1a23b14062487aa3a8f4d81865cc0e349c002ce5) | `python3Packages.pysyncthru: 0.7.5 -> 0.7.7`                      | `2021-08-24 15:17:09Z` |
| [`b1d4c0ac`](https://github.com/NixOS/nixpkgs/commit/b1d4c0ac31690f9d423dd050832178699c55d1db) | `python3Packages.forecast-solar: 2.0.0 -> 2.1.0`                  | `2021-08-24 14:37:08Z` |
| [`ce2fd8d5`](https://github.com/NixOS/nixpkgs/commit/ce2fd8d5fe98b80c6866b6bcae0f7f884b3f852b) | `python3Packages.yeelight: 0.7.2 -> 0.7.3`                        | `2021-08-24 14:27:59Z` |
| [`0f95daf2`](https://github.com/NixOS/nixpkgs/commit/0f95daf2a4384f70098d6aabaf5c70c034e9b105) | `python3Packages.hy: init at 1.0a3`                               | `2021-08-24 14:19:35Z` |
| [`ceab0e92`](https://github.com/NixOS/nixpkgs/commit/ceab0e9292fb93bbd8f5dba2360332894a484a79) | `python38Packages.zarr: 2.8.3 -> 2.9.1`                           | `2021-08-24 14:05:31Z` |
| [`c9535833`](https://github.com/NixOS/nixpkgs/commit/c95358335af87b0a6f47049a9b1b2bad7df10a78) | `python3Packages.haversine: 2.3.1 -> 2.4.0`                       | `2021-08-24 14:04:50Z` |
| [`b71c5e58`](https://github.com/NixOS/nixpkgs/commit/b71c5e586e7a8bca6bc2c647b9131dc7fb209b43) | `python3Packages.yara-python: 4.1.0 -> 4.1.2`                     | `2021-08-24 14:02:25Z` |
| [`0caabc36`](https://github.com/NixOS/nixpkgs/commit/0caabc36af2336bbf5bcd4482c50190dff0bfba3) | `rust-analyzer-unwrapped: 2021-08-16 -> 2021-08-23`               | `2021-08-24 13:22:19Z` |
| [`0a077580`](https://github.com/NixOS/nixpkgs/commit/0a0775808ce12d353891bbf501d24dcff4a19df7) | `resvg: 0.15.0 -> 0.16.0`                                         | `2021-08-24 13:05:34Z` |
| [`6fd64ade`](https://github.com/NixOS/nixpkgs/commit/6fd64ade08adda164e8ecb8a2c15c3c9564981f2) | `yara: 4.1.1 -> 4.1.2`                                            | `2021-08-24 11:50:04Z` |
| [`3c8a0936`](https://github.com/NixOS/nixpkgs/commit/3c8a09364d993ee3e69521701c3df7fbcb6038da) | `home-assistant: allow serial access when using deconz`           | `2021-08-24 10:09:12Z` |
| [`5ebc1a05`](https://github.com/NixOS/nixpkgs/commit/5ebc1a0582593da76606a464550b2df3ce2a88c8) | `python38Packages.owslib: 0.24.1 -> 0.25.0`                       | `2021-08-24 09:44:47Z` |
| [`9724dcff`](https://github.com/NixOS/nixpkgs/commit/9724dcff6288e2d063c41890885014ca053672ed) | `mark: 6.0 -> 6.2`                                                | `2021-08-24 09:41:30Z` |
| [`ae904449`](https://github.com/NixOS/nixpkgs/commit/ae9044494a3df2e653f0579387a82a14cf7441ca) | `python3Packages.aioesphomeapi: 6.1.0 -> 7.0.0`                   | `2021-08-24 08:07:14Z` |
| [`59c2ffd5`](https://github.com/NixOS/nixpkgs/commit/59c2ffd586d4c9396fda8e796760d158c84e2987) | `python3Packages.staticjinja: switch to poetry-core`              | `2021-08-24 07:44:02Z` |
| [`76a5135b`](https://github.com/NixOS/nixpkgs/commit/76a5135b8e2d246700be37a566180b8888c0743b) | `tarsnapper: add meta`                                            | `2021-08-24 07:18:18Z` |
| [`5086f1dc`](https://github.com/NixOS/nixpkgs/commit/5086f1dc3308d13e7d7b9cd54a39879463d361fc) | `python38Packages.emcee: 3.1.0 -> 3.1.1`                          | `2021-08-24 05:17:16Z` |
| [`2e44dc9a`](https://github.com/NixOS/nixpkgs/commit/2e44dc9a9c3db63dabf6cfd19d2a82f869cdd2c6) | `google-cloud-sdk-gce: override python to 3.8`                    | `2021-08-24 04:51:43Z` |
| [`239b1d4d`](https://github.com/NixOS/nixpkgs/commit/239b1d4de2f9024c82955693fa541fd9d1533e48) | `python3Packages.pyezviz: 0.1.9.1 -> 0.1.9.2`                     | `2021-08-23 23:35:56Z` |
| [`77c4c522`](https://github.com/NixOS/nixpkgs/commit/77c4c522558dd46981c4b8853612609fdf32c4cc) | `python3Packages.pyftdi: 0.53.2 -> 0.53.3`                        | `2021-08-23 23:33:16Z` |
| [`1b965cd2`](https://github.com/NixOS/nixpkgs/commit/1b965cd21019a1e431bac68a7baa6b27778d111e) | `python3Packages.mutf8: init at 1.0.3`                            | `2021-08-23 23:30:04Z` |
| [`befe89f3`](https://github.com/NixOS/nixpkgs/commit/befe89f3d79848fcd15e9447ec5387aa69bbfc85) | `lean: 3.31.0 -> 3.32.1`                                          | `2021-08-23 22:43:00Z` |
| [`3692a0a3`](https://github.com/NixOS/nixpkgs/commit/3692a0a365a517d9009e7897447d3d208439ec84) | `python3Packages.pymyq: 3.1.2 -> 3.1.3`                           | `2021-08-23 22:34:53Z` |
| [`ac47659b`](https://github.com/NixOS/nixpkgs/commit/ac47659bde28ef2f9b600e9e1b0f4915d0340161) | `qgis: 3.16.9 → 3.16.10`                                          | `2021-08-23 21:47:39Z` |
| [`fc5bfd68`](https://github.com/NixOS/nixpkgs/commit/fc5bfd684498383bedaf8151c7103b34b2819b85) | `unbound: unify unbound and pyunbound source`                     | `2021-08-23 21:28:31Z` |
| [`2508d1e2`](https://github.com/NixOS/nixpkgs/commit/2508d1e2a56259fd44091cf9acffd7745a8d7267) | `beamPackages: Deduplicate default package set`                   | `2021-08-23 14:06:41Z` |
| [`914705b8`](https://github.com/NixOS/nixpkgs/commit/914705b89520b0dc43c316a8c527124d437075aa) | `beamPackages: Use nixpkgs fixed-point instead of rec`            | `2021-08-23 13:59:10Z` |
| [`982b1e61`](https://github.com/NixOS/nixpkgs/commit/982b1e61fa610d545e230462eb4dd106897f9074) | `python38Packages.xmlschema: 1.6.4 -> 1.7.0`                      | `2021-08-23 08:12:03Z` |
| [`4be13dc0`](https://github.com/NixOS/nixpkgs/commit/4be13dc00b88a451bf1115cd8e7d12daa5342e9e) | `python3Packages.pylev: 1.3.0 -> 1.4.0`                           | `2021-08-23 06:05:56Z` |
| [`223eadd6`](https://github.com/NixOS/nixpkgs/commit/223eadd6dc6f102064571fca3ef69a145e21e6e1) | `python38Packages.pyopencl: 2021.2.2 -> 2021.2.6`                 | `2021-08-23 06:05:36Z` |
| [`f0ed982c`](https://github.com/NixOS/nixpkgs/commit/f0ed982c2f445c4c8daa731f1db5340ca626fdf5) | `python38Packages.playsound: 1.2.2 -> 1.3.0`                      | `2021-08-23 05:36:18Z` |
| [`7e8aaf47`](https://github.com/NixOS/nixpkgs/commit/7e8aaf4775e551523f325d10f536557d55236778) | `imath: 3.0.5 -> 3.1.2`                                           | `2021-08-22 21:09:18Z` |
| [`0ee218ee`](https://github.com/NixOS/nixpkgs/commit/0ee218ee36529afcbb89eccc06a96ed7a71ae294) | `tfswitch: 0.12.1119 -> 0.12.1168`                                | `2021-08-22 18:49:40Z` |
| [`a5de25bd`](https://github.com/NixOS/nixpkgs/commit/a5de25bd3b90904ed6b148ecc34b3e956206153f) | `python38Packages.pybase64: 1.1.4 -> 1.2.0`                       | `2021-08-22 12:03:38Z` |
| [`977ee053`](https://github.com/NixOS/nixpkgs/commit/977ee05375b98d4e2561a5846512e9ee08b4772f) | `python38Packages.portalocker: 2.3.0 -> 2.3.1`                    | `2021-08-22 08:21:47Z` |
| [`67dd93e1`](https://github.com/NixOS/nixpkgs/commit/67dd93e1c60b2db8083939e7ffbfc2c1735d9cf2) | `tiledb: 2.2.4 -> 2.2.9`                                          | `2021-08-22 06:43:50Z` |
| [`637cad02`](https://github.com/NixOS/nixpkgs/commit/637cad02605bc54ad5648bfa6243ab9bf877a18e) | `python38Packages.pytest-mpl: 0.12 -> 0.13`                       | `2021-08-22 06:34:21Z` |
| [`42ee0e6c`](https://github.com/NixOS/nixpkgs/commit/42ee0e6c1edde4f004e77af6cb301fcdf2161570) | `libcouchbase: 3.2.0 -> 3.2.1`                                    | `2021-08-22 05:25:57Z` |
| [`02753974`](https://github.com/NixOS/nixpkgs/commit/02753974e0a57021355189dc1db03916a91003c3) | `python3Packages.pydmd: marked as broken at aarch64`              | `2021-08-21 17:56:26Z` |
| [`3dbd616b`](https://github.com/NixOS/nixpkgs/commit/3dbd616b0f04465e148491747f39624bf121e7da) | `python3Packages.pydmd: init at 0.3.3`                            | `2021-08-21 10:04:04Z` |
| [`0c52ee1a`](https://github.com/NixOS/nixpkgs/commit/0c52ee1a7a1a6ad97670f4d253a106f1b69e2efb) | `carla: 2.3.2 -> 2.4.0`                                           | `2021-08-20 19:26:35Z` |
| [`f8d1c8d4`](https://github.com/NixOS/nixpkgs/commit/f8d1c8d48b066de1e816b2c30a7ce73e201d70a5) | `buildbot: deprecate phases`                                      | `2021-08-18 11:40:15Z` |