### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9a5c4b119d7717bc9a418ccf7fbfb9d32bb9b326",
-        "sha256": "1sc8800fvd69av57kmz3j2qmz2d2zrlc7waajb0mgxqv9m9726yp",
+        "rev": "75c8d45096ef362276d7c4ee470745419392c3ed",
+        "sha256": "0wqhsqacmzjqp72rpgvwsf7c8rlfyv5lgnp98834rgsp0h3ljmxc",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/9a5c4b119d7717bc9a418ccf7fbfb9d32bb9b326.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/75c8d45096ef362276d7c4ee470745419392c3ed.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                          | Timestamp              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------- | ---------------------- |
| [`9e8fcb01`](https://github.com/NixOS/nixpkgs/commit/9e8fcb0184170a97b4d0a933783bd7c83aff2ab2) | `nixos/fonts: fixup dd38ae1f`                           | `2021-08-29 09:03:13Z` |
| [`3d245b3a`](https://github.com/NixOS/nixpkgs/commit/3d245b3a377b0a91f1be6f819b77cc04cbf24a7d) | `Revert "Revert "openssl: 1.1.1k -> 1.1.1l" (#135999)"` | `2021-08-28 14:58:44Z` |
| [`b8c5c06a`](https://github.com/NixOS/nixpkgs/commit/b8c5c06aab9e84ba9304b2016428a1d4df4dc512) | `snakemake: 6.6.1 -> 6.7.0`                             | `2021-08-28 06:18:38Z` |