### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0f157df1a38b862ff52340f61a96c0aa0a5ea461",
-        "sha256": "1cv3y3zy81k9c0nhwzzqds2h35s92cxwb2g5dr50s0pbryr0fqrn",
+        "rev": "9a5c4b119d7717bc9a418ccf7fbfb9d32bb9b326",
+        "sha256": "1sc8800fvd69av57kmz3j2qmz2d2zrlc7waajb0mgxqv9m9726yp",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/0f157df1a38b862ff52340f61a96c0aa0a5ea461.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/9a5c4b119d7717bc9a418ccf7fbfb9d32bb9b326.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                        | Timestamp              |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ---------------------- |
| [`ad4883cb`](https://github.com/NixOS/nixpkgs/commit/ad4883cb96307bcf5094cbbae761411743ebb8a4) | `gnucash: Add patch that fixes enableDebugging gnucash`               | `2021-08-29 06:28:51Z` |
| [`186315de`](https://github.com/NixOS/nixpkgs/commit/186315def77d62b53ad6ccdf57ec9593edbe8bc3) | `chromium: Move the version helper functions into default.nix`        | `2021-08-28 21:27:55Z` |
| [`00e380f1`](https://github.com/NixOS/nixpkgs/commit/00e380f1be5f393b7ea8ec9848d89284dd5254ce) | `llvmPackages/update.sh: Support LLVM 13+`                            | `2021-08-28 20:55:08Z` |
| [`680c2e60`](https://github.com/NixOS/nixpkgs/commit/680c2e60c9cf5d0bbeb81a31cfec2ca0c77b903a) | `llvm/update-git.py: Automatically commit the changes`                | `2021-08-28 20:54:31Z` |
| [`4f9e77d1`](https://github.com/NixOS/nixpkgs/commit/4f9e77d17cfb4fb9f93bdc7db92763771c3ededb) | `dnsproxy: 0.39.2 -> 0.39.4`                                          | `2021-08-28 03:09:52Z` |
| [`f8f60445`](https://github.com/NixOS/nixpkgs/commit/f8f60445d97a3d510192559fe03fbd2190fed4ca) | `cloudflared: 2021.8.3 -> 2021.8.6`                                   | `2021-08-28 02:05:31Z` |
| [`ff3aa121`](https://github.com/NixOS/nixpkgs/commit/ff3aa121fdcb16c29374a924714f03e32f56181d) | `simgear: 2020.3.8 -> 2020.3.11`                                      | `2021-08-28 00:22:39Z` |
| [`7a9526d4`](https://github.com/NixOS/nixpkgs/commit/7a9526d433c35e515b7692904f51a3e733842374) | `sentry-cli: fix build on Darwin`                                     | `2021-08-28 00:04:20Z` |
| [`1d9b5a62`](https://github.com/NixOS/nixpkgs/commit/1d9b5a62e01fad75e5473aea3d86c506ba6c59ba) | `elvish: 0.16.1 -> 0.16.3`                                            | `2021-08-28 00:04:20Z` |
| [`081d39ee`](https://github.com/NixOS/nixpkgs/commit/081d39eee2a7a497069512857cc200384515cc5e) | `ncspot: 0.8.1 -> 0.8.2`                                              | `2021-08-28 00:04:20Z` |
| [`eaeb4fe0`](https://github.com/NixOS/nixpkgs/commit/eaeb4fe04ee5a5ffae4f7dc03d3f072d59d80337) | `nixos/nextcloud: remove invalid `--database-table-prefix` option`    | `2021-08-27 18:21:25Z` |
| [`bae65a3c`](https://github.com/NixOS/nixpkgs/commit/bae65a3c06ae03c17edc91be35bfbf067d27ed23) | `nixos/mautrix-telegram: loosen umask to keep `config.json` writable` | `2021-08-27 09:41:30Z` |
| [`e4591b39`](https://github.com/NixOS/nixpkgs/commit/e4591b39178324c7881239904bb45b99ee3536c2) | `mu: add chvp as maintainer`                                          | `2021-08-27 07:46:59Z` |
| [`6e3451a6`](https://github.com/NixOS/nixpkgs/commit/6e3451a6a8219ded3f124fc1a7d9e63cdc70d28e) | `mu: 1.6.4 -> 1.6.5`                                                  | `2021-08-27 07:45:06Z` |
| [`41564319`](https://github.com/NixOS/nixpkgs/commit/41564319a1ee3b2a0ff009c4fe5d300d621e0f9a) | `python38Packages.dropbox: 11.16.0 -> 11.18.0`                        | `2021-08-27 03:26:46Z` |
| [`d90ad10b`](https://github.com/NixOS/nixpkgs/commit/d90ad10b3b069a030d21005972a4ea42c37ec925) | `cjson: 1.7.14 -> 1.7.15`                                             | `2021-08-26 02:09:58Z` |
| [`b0483dff`](https://github.com/NixOS/nixpkgs/commit/b0483dff7550760e072f760d4053310cca6723f8) | `libquotient: 0.6.7 -> 0.6.8`                                         | `2021-08-25 08:10:08Z` |
| [`a8ee4659`](https://github.com/NixOS/nixpkgs/commit/a8ee46597c6caa9eb1ba1703151eb390052bf083) | `wlc: 1.11 -> 1.12`                                                   | `2021-08-25 03:43:02Z` |
| [`701cce0f`](https://github.com/NixOS/nixpkgs/commit/701cce0f84445fbe41d79a97b941338294c5dc4f) | `buf: 0.51.1 -> 0.52.0`                                               | `2021-08-24 12:59:00Z` |
| [`1ecaf6d1`](https://github.com/NixOS/nixpkgs/commit/1ecaf6d1619fb14be3c630c12328a383507ad50b) | `joker: 0.17.1 -> 0.17.2`                                             | `2021-08-24 07:12:15Z` |
| [`c326a3f3`](https://github.com/NixOS/nixpkgs/commit/c326a3f39f0ddbde7de1d9bc20b167444e6d392a) | `stripe-cli: 1.5.12 -> 1.7.0`                                         | `2021-08-22 06:37:45Z` |
| [`d5b697b1`](https://github.com/NixOS/nixpkgs/commit/d5b697b1a47a46caa9b815d5bbe86f1febf147d6) | `sentry-cli: 1.66.0 -> 1.68.0`                                        | `2021-08-17 23:11:35Z` |
| [`94d837e3`](https://github.com/NixOS/nixpkgs/commit/94d837e3cbad9fdb230463c010e40f97adf0e655) | `go-tools: 2021.1 -> 2021.1.1`                                        | `2021-08-17 05:42:44Z` |