### PR TITLE
chore(deps): update sops-nix

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "024c079aa1fb582068b79138597ac41f4f3ce799",
-        "sha256": "0496jpyj81048pc1fn1v61xqw357b0hwmv06d6r2bcfxg2a6fcvi",
+        "rev": "3e4ebc851c91d1ce5c65da23436726c555a0d7e8",
+        "sha256": "0mpzkjvw2vyd6mf5hx6naic3sbhiwj1n6v5j94bm31marm8d2adq",
         "type": "tarball",
-        "url": "https://github.com/Mic92/sops-nix/archive/024c079aa1fb582068b79138597ac41f4f3ce799.tar.gz",
+        "url": "https://github.com/Mic92/sops-nix/archive/3e4ebc851c91d1ce5c65da23436726c555a0d7e8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                         | Timestamp              |
| ----------------------------------------------------------------------------------------------- | -------------------------------------- | ---------------------- |
| [`4919735a`](https://github.com/Mic92/sops-nix/commit/4919735a5ef8ffd735d40c6c27c0b717a2c7ab5a) | `fork sops with new openpgp library`   | `2021-08-29 16:20:30Z` |
| [`419e21b8`](https://github.com/Mic92/sops-nix/commit/419e21b80fc356dbf7fc2ca63667c1e9c3b2fa7a) | `Adding logo (#112)`                   | `2021-08-29 14:04:06Z` |
| [`3e2aefbc`](https://github.com/Mic92/sops-nix/commit/3e2aefbc619cabda04a23746430e9f7a61d5cd87) | `switch to maintained openpgp library` | `2021-08-29 13:24:07Z` |