### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8a56ac5db3e83a1e19bbe3a696cab83c6f21c359",
-        "sha256": "1mpapzbql4cv80sksfwb5dlqq9d49s58qgad8nqp85fa49422qz8",
+        "rev": "075a6f16c0c67a97d4c81d9e90b6e5a3addf7503",
+        "sha256": "0cr4lh4qk1p1hx2wixhsn0yskfr5k3h10nild66gv1qk8f3xszj1",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/8a56ac5db3e83a1e19bbe3a696cab83c6f21c359.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/075a6f16c0c67a97d4c81d9e90b6e5a3addf7503.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                         | Timestamp              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------ | ---------------------- |
| [`075a6f16`](https://github.com/NixOS/nixpkgs/commit/075a6f16c0c67a97d4c81d9e90b6e5a3addf7503) | `tar2ext4: 0.8.20 -> 0.8.21`                           | `2021-08-31 11:02:17Z` |
| [`9de959a0`](https://github.com/NixOS/nixpkgs/commit/9de959a06fd2f7184155c17ad3e51d2ebd2d425a) | `caddy: 2.4.3 -> 2.4.4 (#136252)`                      | `2021-08-31 09:56:51Z` |
| [`c87483cb`](https://github.com/NixOS/nixpkgs/commit/c87483cb559ce135e0f79e7a9e392613e14e6d95) | `kops: 1.21.0 -> 1.21.1 (#136057)`                     | `2021-08-31 09:55:30Z` |
| [`1dd3bd87`](https://github.com/NixOS/nixpkgs/commit/1dd3bd8728bc31bc985d16087a2bd4fcf6e56d16) | `nixos/syncthing: fix declarative init crash on HTTPS` | `2021-08-31 09:27:51Z` |
| [`274c9f6e`](https://github.com/NixOS/nixpkgs/commit/274c9f6e0bab2cf7955059ee317098d1f6d9b643) | `logstash: fix passthru.tests`                         | `2021-08-31 09:05:09Z` |
| [`92a5eac4`](https://github.com/NixOS/nixpkgs/commit/92a5eac48b363984c4ab6de97ec36409bed55fd2) | `libe57format: 2.1 -> 2.2.0`                           | `2021-08-31 09:01:23Z` |
| [`9e7af8a1`](https://github.com/NixOS/nixpkgs/commit/9e7af8a13c5fce9d35e2d5b11dbd5f30a879148b) | `nixos/roon-bridge: fix openFirewall`                  | `2021-08-31 08:21:07Z` |
| [`edddb705`](https://github.com/NixOS/nixpkgs/commit/edddb705e8c735eb868d2e95663ae9a633b2f8d3) | `nixos/roon-server: fix openFirewall`                  | `2021-08-31 08:20:07Z` |
| [`6cdb2092`](https://github.com/NixOS/nixpkgs/commit/6cdb2092d679c028c54a032444308f30b7c0a2ce) | `flawfinder: 2.0.18 -> 2.0.19`                         | `2021-08-31 07:36:18Z` |
| [`56feed59`](https://github.com/NixOS/nixpkgs/commit/56feed592e3441faa4eb7da016b04ee13148b447) | `kakoune: remove pkg-config, cleanup preConfigure`     | `2021-08-31 07:23:15Z` |
| [`c2f8476d`](https://github.com/NixOS/nixpkgs/commit/c2f8476de0d966b081739f56f3fdf4a7893079c4) | `stalonetray: 0.8.3 -> 0.8.4`                          | `2021-08-31 05:47:39Z` |
| [`6c10f151`](https://github.com/NixOS/nixpkgs/commit/6c10f151a1efc28f6fa7d474bda48378afcb6ff4) | `docs: update beam.section`                            | `2021-08-31 03:00:47Z` |
| [`7194273c`](https://github.com/NixOS/nixpkgs/commit/7194273c778d51cf9d209f494a21eee0621d3f82) | `sage: adapt tests for networkx 2.6`                   | `2021-08-31 01:43:24Z` |
| [`977ac07f`](https://github.com/NixOS/nixpkgs/commit/977ac07fed14848c0dcbf0e17da1f5ea2778d600) | `ipfs: increase UDP buffer size`                       | `2021-08-31 00:50:59Z` |
| [`54dbdcbc`](https://github.com/NixOS/nixpkgs/commit/54dbdcbcbb9886ed01693b7e5a7947b8fad07d2e) | `ipfs: nixpkgs-fmt`                                    | `2021-08-31 00:50:59Z` |
| [`6f28a718`](https://github.com/NixOS/nixpkgs/commit/6f28a718e5a7d6c278d795274246f6b3eac488ab) | `kibana update nodejs 10 -> 14`                        | `2021-08-31 00:06:13Z` |
| [`59e34733`](https://github.com/NixOS/nixpkgs/commit/59e34733b7b0276f364f53c2bbac8721a0214aa9) | `beats: buildGoPackage -> buildGoModule`               | `2021-08-31 00:06:13Z` |
| [`159be779`](https://github.com/NixOS/nixpkgs/commit/159be7791c43ec5b3db0403bf47373981a6d7f9f) | `logstash: fix download url`                           | `2021-08-31 00:06:13Z` |
| [`f9321de0`](https://github.com/NixOS/nixpkgs/commit/f9321de0f3dc6d97bf68c10ac4d5263162c25ed8) | `elk7: 7.5.1 -> 7.10.2`                                | `2021-08-31 00:06:13Z` |
| [`8b2cecc3`](https://github.com/NixOS/nixpkgs/commit/8b2cecc3ce33053da4a4aab33991839f9a7a1a54) | `beats: nixpkgs-fmt`                                   | `2021-08-31 00:06:13Z` |
| [`9a3c58ee`](https://github.com/NixOS/nixpkgs/commit/9a3c58ee74ad3d89cd848f10d787c753a92f70bd) | `logstash: nixpkgs-fmt`                                | `2021-08-31 00:06:13Z` |
| [`4a2d9eb0`](https://github.com/NixOS/nixpkgs/commit/4a2d9eb0fe02bb308279f50f05d31de66a8ba857) | `kibana: nixpkgs-fmt`                                  | `2021-08-31 00:06:13Z` |
| [`d702fbfe`](https://github.com/NixOS/nixpkgs/commit/d702fbfe32f27e2aa62128db76ee9c845871ac44) | `elasticsearch: nixpkgs-fmt`                           | `2021-08-31 00:06:13Z` |
| [`197a496c`](https://github.com/NixOS/nixpkgs/commit/197a496c7f2e5959ab4ce3b9d96cf9f2fc0e93f7) | `houdini: use libudev0-shim`                           | `2021-08-30 23:44:46Z` |
| [`db4b3ef1`](https://github.com/NixOS/nixpkgs/commit/db4b3ef15a3fed741820affdb35154b8af9c8b11) | `dwz: init at 0.14 (#136078)`                          | `2021-08-30 23:27:43Z` |
| [`a96144ce`](https://github.com/NixOS/nixpkgs/commit/a96144ce4fe95365aa553cfda316a962e2ca34e8) | `lima: 0.6.0 -> 0.6.1`                                 | `2021-08-30 23:26:09Z` |
| [`7f3a4f6b`](https://github.com/NixOS/nixpkgs/commit/7f3a4f6b67a4887e1fbf9c576f3f4b369e98e274) | `linuxPackages.isgx: 2.11 -> 2.14`                     | `2021-08-30 23:17:02Z` |
| [`875901c0`](https://github.com/NixOS/nixpkgs/commit/875901c0d52abd9e69ae133794fbc4d19616f831) | `podman: 3.3.0 -> 3.3.1`                               | `2021-08-30 22:18:08Z` |
| [`3e299737`](https://github.com/NixOS/nixpkgs/commit/3e299737a2a34e6d6e38f724377aaf4a820a1402) | `linux_latest-libre: 18260 -> 18268`                   | `2021-08-30 20:25:18Z` |
| [`8bfb5762`](https://github.com/NixOS/nixpkgs/commit/8bfb5762506054294052d5b1df822518c5e382fd) | `linux_latest: 5.13.13 -> 5.14`                        | `2021-08-30 20:25:18Z` |
| [`ff0dfaae`](https://github.com/NixOS/nixpkgs/commit/ff0dfaaee0975cc0deb118f51120e281eccc6497) | `nvidia_x11: 470.57.02 → 470.63.01`                    | `2021-08-30 20:24:52Z` |
| [`a8dc11b7`](https://github.com/NixOS/nixpkgs/commit/a8dc11b757e2f89829eb7a377e9f8cd37a9a7d0b) | `onlyoffice-bin: 6.2.0 -> 6.3.1`                       | `2021-08-30 20:10:59Z` |
| [`a7432ad3`](https://github.com/NixOS/nixpkgs/commit/a7432ad3115c153a901cd49da24e7b766cce1e21) | `qt5.qt3d: init module`                                | `2021-08-30 20:10:49Z` |
| [`0afbe1f2`](https://github.com/NixOS/nixpkgs/commit/0afbe1f28b46e8de86a47c6bfed8cd96466c7f9d) | `tfsec: 0.58.5 -> 0.58.6`                              | `2021-08-30 19:43:10Z` |
| [`7032ab6d`](https://github.com/NixOS/nixpkgs/commit/7032ab6d616e3ce6092d2231f1e718ec98f8424a) | `linuxPackages.isgx: enable parallel building`         | `2021-08-30 19:29:45Z` |
| [`5ad9e2a7`](https://github.com/NixOS/nixpkgs/commit/5ad9e2a74b1cfc4a0816f358a621562795638be0) | `linuxPackages.akvcam: 1.2.0 -> 1.2.2`                 | `2021-08-30 19:20:08Z` |
| [`7484cbf5`](https://github.com/NixOS/nixpkgs/commit/7484cbf58e201d57a1cfafb26e08efeb50a07d2d) | `markdown-anki-decks: jailbreak more dependencies`     | `2021-08-30 19:07:09Z` |
| [`27e4ca6f`](https://github.com/NixOS/nixpkgs/commit/27e4ca6ff1446d9e8eb087d7cc28e253264e8422) | `vimPlugins.neon: init at 2021-07-30`                  | `2021-08-30 18:47:37Z` |
| [`300b61c5`](https://github.com/NixOS/nixpkgs/commit/300b61c5944b72ed6e8b9d94aac2334b2f000c0c) | `consul: 1.10.1 -> 1.10.2`                             | `2021-08-30 18:07:20Z` |
| [`d24e7240`](https://github.com/NixOS/nixpkgs/commit/d24e724084e69ea4b2bb8b283a97d4d6076778db) | `ipcalc: 0.4.1 -> 1.0.1`                               | `2021-08-30 17:09:36Z` |
| [`008b192d`](https://github.com/NixOS/nixpkgs/commit/008b192dd9642ef96cc2c240522fc729b2765d72) | `python3Packages.pg8000: 1.21.0 -> 1.21.1`             | `2021-08-30 17:00:04Z` |
| [`15937fa4`](https://github.com/NixOS/nixpkgs/commit/15937fa4b57204ab3caf2f3175f2cfcde4552c88) | `python3Packages.scramp: 1.4.0 -> 1.4.1`               | `2021-08-30 16:57:03Z` |
| [`9ec4fb0c`](https://github.com/NixOS/nixpkgs/commit/9ec4fb0cd10d91831ba801ee675d6134f880c9f0) | `R: add memory profiling compile option`               | `2021-08-30 16:24:42Z` |
| [`8a2ec31e`](https://github.com/NixOS/nixpkgs/commit/8a2ec31e224de9461390cdd03e5e0b0290cdad0b) | `gcdemu: 3.2.3 -> 3.2.5`                               | `2021-08-30 15:52:29Z` |
| [`346fd57a`](https://github.com/NixOS/nixpkgs/commit/346fd57a3703183a641f5bbc1e212bb9f88f6fd8) | `cdemu-daemon: 3.2.3 -> 3.2.5`                         | `2021-08-30 15:52:29Z` |
| [`1c6e1eb8`](https://github.com/NixOS/nixpkgs/commit/1c6e1eb81e223702afe20d24132f7eb1b457bc37) | `cdemu-client: 3.2.3 -> 3.2.5`                         | `2021-08-30 15:52:29Z` |
| [`a08181ed`](https://github.com/NixOS/nixpkgs/commit/a08181ed7298e89ec9b3cb079a37a00d20f82df9) | `image-analyzer: 3.2.3 -> 3.2.5`                       | `2021-08-30 15:52:29Z` |
| [`8d0364ee`](https://github.com/NixOS/nixpkgs/commit/8d0364eeaefda67e8c7a39693c857c20e06db50e) | `libmirage: 3.2.3 -> 3.2.5`                            | `2021-08-30 15:52:29Z` |
| [`067da6cc`](https://github.com/NixOS/nixpkgs/commit/067da6cc0ba13786ee93a03a50892f1f124aa6a5) | `linuxPackages.vhba: 20190831 -> 20210418`             | `2021-08-30 15:52:29Z` |
| [`9b861bd3`](https://github.com/NixOS/nixpkgs/commit/9b861bd3b0389c2095beb55f5795f820c1a70982) | `linuxPackages.vhba: enable PIC`                       | `2021-08-30 15:52:00Z` |
| [`ead3028d`](https://github.com/NixOS/nixpkgs/commit/ead3028db029d577f6dd4b2983eb093a2919a28a) | `nixos/syncthing: fix escapes interpreted in config`   | `2021-08-30 15:34:34Z` |
| [`b5441128`](https://github.com/NixOS/nixpkgs/commit/b544112862fa347add65acced4466c3aaa620c7b) | `kakoune: simplify derivation`                         | `2021-08-30 14:40:23Z` |
| [`d874a520`](https://github.com/NixOS/nixpkgs/commit/d874a520155a73111f227744672254de0624aae5) | `epmd: provide default`                                | `2021-08-30 13:26:57Z` |
| [`e9f8f75a`](https://github.com/NixOS/nixpkgs/commit/e9f8f75afc04dffb7c5d071d73d5f21037e1b136) | `rubygems: 3.2.24 -> 3.2.26`                           | `2021-08-30 11:58:39Z` |
| [`12d7e03f`](https://github.com/NixOS/nixpkgs/commit/12d7e03f566dabd3ded953f5607692ad5c5cbf25) | `python3Packages.pyupgrade: 2.24.0 -> 2.25.0`          | `2021-08-30 11:45:35Z` |
| [`3e25f7fe`](https://github.com/NixOS/nixpkgs/commit/3e25f7feaaf09c15167d0410999fc38da3872e6c) | `linuxPackages.rtl88xxau-aircrack: parallel build`     | `2021-08-30 11:35:52Z` |
| [`66a079fc`](https://github.com/NixOS/nixpkgs/commit/66a079fc31c10c44e05d53b6dc9faa0c056412c0) | `linuxPackages.rtl88x2bu: parallel build`              | `2021-08-30 11:35:52Z` |
| [`9ef6829a`](https://github.com/NixOS/nixpkgs/commit/9ef6829aead59a31a5e0c3bffa814191c0922d4a) | `linuxPackages.rtl8821cu: parallel build`              | `2021-08-30 11:35:52Z` |
| [`6da5cc14`](https://github.com/NixOS/nixpkgs/commit/6da5cc14c7636eeb58d27e2aa1dd128e814e329d) | `linuxPackages.rtl8821ce: parallel build`              | `2021-08-30 11:35:52Z` |
| [`177074e3`](https://github.com/NixOS/nixpkgs/commit/177074e3cb1415aa729947f811d431824f4a08f7) | `linuxPackages.rtl8821au: parallel build`              | `2021-08-30 11:35:52Z` |
| [`ec33cdf9`](https://github.com/NixOS/nixpkgs/commit/ec33cdf902a9c5cd74831b5c3cb725ef8b4c113c) | `linuxPackages.rtl8814au: parallel build`              | `2021-08-30 11:35:52Z` |
| [`db1f8c59`](https://github.com/NixOS/nixpkgs/commit/db1f8c596dda9dcf62cb65cd042de0483c5ea5f9) | `linuxPackages.rtl8812au: parallel build`              | `2021-08-30 11:35:52Z` |
| [`97389b76`](https://github.com/NixOS/nixpkgs/commit/97389b76507e359679d7758afae84b4b6f41dd99) | `linuxPackages.rtl8188eus-aircrack: parallel build`    | `2021-08-30 11:35:52Z` |
| [`526d290b`](https://github.com/NixOS/nixpkgs/commit/526d290b7ce8391eafb693af09281ebaa09bf00b) | `dbeaver: 21.1.5 -> 21.2.0`                            | `2021-08-30 11:20:21Z` |
| [`bf6c90bd`](https://github.com/NixOS/nixpkgs/commit/bf6c90bd91545013f2fc7128de83fb22a98305b7) | `ocamlPackages.ppx_optcomp: 0.14.1 → 0.14.3`           | `2021-08-30 11:17:00Z` |
| [`bc9e07ba`](https://github.com/NixOS/nixpkgs/commit/bc9e07ba1007b03d15427bac5275bea5b32f10ca) | `terraform-providers.aws: 3.43.0 -> 3.56.0 (#136102)`  | `2021-08-30 11:13:36Z` |
| [`a8331640`](https://github.com/NixOS/nixpkgs/commit/a8331640b1bd4cac9595f4e0d4e77dc796fd0a91) | `slurm: 20.11.8.1 -> 21.08.0.1`                        | `2021-08-30 10:37:43Z` |
| [`3c190ee2`](https://github.com/NixOS/nixpkgs/commit/3c190ee25a519fb39901ca2b8a69d1e062f5022f) | `python3Packages.typer: 0.3.2 -> 0.4.0`                | `2021-08-30 09:49:54Z` |
| [`71af4f6a`](https://github.com/NixOS/nixpkgs/commit/71af4f6ab199275e1a43d37875f12dd88ed3580c) | `uxn: init at 0.0.0+unstable=2021-08-27`               | `2021-08-30 04:02:49Z` |
| [`8f36abb5`](https://github.com/NixOS/nixpkgs/commit/8f36abb5288b2d7942bfad4e4b7caf301ff23600) | `nixos/ipfs: run profile applications offline`         | `2021-08-29 23:00:44Z` |
| [`a461d064`](https://github.com/NixOS/nixpkgs/commit/a461d064cbfdcd69d8c904faf0e4e62f279e51b9) | `kakoune: 2020.09.01 -> 2021.08.28`                    | `2021-08-29 20:36:44Z` |
| [`75d58061`](https://github.com/NixOS/nixpkgs/commit/75d580619de8fe7b8d7771a53113b078343787ff) | `anki-bin: 2.1.46 -> 2.1.47`                           | `2021-08-29 08:11:47Z` |
| [`e8d2c73f`](https://github.com/NixOS/nixpkgs/commit/e8d2c73f6e8e970a9fd8b0ca9aa610a486eea343) | `anki-bin: passthru sources`                           | `2021-08-29 08:08:55Z` |
| [`69071262`](https://github.com/NixOS/nixpkgs/commit/690712624175de2f5856fcdcf43681792410e609) | `nextcloud22: 22.1.0 -> 22.1.1`                        | `2021-08-27 15:50:41Z` |
| [`174c5e16`](https://github.com/NixOS/nixpkgs/commit/174c5e166e2e16919ad399316f1efaf194f30c0f) | `r-modules: revert changes to lwgeom`                  | `2021-08-24 11:16:51Z` |
| [`d7ac07cd`](https://github.com/NixOS/nixpkgs/commit/d7ac07cdbbba71cdd8a5f6a762595f1e7082c9a9) | `r-modules: fix r package build failures`              | `2021-08-23 23:11:14Z` |
| [`6fb4874a`](https://github.com/NixOS/nixpkgs/commit/6fb4874a07ee098489a035bee2325ba5a55def45) | `houdini: 18.0 -> 18.5`                                | `2021-07-04 22:51:07Z` |
| [`d9f81d9b`](https://github.com/NixOS/nixpkgs/commit/d9f81d9bf62f9c0f28aa17856256a68c3a39775c) | `Switch to pure FHS env`                               | `2021-07-04 22:51:06Z` |
| [`83eb83e7`](https://github.com/NixOS/nixpkgs/commit/83eb83e70e8b05757cd291963e0aa851a6cbc813) | `houdini: remove unnecessary build steps`              | `2021-07-04 22:50:15Z` |