### PR TITLE
chore(deps): update sops-nix

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "0d4bdc1c21b96462ecd7b93564369f6ff900bd83",
-        "sha256": "1q1i2741fq2g6zib31ssfas6xlqll0mnd8nlpfxqq7winv2gnwrs",
+        "rev": "024c079aa1fb582068b79138597ac41f4f3ce799",
+        "sha256": "0496jpyj81048pc1fn1v61xqw357b0hwmv06d6r2bcfxg2a6fcvi",
         "type": "tarball",
-        "url": "https://github.com/Mic92/sops-nix/archive/0d4bdc1c21b96462ecd7b93564369f6ff900bd83.tar.gz",
+        "url": "https://github.com/Mic92/sops-nix/archive/024c079aa1fb582068b79138597ac41f4f3ce799.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                            | Timestamp              |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------- | ---------------------- |
| [`1029f6e0`](https://github.com/Mic92/sops-nix/commit/1029f6e0c98d6133e302a9e881c3f85034ef511e) | `workflow: Update nixos channel to 21.05` | `2021-08-28 10:06:18Z` |
| [`9b4eade5`](https://github.com/Mic92/sops-nix/commit/9b4eade56593f91e6d908f044284c494a975aefa) | `Add aarch64-darwin to supported systems` | `2021-08-28 05:04:18Z` |