### PR TITLE
chore(deps): update home-manager

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "33db7cc6a66d1c1cb77c23ae8e18cefd0425a0c8",
-        "sha256": "0c389qdjjz5a3afyy06q09gal22hi46s0w07dd9d7bpvpfsnk6dp",
+        "rev": "61ca2fc1c00a275b8bd61582b23195d60fe0fa40",
+        "sha256": "10pnnpikq9yikvkzfsap172wsi2h207camv1n5myr8f22qmw1vgm",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/33db7cc6a66d1c1cb77c23ae8e18cefd0425a0c8.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/61ca2fc1c00a275b8bd61582b23195d60fe0fa40.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixos-hardware": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                          | Timestamp              |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- | ---------------------- |
| [`61ca2fc1`](https://github.com/nix-community/home-manager/commit/61ca2fc1c00a275b8bd61582b23195d60fe0fa40) | `mcfly: switch to init command (#2301)` | `2021-08-30 03:42:54Z` |