### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "73164006951cea087c822e02760d9a1473216110",
-        "sha256": "0b29rirlbmx6zcaslrdm69g2n2bbsjwjci5dmgxmdb2q5nb7wink",
+        "rev": "b769bd2b01bce5afe0af703218593355c6f52337",
+        "sha256": "1ngsl0acsym0srsirf0c118v02s2c7mxzisha3l3665znqd7fmjq",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/73164006951cea087c822e02760d9a1473216110.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/b769bd2b01bce5afe0af703218593355c6f52337.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| [`ac0b44b1`](https://github.com/NixOS/nixpkgs/commit/ac0b44b1eea909a45e332aa3ed266dea0bd0a125) | `dcmtk: support darwin platform (#136005)`                         | `2021-08-28 06:00:18Z` |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ---------------------- |
| [`b2b0115e`](https://github.com/NixOS/nixpkgs/commit/b2b0115e70003e0070a50a1e0217a43c7e081588) | `Revert "openssl: 1.1.1k -> 1.1.1l" (#135999)`                     | `2021-08-28 03:36:39Z` |
| [`9bd880fa`](https://github.com/NixOS/nixpkgs/commit/9bd880fa7258900cb13bc60b60e441189846bf0f) | `linux_xanmod: 5.13.12 -> 5.13.13`                                 | `2021-08-28 01:54:20Z` |
| [`f58cfd33`](https://github.com/NixOS/nixpkgs/commit/f58cfd33c2e6ba5ccc5fd53ce5f53ee19c73faae) | `python38Packages.aiolifx: 0.6.9 -> 0.6.10`                        | `2021-08-28 01:14:08Z` |
| [`b0daf8fb`](https://github.com/NixOS/nixpkgs/commit/b0daf8fb06497da6b3bc0259d4d93617fe81bdfe) | `remarshal: use toPythonApplication (#135897)`                     | `2021-08-28 01:01:48Z` |
| [`e2e44d9b`](https://github.com/NixOS/nixpkgs/commit/e2e44d9b5c6bf84b89d2f5bb7145e95923aa43f4) | `bear: fix on x86_64-darwin`                                       | `2021-08-28 00:22:27Z` |
| [`174868d4`](https://github.com/NixOS/nixpkgs/commit/174868d4fa8452c0dc7ebcaf5548376351fa280a) | `openssl: 1.1.1k -> 1.1.1l`                                        | `2021-08-28 00:21:11Z` |
| [`c0c88243`](https://github.com/NixOS/nixpkgs/commit/c0c88243ee64e4fd5bbedf3c79f411f0b942880c) | `gnome.simple-scan: 40.0 -> 40.1`                                  | `2021-08-28 00:04:32Z` |
| [`7f59b0a9`](https://github.com/NixOS/nixpkgs/commit/7f59b0a98cbd0598fe6cf8eb838e29e2d95093d3) | `gdu: 5.6.0 -> 5.6.2`                                              | `2021-08-27 23:00:23Z` |
| [`f34c35c6`](https://github.com/NixOS/nixpkgs/commit/f34c35c6dc5f5cae9a86bc22920dc69440bda229) | `cloudlist: init at 0.0.1`                                         | `2021-08-27 22:16:39Z` |
| [`7e3bf56a`](https://github.com/NixOS/nixpkgs/commit/7e3bf56a0887d158841b8c09e90357462f9bca3e) | `vault: 1.8.1 -> 1.8.2`                                            | `2021-08-27 21:54:18Z` |
| [`5a4d7fc3`](https://github.com/NixOS/nixpkgs/commit/5a4d7fc3fb7a6a470a2b7aee521f087096a958d5) | `sudo: 1.9.7 -> 1.9.7p2`                                           | `2021-08-27 21:53:51Z` |
| [`999f55ee`](https://github.com/NixOS/nixpkgs/commit/999f55ee01390f5d455662e48067de68ab6260bb) | `bear: unbreak on aarch64-darwin`                                  | `2021-08-27 21:30:51Z` |
| [`08b86004`](https://github.com/NixOS/nixpkgs/commit/08b86004a2b671a4e51d8d4b8f4cb6c54ada23b9) | `mucommander: unbreak on darwin`                                   | `2021-08-27 21:29:25Z` |
| [`861350f6`](https://github.com/NixOS/nixpkgs/commit/861350f65bebd7ad8b15fc6dfe5c0d3137ff04a6) | `discord-canary: 0.0.126 -> 0.0.128`                               | `2021-08-27 21:22:22Z` |
| [`3ef54d20`](https://github.com/NixOS/nixpkgs/commit/3ef54d2032dda4e3c7c1cd26f4456d11fe6d129f) | `terminal-colors: init at 3.0.1`                                   | `2021-08-27 21:10:05Z` |
| [`1a9ec741`](https://github.com/NixOS/nixpkgs/commit/1a9ec74169199eab3442808e2727aabc47c65af1) | `diffoscope: 181 -> 182`                                           | `2021-08-27 21:07:47Z` |
| [`ff2e5a6d`](https://github.com/NixOS/nixpkgs/commit/ff2e5a6d3cdb6b0bad0fdf62477cef910e0d4aac) | `dutree: fix darwin build`                                         | `2021-08-27 20:59:36Z` |
| [`3da886bf`](https://github.com/NixOS/nixpkgs/commit/3da886bf41981dcb541a0d98761cd69c0860cf92) | `treewide: remove ma27 from the maintainer-list of a few packages` | `2021-08-27 20:28:49Z` |
| [`176705c2`](https://github.com/NixOS/nixpkgs/commit/176705c2953c17d6f7c703745d926c053e59e9f1) | `vintagestory: init at 1.15.5`                                     | `2021-08-27 20:13:13Z` |
| [`1cb0ebd2`](https://github.com/NixOS/nixpkgs/commit/1cb0ebd2e25fa7160c204812f7ac47877c5190e5) | `c2ffi: unstable-2021-04-15 -> unstable-2021-06-15`                | `2021-08-27 19:49:53Z` |
| [`04fa5e85`](https://github.com/NixOS/nixpkgs/commit/04fa5e852a0c467cfa29dce74500705ed5d21e0c) | `chromiumDev: 94.0.4606.20 -> 95.0.4621.4`                         | `2021-08-27 18:48:18Z` |
| [`33a4dae9`](https://github.com/NixOS/nixpkgs/commit/33a4dae995e39360da9b70024da3e1267318ff84) | `chromiumBeta: 93.0.4577.58 -> 94.0.4606.20`                       | `2021-08-27 18:48:00Z` |
| [`8ad3441f`](https://github.com/NixOS/nixpkgs/commit/8ad3441f2d1c50f02f4d1326502a64d8f2bd5fb8) | `exodus: fix the desktop file patch`                               | `2021-08-27 16:18:41Z` |
| [`3dd17ae2`](https://github.com/NixOS/nixpkgs/commit/3dd17ae22f17fb2f5f3bcf99437fe899d727beac) | `gitlab: Enable puma's systemd notify support`                     | `2021-08-27 15:38:40Z` |
| [`8a2c51a1`](https://github.com/NixOS/nixpkgs/commit/8a2c51a15fe0ee831880490f2e3245d9dcef830f) | `python3Packages.simplisafe-python: 11.0.4 -> 11.0.5`              | `2021-08-27 14:20:57Z` |
| [`a241fee9`](https://github.com/NixOS/nixpkgs/commit/a241fee93a04633269a715f568e3a1015b29c674) | `python38Packages.wurlitzer: 2.1.1 -> 3.0.2`                       | `2021-08-27 09:26:38Z` |
| [`de81edf6`](https://github.com/NixOS/nixpkgs/commit/de81edf6ef023d45d32c024d8be272d0d2eb343b) | `lib/strings: fix infinite recursion on concatStringsSep fallback` | `2021-08-27 00:08:05Z` |
| [`7e6a2d6b`](https://github.com/NixOS/nixpkgs/commit/7e6a2d6b1fc3b784bf16c884ec01e3d7c8fd2720) | `python3Packages.aiorecollect: 1.0.7 -> 1.0.8`                     | `2021-08-26 22:29:13Z` |
| [`3bce5c2f`](https://github.com/NixOS/nixpkgs/commit/3bce5c2f415bfb98d791c8c9985695e14a878bc3) | `shepherd: init at 1.14.1`                                         | `2021-08-26 20:02:02Z` |
| [`99387372`](https://github.com/NixOS/nixpkgs/commit/99387372d5af951fa7ab1cad970b7bef83b6b91c) | `gitlab: 14.1.2 -> 14.2.1`                                         | `2021-08-26 17:01:22Z` |
| [`93d02516`](https://github.com/NixOS/nixpkgs/commit/93d02516bf150ca40747d4530af5a66e1b61e643) | `librepo: 1.13.0 -> 1.14.2`                                        | `2021-08-26 08:52:31Z` |
| [`bf27bf09`](https://github.com/NixOS/nixpkgs/commit/bf27bf09092a7d4a50ff3d340d15ef21966905e0) | `waifu2x-converter-cpp: Enable build on Darwin`                    | `2021-08-26 00:14:13Z` |
| [`4f5bc22a`](https://github.com/NixOS/nixpkgs/commit/4f5bc22ad7634b72c71b4795bec496f7a8544d6b) | `waifu2x-converter-cpp: Remove obsolete patch`                     | `2021-08-26 00:01:24Z` |
| SHA256                                                                                         | Commit Message                                                     | Timestamp              |