### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b769bd2b01bce5afe0af703218593355c6f52337",
-        "sha256": "1ngsl0acsym0srsirf0c118v02s2c7mxzisha3l3665znqd7fmjq",
+        "rev": "0f157df1a38b862ff52340f61a96c0aa0a5ea461",
+        "sha256": "1cv3y3zy81k9c0nhwzzqds2h35s92cxwb2g5dr50s0pbryr0fqrn",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/b769bd2b01bce5afe0af703218593355c6f52337.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/0f157df1a38b862ff52340f61a96c0aa0a5ea461.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                           | Timestamp              |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ---------------------- |
| [`4fecb8b2`](https://github.com/NixOS/nixpkgs/commit/4fecb8b2d0c31caf963a35b4525b4a884adecec9) | `nixos/airsonic: make path to war file and jre configurable (#135709)`                   | `2021-08-28 18:26:03Z` |
| [`e2551a69`](https://github.com/NixOS/nixpkgs/commit/e2551a696b32560164388d9e6b4a5b828cd25575) | `charge-lnd: 0.2.2 -> 0.2.3`                                                             | `2021-08-28 16:50:51Z` |
| [`93462299`](https://github.com/NixOS/nixpkgs/commit/934622990298da37d08e89f62094e4c747cb1037) | `inferno: init at 0.10.6`                                                                | `2021-08-28 12:38:51Z` |
| [`2784f1bd`](https://github.com/NixOS/nixpkgs/commit/2784f1bd6908b37ed0d686778f347e63692c0f84) | `pkgsMusl.python*: disable LTO`                                                          | `2021-08-28 12:28:12Z` |
| [`33359f51`](https://github.com/NixOS/nixpkgs/commit/33359f518b3e9254889fdbebca3be5509541f140) | `esbuild: 0.12.23 -> 0.12.24`                                                            | `2021-08-28 12:22:12Z` |
| [`420ae3f0`](https://github.com/NixOS/nixpkgs/commit/420ae3f0410b836e922bced1e9f1808be07c6727) | `racket: 8.1 -> 8.2`                                                                     | `2021-08-28 12:05:30Z` |
| [`e0b89aff`](https://github.com/NixOS/nixpkgs/commit/e0b89affa04465a31c8564b49518a2eaad95573f) | `haskellPackages: fix ghc build on aarch64-darwin`                                       | `2021-08-28 10:54:06Z` |
| [`236fd9c9`](https://github.com/NixOS/nixpkgs/commit/236fd9c90262fcbdcbedb9ee580a0473c79315c7) | `darwin.signingUtils: move signDarwinBinariesIn from fixupOutputHooks to postFixupHooks` | `2021-08-28 10:54:05Z` |
| [`3e9661ce`](https://github.com/NixOS/nixpkgs/commit/3e9661ce7f0622411169b7551b3617feec72a687) | `libguestfs: change license to gpl2Plus and lgpl21Plus`                                  | `2021-08-28 10:53:44Z` |
| [`9c442fa9`](https://github.com/NixOS/nixpkgs/commit/9c442fa9014640a0dcc771635db6cc93f6c8f0f2) | `libguestfs: enable strictDeps`                                                          | `2021-08-28 10:53:44Z` |
| [`07c31956`](https://github.com/NixOS/nixpkgs/commit/07c3195664eaf0d927965ef75e850bcdb0b550db) | `libguestfs: 1.40.2 -> 1.44.1`                                                           | `2021-08-28 10:53:44Z` |
| [`21482724`](https://github.com/NixOS/nixpkgs/commit/21482724329dc52a307a3808a9ef5265a6e7b29e) | `nixos/paperless-ng: fix web file upload`                                                | `2021-08-28 10:22:52Z` |
| [`c7cccc55`](https://github.com/NixOS/nixpkgs/commit/c7cccc55fe2fb39761ce6427294a102af865971a) | `python38Packages.ntc-templates: 2.2.2 -> 2.3.0`                                         | `2021-08-28 10:12:03Z` |
| [`cc11b48a`](https://github.com/NixOS/nixpkgs/commit/cc11b48a1e904ac200542f92a06f2158b73e6317) | `exploitdb: 2021-08-24 -> 2021-08-28`                                                    | `2021-08-28 09:51:47Z` |
| [`9bd51f0d`](https://github.com/NixOS/nixpkgs/commit/9bd51f0db9773c2ccec9964a25c2af4745888875) | `nix-prefetch-git: add fetchLFS flag to the JSON output`                                 | `2021-08-28 08:14:48Z` |
| [`2d2d5ce3`](https://github.com/NixOS/nixpkgs/commit/2d2d5ce304316663a5de645b4d76f8ae816337af) | `nix-prefetch-git: add git-lfs dependency`                                               | `2021-08-28 08:14:48Z` |
| [`f43829a1`](https://github.com/NixOS/nixpkgs/commit/f43829a1d809722340157dbe8f1e7fd6be48070e) | `nix-prefetch-git: provide fallback for $TMPDIR`                                         | `2021-08-28 08:14:48Z` |
| [`4e04f84a`](https://github.com/NixOS/nixpkgs/commit/4e04f84aacea7760d97a244a03c999d379081875) | `tfsec: 0.58.4 -> 0.58.5`                                                                | `2021-08-28 07:48:57Z` |
| [`8d9814b4`](https://github.com/NixOS/nixpkgs/commit/8d9814b4d082a42b33dcdd46deeed46ba98379e0) | `python3Packages.tldextract: 3.1.0 -> 3.1.1`                                             | `2021-08-28 07:34:15Z` |
| [`f108efaa`](https://github.com/NixOS/nixpkgs/commit/f108efaa01d5fd6b7c984c46f7e82aa0fa67b4a6) | `python38Packages.internetarchive: 2.0.3 -> 2.1.0`                                       | `2021-08-28 05:18:39Z` |
| [`4ca57d82`](https://github.com/NixOS/nixpkgs/commit/4ca57d8219b4ffca43a5b0f1ed2e957cc7c03dc9) | `scid-vs-pc: 4.21 -> 4.22`                                                               | `2021-08-28 00:15:09Z` |
| [`0a7137a2`](https://github.com/NixOS/nixpkgs/commit/0a7137a2dfe05ba080381fb8e4f311b43c534a01) | `yt-dlp: use PyPI tarball`                                                               | `2021-08-28 00:04:20Z` |
| [`601751a7`](https://github.com/NixOS/nixpkgs/commit/601751a7b6d9620207878e2cd9ede3034ed533a1) | `yq-go: 4.12.0 -> 4.12.1`                                                                | `2021-08-27 22:44:53Z` |
| [`6642509b`](https://github.com/NixOS/nixpkgs/commit/6642509bac4ca9d85f9c6a9fe0f41379e2dbc24b) | `stm32flash: 0.5 -> 0.6`                                                                 | `2021-08-27 22:18:04Z` |
| [`bac15390`](https://github.com/NixOS/nixpkgs/commit/bac15390f5dbe8072b7acc77329e68a9fdfb5758) | `llvmPackages_13: 13.0.0-rc1 -> 13.0.0-rc2`                                              | `2021-08-27 22:00:47Z` |
| [`c77d8396`](https://github.com/NixOS/nixpkgs/commit/c77d83960cef37f11b43f8e23ac15d27312b1d33) | `nextcloud-client: 3.3.1 -> 3.3.2`                                                       | `2021-08-26 17:08:38Z` |
| [`b0d9437c`](https://github.com/NixOS/nixpkgs/commit/b0d9437ce506034946e539a8892d49893b6895c3) | `sensu-go-backend: 6.2.7 -> 6.4.1`                                                       | `2021-08-26 13:27:14Z` |
| [`d1d6f694`](https://github.com/NixOS/nixpkgs/commit/d1d6f694677e2b56f223aea37be56d2b51607e42) | `goreleaser: 0.175.0 -> 0.176.0`                                                         | `2021-08-26 05:56:56Z` |
| [`02c5e517`](https://github.com/NixOS/nixpkgs/commit/02c5e5173f459fcbccc5e06a33761ee94ebfec25) | `haskellPackages: introduce ghc8105Binary to enable aarch64-darwin bootstrap`            | `2021-08-24 16:49:25Z` |