### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7e700329073ffe012bae01dd8464f3e1cf4da102",
-        "sha256": "0sfzk8n108lr6brrasvzbk6p5rvy2823r29hp3vd0pb1njjj1mcw",
+        "rev": "73164006951cea087c822e02760d9a1473216110",
+        "sha256": "0b29rirlbmx6zcaslrdm69g2n2bbsjwjci5dmgxmdb2q5nb7wink",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/7e700329073ffe012bae01dd8464f3e1cf4da102.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/73164006951cea087c822e02760d9a1473216110.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                          | Timestamp              |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ---------------------- |
| [`73164006`](https://github.com/NixOS/nixpkgs/commit/73164006951cea087c822e02760d9a1473216110) | `python38Packages.scikit-hep-testdata: 0.4.6 -> 0.4.7`                  | `2021-08-27 19:20:59Z` |
| [`a8ec48a4`](https://github.com/NixOS/nixpkgs/commit/a8ec48a4c7d330ce57b5d0de3ad23876aa16369e) | `musescore: fix JACK output (#135740)`                                  | `2021-08-27 19:17:33Z` |
| [`6bb97886`](https://github.com/NixOS/nixpkgs/commit/6bb97886ad705096346e189952cb5d20e9b23ee8) | `llvmPackages_git: 2021-08-03 -> 2021-08-13`                            | `2021-08-27 18:14:28Z` |
| [`c97d75e8`](https://github.com/NixOS/nixpkgs/commit/c97d75e8e520a817dced6d5c569402315065b8ef) | `openipmi: fix collectd assertion`                                      | `2021-08-27 16:47:23Z` |
| [`d90b2fc2`](https://github.com/NixOS/nixpkgs/commit/d90b2fc264e4238eac6b8f2fe1e62c9f0759445e) | `linux-hardened: Fix update script`                                     | `2021-08-27 16:24:48Z` |
| [`4d8a8abb`](https://github.com/NixOS/nixpkgs/commit/4d8a8abb33a5872c009246f86e3d8cbbdd8a9801) | `linux/hardened/patches/5.4: 5.4.142-hardened1 -> 5.4.143-hardened1`    | `2021-08-27 16:24:08Z` |
| [`2c9124ef`](https://github.com/NixOS/nixpkgs/commit/2c9124efdba6769a0fa1285f046f7cb2d4e92c7c) | `linux/hardened/patches/5.13: init at 5.13.13-hardened1`                | `2021-08-27 16:24:08Z` |
| [`21140759`](https://github.com/NixOS/nixpkgs/commit/2114075986ac3653d5a83e1c693b84d7197e7176) | `linux/hardened/patches/5.10: 5.10.60-hardened1 -> 5.10.61-hardened1`   | `2021-08-27 16:24:08Z` |
| [`3e58b971`](https://github.com/NixOS/nixpkgs/commit/3e58b9716e563221fa66c1c17a16dd40adaca6a1) | `linux/hardened/patches/4.19: 4.19.204-hardened1 -> 4.19.205-hardened1` | `2021-08-27 16:24:08Z` |
| [`fec4358b`](https://github.com/NixOS/nixpkgs/commit/fec4358b1ee9c19d0b6b4dc5df63eb81cb8d5af7) | `linux/hardened/patches/4.14: 4.14.244-hardened1 -> 4.14.245-hardened1` | `2021-08-27 16:24:08Z` |
| [`ea89b8bc`](https://github.com/NixOS/nixpkgs/commit/ea89b8bc1f8a046edd5475471ba0ae8845adbf95) | `linux_latest-libre: 18239 -> 18260`                                    | `2021-08-27 16:24:08Z` |
| [`cc93163a`](https://github.com/NixOS/nixpkgs/commit/cc93163a9543c97e7f2775bbee3fb1a719d944a0) | `linux-rt_5_10: 5.10.56-rt49 -> 5.10.59-rt52`                           | `2021-08-27 16:24:08Z` |
| [`aeb198d7`](https://github.com/NixOS/nixpkgs/commit/aeb198d7ced73f236637322b6cd2894c5c902b26) | `linux: 5.4.142 -> 5.4.143`                                             | `2021-08-27 16:24:08Z` |
| [`198f0a0f`](https://github.com/NixOS/nixpkgs/commit/198f0a0f30e56992692e44a07f1817703120da69) | `linux: 5.13.12 -> 5.13.13`                                             | `2021-08-27 16:24:08Z` |
| [`6c457d29`](https://github.com/NixOS/nixpkgs/commit/6c457d29b8865344e07e2383b6fc1f3d31f27085) | `linux: 5.10.60 -> 5.10.61`                                             | `2021-08-27 16:24:08Z` |
| [`12ea01ba`](https://github.com/NixOS/nixpkgs/commit/12ea01bac9d989f7ac60bfbba1ffb099ccfb8362) | `linux: 4.9.280 -> 4.9.281`                                             | `2021-08-27 16:24:08Z` |
| [`770b3058`](https://github.com/NixOS/nixpkgs/commit/770b3058744d01afe5582dc4c9a84f8d1471ceab) | `linux: 4.4.281 -> 4.4.282`                                             | `2021-08-27 16:24:08Z` |
| [`500a91bf`](https://github.com/NixOS/nixpkgs/commit/500a91bf685c9c00b2d89634d800c84a395f6f4f) | `linux: 4.19.204 -> 4.19.205`                                           | `2021-08-27 16:24:08Z` |
| [`467e3a7a`](https://github.com/NixOS/nixpkgs/commit/467e3a7a8758b533147912c2b790ec5de93b4500) | `linux: 4.14.244 -> 4.14.245`                                           | `2021-08-27 16:24:08Z` |
| [`54197b57`](https://github.com/NixOS/nixpkgs/commit/54197b57b26aae15ec1add88f16ebe51a5e7daf2) | `python38Packages.msal: 1.13.0 -> 1.14.0`                               | `2021-08-27 16:20:53Z` |
| [`b4804fdf`](https://github.com/NixOS/nixpkgs/commit/b4804fdffe268d4051b3cf6999a7ff18ca6c5b7c) | `python38Packages.mautrix: 0.10.4 -> 0.10.5`                            | `2021-08-27 16:19:20Z` |
| [`af5ec6d6`](https://github.com/NixOS/nixpkgs/commit/af5ec6d616ab4d9af17becf8a1079fb8576c6bf4) | `wireshark: 3.4.7 -> 3.4.8`                                             | `2021-08-27 14:33:33Z` |
| [`032baedc`](https://github.com/NixOS/nixpkgs/commit/032baedc9777520ffdeaeac5bc3c378deef275f1) | `electron_11: 11.4.11 -> 11.4.12`                                       | `2021-08-27 14:16:43Z` |
| [`0e6f0724`](https://github.com/NixOS/nixpkgs/commit/0e6f0724c6dae128fa1e7ffcf34a8b4bc9e51aa6) | `electron_12: 12.0.16 -> 12.0.17`                                       | `2021-08-27 14:15:52Z` |
| [`f2e2b9d9`](https://github.com/NixOS/nixpkgs/commit/f2e2b9d98870706936613cad32ad5ee7228600f6) | `electron_13: 13.2.0 -> 13.2.2`                                         | `2021-08-27 14:14:39Z` |
| [`b49afb3f`](https://github.com/NixOS/nixpkgs/commit/b49afb3fe6096f6b2047dba6730c6f6b6d4c3473) | `signal-desktop: 5.14.0 -> 5.15.0`                                      | `2021-08-27 13:38:32Z` |
| [`33567bd3`](https://github.com/NixOS/nixpkgs/commit/33567bd3b329560b424c526f419539273f25b48f) | `ssh-audit: 2.4.0 -> 2.5.0`                                             | `2021-08-27 13:38:17Z` |
| [`9f01f3f2`](https://github.com/NixOS/nixpkgs/commit/9f01f3f2670a085420d0da4c8c39e5f0580e4945) | `intel-gmmlib: 21.2.1 -> 21.2.2`                                        | `2021-08-27 13:36:39Z` |
| [`a0eae3b8`](https://github.com/NixOS/nixpkgs/commit/a0eae3b8777f1d0d9e865a50fec1728bf279b009) | `headscale: 0.7.0 -> 0.7.1`                                             | `2021-08-27 13:06:04Z` |
| [`bc2cd871`](https://github.com/NixOS/nixpkgs/commit/bc2cd8712855d57df39a271d4e2fc32c19a9ad03) | `esbuild: 0.12.22 -> 0.12.23`                                           | `2021-08-27 12:59:36Z` |
| [`c765c1d6`](https://github.com/NixOS/nixpkgs/commit/c765c1d6955d9a450a005712906215ee3c0d2f25) | `ocamlPackages.ocaml-lsp: 1.5.0 -> 1.7.0`                               | `2021-08-27 11:38:37Z` |
| [`6ba20fa0`](https://github.com/NixOS/nixpkgs/commit/6ba20fa087be388c286bf439a69b95abafdbaa9c) | `ocamlPackages.pp: init at 1.1.2`                                       | `2021-08-27 11:38:37Z` |
| [`61ea3fe6`](https://github.com/NixOS/nixpkgs/commit/61ea3fe636a7ceaf0356e2b78a41f6587a46bf4d) | `ocamlPackages.rfc7748: init at 1.0`                                    | `2021-08-27 10:00:16Z` |
| [`843eebbd`](https://github.com/NixOS/nixpkgs/commit/843eebbd8e0a951e5c2c3f1cd2e17a39f6c08701) | `ocamlPackages.noise: init at 0.2.0`                                    | `2021-08-27 10:00:16Z` |
| [`dd37bf5d`](https://github.com/NixOS/nixpkgs/commit/dd37bf5d75fd1fbfc7e71d46c9db926909198eef) | `ocamlPackages.chacha: init at 1.0.0`                                   | `2021-08-27 10:00:16Z` |
| [`38927fac`](https://github.com/NixOS/nixpkgs/commit/38927fac53a02f233f294265e48cc2bcbd7b2667) | `ocamlPackages.callipyge: init at 0.2`                                  | `2021-08-27 10:00:16Z` |
| [`d945e55f`](https://github.com/NixOS/nixpkgs/commit/d945e55ffc55f2f3800239b7d1933fb338b05e5e) | `miniserve: 0.14.0 -> 0.15.0`                                           | `2021-08-27 09:11:47Z` |
| [`6f8fe2e5`](https://github.com/NixOS/nixpkgs/commit/6f8fe2e58b7ff1a6e5e2ed36dbaf76d3a576aae1) | `mob: 1.9.0 -> 1.10.0`                                                  | `2021-08-27 08:40:21Z` |
| [`d890b9b6`](https://github.com/NixOS/nixpkgs/commit/d890b9b6179199bf021ed0b3c1dbe0310b623992) | `kube-capacity: 0.6.0 -> 0.6.1`                                         | `2021-08-27 07:13:24Z` |
| [`1f7711f0`](https://github.com/NixOS/nixpkgs/commit/1f7711f0dd9d0a1163b5758038cafd324b274e81) | `python3Packages.anybadge: init at 1.7.0`                               | `2021-08-27 05:49:52Z` |
| [`93edf35c`](https://github.com/NixOS/nixpkgs/commit/93edf35cc57d6aeedf452ace674c457269d8fb8e) | `python38Packages.itemadapter: 0.3.0 -> 0.4.0`                          | `2021-08-27 05:07:59Z` |
| [`5e7145ff`](https://github.com/NixOS/nixpkgs/commit/5e7145ff0f85f7de37190106cca2de1d1c144265) | `disfetch: 2.14 -> 2.15`                                                | `2021-08-27 03:00:18Z` |
| [`a2672543`](https://github.com/NixOS/nixpkgs/commit/a267254318933eb62336cff468f4c1d642503f11) | `chamber: 2.10.2 -> 2.10.3`                                             | `2021-08-27 01:51:56Z` |
| [`e1816fe4`](https://github.com/NixOS/nixpkgs/commit/e1816fe41f4c0511dbd27d44855a53a1366d51cf) | `python3Packages.databases: 0.4.3 -> 0.5.0`                             | `2021-08-26 17:17:36Z` |
| [`db2f3345`](https://github.com/NixOS/nixpkgs/commit/db2f3345f44688a40b0d8db5aaeb44b9fbd037a4) | `home-assistant: unpin ring-doorbell`                                   | `2021-08-26 16:58:18Z` |
| [`64c693ae`](https://github.com/NixOS/nixpkgs/commit/64c693aebf45d3dfaafc0d429c640758259b7a3c) | `python3Packages.ring-doorbell: 0.7.0 -> 0.7.1`                         | `2021-08-26 15:56:19Z` |
| [`5ab6a61a`](https://github.com/NixOS/nixpkgs/commit/5ab6a61ada45e9d2299869cbef15a7416de46a06) | `vorta: 0.7.7 -> 0.7.8`                                                 | `2021-08-26 10:38:04Z` |
| [`241d8155`](https://github.com/NixOS/nixpkgs/commit/241d81556f153a87a999ea53edeeed454e550f60) | `infracost: 0.9.5 -> 0.9.6`                                             | `2021-08-26 07:19:51Z` |
| [`a8f5a5ec`](https://github.com/NixOS/nixpkgs/commit/a8f5a5ec02bc56fb8bda4cc5c5002bc3596eada0) | `ttyper: init at 0.2.5`                                                 | `2021-08-25 23:34:38Z` |
| [`7442367e`](https://github.com/NixOS/nixpkgs/commit/7442367e582b286401f1c87d535d649c8595651e) | `terragrunt: 0.31.5 -> 0.31.7`                                          | `2021-08-25 14:05:22Z` |
| [`5e053d9d`](https://github.com/NixOS/nixpkgs/commit/5e053d9d79db15703fe26c76460efb3fa6328ab8) | `terraform-ls: 0.20.1 -> 0.21.0`                                        | `2021-08-24 09:14:33Z` |