### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "075a6f16c0c67a97d4c81d9e90b6e5a3addf7503",
-        "sha256": "0cr4lh4qk1p1hx2wixhsn0yskfr5k3h10nild66gv1qk8f3xszj1",
+        "rev": "ed4771d6e23001d55bf6b422699ad798dcd61d77",
+        "sha256": "0arkcdglczjw3r07p7plb50hvk8mhzxqa7jyr755phcs5ndqpk4i",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/075a6f16c0c67a97d4c81d9e90b6e5a3addf7503.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/ed4771d6e23001d55bf6b422699ad798dcd61d77.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                    | Timestamp              |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | ---------------------- |
| [`6aaccdcb`](https://github.com/NixOS/nixpkgs/commit/6aaccdcbc854e107da21e8766426e4d8ba8ef8be) | `nixos/nvidia: remove extra space`                                                | `2021-09-01 12:57:33Z` |
| [`db0560c0`](https://github.com/NixOS/nixpkgs/commit/db0560c0f2a700d39528c44e84c6c6ca8be0857e) | `nixos/nvidia: fix missing variable reference`                                    | `2021-09-01 12:54:32Z` |
| [`6cc260cf`](https://github.com/NixOS/nixpkgs/commit/6cc260cfd60f094500b79e279069b499806bf6d8) | `Partially revert "gnome.baobab: use strictDeps"`                                 | `2021-09-01 12:52:41Z` |
| [`7458f66f`](https://github.com/NixOS/nixpkgs/commit/7458f66f63efe11eb7616e9c15bac2595434025f) | `fstar: 2021.07.31 -> 2021.08.27 (#136215)`                                       | `2021-09-01 12:31:20Z` |
| [`d04f44f7`](https://github.com/NixOS/nixpkgs/commit/d04f44f7e8d6f475e91e5539becf156676caff5c) | `chromium: 92.0.4515.159 -> 93.0.4577.63`                                         | `2021-09-01 11:53:00Z` |
| [`93ba1f2f`](https://github.com/NixOS/nixpkgs/commit/93ba1f2fee84bf286c5ced360c635e7052affc75) | `xfig: 3.2.8a -> 3.2.8b (#136366)`                                                | `2021-09-01 11:19:09Z` |
| [`ed48b359`](https://github.com/NixOS/nixpkgs/commit/ed48b359914cbc2b39c213b4814030125ef6d8e4) | `pick: 2.0.2 -> 4.0.0 (#136348)`                                                  | `2021-09-01 08:51:55Z` |
| [`832e3f97`](https://github.com/NixOS/nixpkgs/commit/832e3f971ebf25da6a4979888ff0c951bcd34414) | `gnome.baobab: use strictDeps`                                                    | `2021-09-01 07:37:37Z` |
| [`83b48cc5`](https://github.com/NixOS/nixpkgs/commit/83b48cc5896f4a50497d66f686938affe7cacf9e) | `caddy: build with default go and fix tests`                                      | `2021-09-01 07:15:50Z` |
| [`be95ff21`](https://github.com/NixOS/nixpkgs/commit/be95ff2187e82fd3f41bef646bc69964c7f11d75) | `wrangler: 1.19.0 -> 1.19.1`                                                      | `2021-09-01 07:07:23Z` |
| [`3c843d19`](https://github.com/NixOS/nixpkgs/commit/3c843d19845aa1d597fd77d34db1c159fd0fff6a) | `phoc: Change source URL to GNOME GitLab`                                         | `2021-09-01 06:33:30Z` |
| [`34e8efc3`](https://github.com/NixOS/nixpkgs/commit/34e8efc3b9de1a3c6937ecdbdccc2a9189a93c5c) | `phosh: Remove archseer as maintainer`                                            | `2021-09-01 06:33:30Z` |
| [`11dc269e`](https://github.com/NixOS/nixpkgs/commit/11dc269ec100eedd6658dd5f6faad4908fd4f373) | `phosh: 0.12.1 -> 0.13.1`                                                         | `2021-09-01 06:33:24Z` |
| [`e444a24b`](https://github.com/NixOS/nixpkgs/commit/e444a24b0e3703c809a6ffbf8a255d7a1e7523a9) | `danger-gitlab: init at 8.0.0`                                                    | `2021-09-01 05:39:22Z` |
| [`e0c48f21`](https://github.com/NixOS/nixpkgs/commit/e0c48f213be0adf3265c6ba175b2e1f5ec14c7f0) | `python38Packages.ntc-templates: 2.3.0 -> 2.3.1`                                  | `2021-09-01 01:10:27Z` |
| [`912565a7`](https://github.com/NixOS/nixpkgs/commit/912565a7081615a61811ee2b5e64c6216b425e6a) | `whitespace`                                                                      | `2021-08-31 21:53:58Z` |
| [`6e968a85`](https://github.com/NixOS/nixpkgs/commit/6e968a8550a4dbaf257f7d2ce57299e5df5a3610) | `bluespec: style changes, checkInputs`                                            | `2021-08-31 21:53:58Z` |
| [`83088d45`](https://github.com/NixOS/nixpkgs/commit/83088d4503f3daf37b5065aeffe38224542ab2ae) | `whitespace`                                                                      | `2021-08-31 21:53:58Z` |
| [`dea07960`](https://github.com/NixOS/nixpkgs/commit/dea07960df60dc196c158eb538328784791baef3) | `bluespec: use only 'check-smoke' for now`                                        | `2021-08-31 21:53:58Z` |
| [`de2257e1`](https://github.com/NixOS/nixpkgs/commit/de2257e11c3d2e70befaba6ef90a8ef0572e41dc) | `whitespace`                                                                      | `2021-08-31 21:53:58Z` |
| [`67247c11`](https://github.com/NixOS/nixpkgs/commit/67247c113e30f51061bf913ad19d54ad84aede44) | `bluespec: unstable-2021.03.29 -> 2021.07`                                        | `2021-08-31 21:53:58Z` |
| [`e62a0eac`](https://github.com/NixOS/nixpkgs/commit/e62a0eac8f2cfe58efae9200f9d267169f519cab) | `buildLuarocksPackage: cleanup`                                                   | `2021-08-31 20:16:28Z` |
| [`9af43148`](https://github.com/NixOS/nixpkgs/commit/9af43148f9778146f0e4f9ac9619e6d0ac594349) | `merkaartor: fix hash`                                                            | `2021-08-31 19:55:14Z` |
| [`7b63df2f`](https://github.com/NixOS/nixpkgs/commit/7b63df2fdeb0e14ed77b41be11cbf1e390cea15f) | `ocaml-ng.ocamlPackages_4_08.uunf: mark as broken on aarch64`                     | `2021-08-31 19:15:10Z` |
| [`29c70e8b`](https://github.com/NixOS/nixpkgs/commit/29c70e8b88e1f2ae25f44691d34ffdb073d575f5) | `element-{web,desktop}: 1.8.1 -> 1.8.2`                                           | `2021-08-31 16:44:11Z` |
| [`5f62c582`](https://github.com/NixOS/nixpkgs/commit/5f62c582a4d9d73e1dbd07fb4295b931be8ad36e) | `sequoia: fix license`                                                            | `2021-08-31 16:37:03Z` |
| [`767bb4e4`](https://github.com/NixOS/nixpkgs/commit/767bb4e4bbb9a8d06d4c3cbc14092902c2465f98) | `nixos/nextcloud: apply doc fixes suggested by fabaff`                            | `2021-08-31 15:57:40Z` |
| [`9f0d327b`](https://github.com/NixOS/nixpkgs/commit/9f0d327b661b24d0c1a99a39bf53040967331408) | `tea: 0.7.0 -> 0.7.1`                                                             | `2021-08-31 15:42:11Z` |
| [`9a218676`](https://github.com/NixOS/nixpkgs/commit/9a218676434f8d9c58a113a9d9d7d08eb1f7083e) | `git-branchless: add msfjarvis as co-maintainer`                                  | `2021-08-31 15:30:09Z` |
| [`dd86b52c`](https://github.com/NixOS/nixpkgs/commit/dd86b52c94af28acecbc3ad0bf4050cd8dae9126) | `maintainers: add msfjarvis`                                                      | `2021-08-31 15:30:09Z` |
| [`65be0ede`](https://github.com/NixOS/nixpkgs/commit/65be0edee53214acddf1feceafa58e8b852ba2b5) | `git-branchless: add support for Darwin builds`                                   | `2021-08-31 15:30:09Z` |
| [`19ea42a1`](https://github.com/NixOS/nixpkgs/commit/19ea42a1f6dc98745efead05fc4a7eab3907f3ae) | `zfsUnstable: 2.1.0 -> unstable-2021-08-30`                                       | `2021-08-31 14:59:20Z` |
| [`5947c598`](https://github.com/NixOS/nixpkgs/commit/5947c5989979c684d97f7154695e77e2000afbb7) | `matrix-synapse: 1.41.0 -> 1.41.1`                                                | `2021-08-31 14:04:06Z` |
| [`8bce3034`](https://github.com/NixOS/nixpkgs/commit/8bce3034fda3b8d201961d382b55caaa54636e4d) | `ipfs: add autoMigrate option`                                                    | `2021-08-31 13:22:36Z` |
| [`60adf763`](https://github.com/NixOS/nixpkgs/commit/60adf763357f7ae4b51b945ac967cb46c747d9ea) | `offlineimap: 7.3.3 -> 7.3.4 (#136145)`                                           | `2021-08-31 13:17:09Z` |
| [`eb22f77b`](https://github.com/NixOS/nixpkgs/commit/eb22f77b930ca33e715a889520a7201b4041c630) | `skypeforlinux: 8.69.0.77 -> 8.75.0.140`                                          | `2021-08-31 12:31:46Z` |
| [`98429b2d`](https://github.com/NixOS/nixpkgs/commit/98429b2de9e937e58ee339a95f501e4a9d78d447) | `hashcat: 6.2.3 -> 6.2.4`                                                         | `2021-08-31 12:28:55Z` |
| [`7d471c87`](https://github.com/NixOS/nixpkgs/commit/7d471c87544b6743b8c36ab965271220d334d125) | `usbredir: fix cross`                                                             | `2021-08-31 12:27:03Z` |
| [`aa292512`](https://github.com/NixOS/nixpkgs/commit/aa29251293b7507bc248259e2f8681cee1eef103) | `tts: 0.2.0 -> 0.2.1`                                                             | `2021-08-31 12:26:32Z` |
| [`43b2aeb7`](https://github.com/NixOS/nixpkgs/commit/43b2aeb7f47c15e66958dab4db91c3e6019b6abe) | `oh-my-zsh: 2021-08-18 → 2021-08-27`                                              | `2021-08-31 12:02:07Z` |
| [`1342c464`](https://github.com/NixOS/nixpkgs/commit/1342c4648b6f04064882daacdfc6a5650d406700) | `jenkins: 2.289.3 → 2.303.1`                                                      | `2021-08-31 12:01:24Z` |
| [`45af244b`](https://github.com/NixOS/nixpkgs/commit/45af244b2d44cc9a434c5da292f646cdbcadaa90) | `tts: relax mecab-python3 constraint`                                             | `2021-08-31 12:00:13Z` |
| [`cf5caf02`](https://github.com/NixOS/nixpkgs/commit/cf5caf02c908a7e30884b69a7c554c6ad605ac94) | `python3Packages.coqpit: 0.0.10 -> 0.0.13`                                        | `2021-08-31 11:57:35Z` |
| [`1dfaced6`](https://github.com/NixOS/nixpkgs/commit/1dfaced689df9590622d627f0f1ecbf0f690a6f0) | `linuxPackages.xmm7360-pci: mark broken on Linux 5.14`                            | `2021-08-31 11:08:55Z` |
| [`357eacbc`](https://github.com/NixOS/nixpkgs/commit/357eacbcd41fe87845554018f96d3cb81faf7679) | `linuxPackages.rtw88: mark broken on Linux 5.14`                                  | `2021-08-31 11:08:55Z` |
| [`f86c5420`](https://github.com/NixOS/nixpkgs/commit/f86c54202d770454226fa415b7fb26514afe1de7) | `networkmanagerapplet: 1.22.0 -> 1.24.0`                                          | `2021-08-31 10:31:51Z` |
| [`afde3709`](https://github.com/NixOS/nixpkgs/commit/afde3709d7eb5d34275ab3d65a3a1afc78d3d413) | `step-cli: 0.16.1 -> 0.17.2`                                                      | `2021-08-31 10:12:06Z` |
| [`7bcc7aad`](https://github.com/NixOS/nixpkgs/commit/7bcc7aad5900bbd334ca9e7027bce37036b406eb) | `nmap: 7.91 -> 7.92`                                                              | `2021-08-31 09:39:05Z` |
| [`b8f14e34`](https://github.com/NixOS/nixpkgs/commit/b8f14e34361d5ed7429bd9465a21706b5ecf4c30) | `python3Packages.karton-dashboard: 1.2.0 -> 1.2.1`                                | `2021-08-31 09:25:47Z` |
| [`9064e2c4`](https://github.com/NixOS/nixpkgs/commit/9064e2c442578f5b6c53c173f31fa75158ebb01a) | `python3Packages.zeroconf: 0.36.0 -> 0.36.2`                                      | `2021-08-31 09:11:33Z` |
| [`eb8e9434`](https://github.com/NixOS/nixpkgs/commit/eb8e943493164009f34ba4c0a824533ce755f1dd) | `Fix interaction between appendOverlays and otherPackageSets`                     | `2021-08-31 07:18:08Z` |
| [`4502d638`](https://github.com/NixOS/nixpkgs/commit/4502d6386e3e35f7297497075a22226f05ea44b5) | `ipfs: nixpkgs-fmt`                                                               | `2021-08-31 03:55:31Z` |
| [`8afec3d9`](https://github.com/NixOS/nixpkgs/commit/8afec3d92ff1f055af2583569c32a2d254bb2c83) | `linuxPackages.ddcci-driver: use kernel's make flags`                             | `2021-08-31 00:12:05Z` |
| [`19e4afc9`](https://github.com/NixOS/nixpkgs/commit/19e4afc912d8c62c8977a54d590e8d1cef7fb195) | `linuxPackages.nvidia-x11: use makeFlags in builder.sh`                           | `2021-08-31 00:06:12Z` |
| [`4a8ab482`](https://github.com/NixOS/nixpkgs/commit/4a8ab482e0d7c28afb95df19bb376edfd7b87ca1) | `linuxPackages.nvidia_x11.settings: use makeFlags in preBuild's libXNVCtrl build` | `2021-08-31 00:06:11Z` |
| [`0b63366e`](https://github.com/NixOS/nixpkgs/commit/0b63366e6f415c37fcd3f33e7fcb75f3883a6e1c) | `linuxPackages.nvidia_x11.settings: pick up nvidia_x11 makeFlags`                 | `2021-08-31 00:06:10Z` |
| [`fe31fdf4`](https://github.com/NixOS/nixpkgs/commit/fe31fdf43bdb4fa8f3ab59928b6ede6c1232d475) | `linuxPackages.nvidia_x11.persistenced: pick up nvidia_x11 makeFlags`             | `2021-08-31 00:06:09Z` |
| [`636e17aa`](https://github.com/NixOS/nixpkgs/commit/636e17aab5d90ee0163858cd0e110d51850a6354) | `linuxPackages.nvidia_x11: apply kernel module makeFlags`                         | `2021-08-31 00:06:08Z` |
| [`7b2709f6`](https://github.com/NixOS/nixpkgs/commit/7b2709f6a4b4b56f802b6ea09740baf99e06ee60) | `nixos/nvidia: let user choose whether to install nvidia-settings`                | `2021-08-31 00:06:07Z` |
| [`1d22aed0`](https://github.com/NixOS/nixpkgs/commit/1d22aed0417ef945552d4dc2abcf04e806162351) | `luarocks-nix: bumped luarocks-nix`                                               | `2021-08-30 23:01:56Z` |
| [`6312bac4`](https://github.com/NixOS/nixpkgs/commit/6312bac40846b92fd1b33def488badcd902241a1) | `luaPackages.ansicolors: remove because unmaintained since 2013`                  | `2021-08-30 22:42:30Z` |
| [`a2fd4779`](https://github.com/NixOS/nixpkgs/commit/a2fd477970f3cfb5c5c51bc527ce6ace47b1cfab) | `lua: restore knownRockspec and lgi`                                              | `2021-08-30 22:42:26Z` |
| [`24ac87c4`](https://github.com/NixOS/nixpkgs/commit/24ac87c440a1b9f6f2ca8b653d1242d3ee1497b7) | `luaPackages.luadoc: remove since last update in 2013`                            | `2021-08-30 22:13:11Z` |
| [`404e5b10`](https://github.com/NixOS/nixpkgs/commit/404e5b1040f4998bf95558468fd050836aa91b4d) | `luaPackages.ltermbox: removed`                                                   | `2021-08-30 22:09:47Z` |
| [`15e5c924`](https://github.com/NixOS/nixpkgs/commit/15e5c924959cc2e8398737b69fbeb7b2082a836a) | `luaPackages: update`                                                             | `2021-08-30 22:07:28Z` |
| [`20ce363d`](https://github.com/NixOS/nixpkgs/commit/20ce363de43e45cc636c1bee04e0d97a424e08e7) | `qt5: Expose internal variables to facilitate out-of-tree building of modules`    | `2021-08-30 20:15:44Z` |
| [`f6187a43`](https://github.com/NixOS/nixpkgs/commit/f6187a43a06b76ffd467646ab49ac0421d50d22c) | `firefox-bin: 91.0.1 -> 91.0.2`                                                   | `2021-08-30 19:00:20Z` |
| [`01b534e8`](https://github.com/NixOS/nixpkgs/commit/01b534e8884a6a997a1f382297c513d5c8a0d9b9) | `firefox: 91.0.1 -> 91.0.2`                                                       | `2021-08-30 18:58:16Z` |
| [`00d1b4f1`](https://github.com/NixOS/nixpkgs/commit/00d1b4f193401c05382c7cd67c9dd5525c043e9d) | `nomad_1_1: 1.1.3 -> 1.1.4`                                                       | `2021-08-30 18:09:51Z` |
| [`2fcc3383`](https://github.com/NixOS/nixpkgs/commit/2fcc338369c6cd5399641c3281ae3cef444ab8d5) | `nomad_1_0: 1.0.9 -> 1.0.10`                                                      | `2021-08-30 18:09:08Z` |
| [`e477127d`](https://github.com/NixOS/nixpkgs/commit/e477127df0735afe24e4f53a382c8d39530a9506) | `vault-bin: 1.8.1 -> 1.8.2`                                                       | `2021-08-30 18:06:26Z` |
| [`ea4b2dbc`](https://github.com/NixOS/nixpkgs/commit/ea4b2dbcbce077a47953522ad78d764b22a438a8) | `android-tools: install missing tools`                                            | `2021-08-30 11:53:07Z` |
| [`f4153fb0`](https://github.com/NixOS/nixpkgs/commit/f4153fb02c10e63a6fbb501876f609c8a55f262d) | `grilo: add patch for CVE-2021-39365`                                             | `2021-08-30 10:43:07Z` |
| [`85b532da`](https://github.com/NixOS/nixpkgs/commit/85b532dad3c4b8e2f21c895fe07f17ec68f2243d) | `bwm_ng: 0.6.1 -> 0.6.3`                                                          | `2021-08-30 09:03:31Z` |
| [`1cf45a50`](https://github.com/NixOS/nixpkgs/commit/1cf45a505f6b4a95bf8463a32bc649d25c7eb668) | `mrtg: 2.17.7 -> 2.17.8`                                                          | `2021-08-30 08:35:09Z` |
| [`a748e65c`](https://github.com/NixOS/nixpkgs/commit/a748e65c121d072e2443b0f8c0773d2fc1ccfd86) | `msgpack: 3.2.0 -> 3.3.0`                                                         | `2021-08-30 07:22:16Z` |
| [`749421a4`](https://github.com/NixOS/nixpkgs/commit/749421a47b2d6b6d21d4da2cd1fbe504a72cf3ed) | `wine{Unstable,Staging}: 6.15 -> 6.16`                                            | `2021-08-29 22:45:33Z` |
| [`f432f3c4`](https://github.com/NixOS/nixpkgs/commit/f432f3c4a470bc6af831945e5f7e719eeec9d5c4) | `nixos-install-tools: Add tests.nixos-tests`                                      | `2021-08-29 21:11:53Z` |
| [`7292ed91`](https://github.com/NixOS/nixpkgs/commit/7292ed91df14abc1d9b55322b5d112a9b34af6c7) | `update-luarocks-packages: use the current nixpkgs`                               | `2021-08-29 17:39:42Z` |
| [`5b73af6f`](https://github.com/NixOS/nixpkgs/commit/5b73af6f5b142b0a926492427c0dd7891915ccf4) | `update-luarocks-packages: support in-repo rockspecs`                             | `2021-08-29 17:39:42Z` |
| [`2fe26c0c`](https://github.com/NixOS/nixpkgs/commit/2fe26c0ca9d7f2794deb9287209c7879431ed631) | `ssldump: 1.1 -> 1.4`                                                             | `2021-08-28 10:12:04Z` |
| [`baa2707d`](https://github.com/NixOS/nixpkgs/commit/baa2707d2a4fdbbd93a6bd7a79e59a0bb9f77e2a) | `pgcli: 3.1.0 -> 3.2.0`                                                           | `2021-08-28 00:04:20Z` |
| [`d3a7131d`](https://github.com/NixOS/nixpkgs/commit/d3a7131d7d1d507393ce71f5d6ddd9f290aaa567) | `ytmdl: 2021.06.26 -> 2021.08.01`                                                 | `2021-08-28 00:04:20Z` |
| [`55db1996`](https://github.com/NixOS/nixpkgs/commit/55db199650890badc1ad322ebdf59208784b11ff) | `akku: init at 1.1.0`                                                             | `2021-08-28 00:04:20Z` |
| [`87e41eca`](https://github.com/NixOS/nixpkgs/commit/87e41eca9c2408d692538db323b5f0ed0fdec842) | `python39Packages.youtube-search-python: init at 1.4.7`                           | `2021-08-28 00:04:20Z` |
| [`561418f9`](https://github.com/NixOS/nixpkgs/commit/561418f996fc015f4db48b1c9b7c31338cb280d9) | `nixos/nextcloud: add some notes for `Error: Command "upgrade" is not defined.``  | `2021-08-27 20:36:45Z` |
| [`8e532326`](https://github.com/NixOS/nixpkgs/commit/8e532326dd909519b9623ff857717590cf42851d) | `plex: 1.24.0.4930-ab6e1a058 -> 1.24.1.4931-1a38e63c6`                            | `2021-08-27 08:46:42Z` |
| [`70de7b5b`](https://github.com/NixOS/nixpkgs/commit/70de7b5b453f7bf4ef0e889a48b00c009338030d) | `pipewire: 0.3.33 -> 0.3.34`                                                      | `2021-08-26 17:33:18Z` |
| [`2321949d`](https://github.com/NixOS/nixpkgs/commit/2321949d1f8ed0372dd2bf26d247a1fc58bf75b5) | `cargo-expand: 1.0.8 -> 1.0.9`                                                    | `2021-08-26 01:52:58Z` |
| [`9bb81609`](https://github.com/NixOS/nixpkgs/commit/9bb81609bed4d1863b8e3e61c59fd613a1787006) | `spoofer: 1.4.6 -> 1.4.7`                                                         | `2021-08-22 06:31:14Z` |
| [`39c2e364`](https://github.com/NixOS/nixpkgs/commit/39c2e364164c5061155857cadeaf79d8620d94f6) | `stress-ng: 0.12.11 -> 0.13.00`                                                   | `2021-08-22 05:30:33Z` |
| [`b0d44b3f`](https://github.com/NixOS/nixpkgs/commit/b0d44b3f3a9c14884e2cd336cdbad1b6860047f0) | `tclap: 1.2.3 -> 1.2.4`                                                           | `2021-08-19 20:43:37Z` |
| [`aa2dfca4`](https://github.com/NixOS/nixpkgs/commit/aa2dfca483d6d19496149aee60f6f8716fa3deec) | `duplicati: 2.0.6.1 -> 2.0.6.3`                                                   | `2021-08-18 19:12:24Z` |
| [`f6b44b88`](https://github.com/NixOS/nixpkgs/commit/f6b44b88ccad7e5ef24978e865bf7ac64b1675f5) | `pspg: 4.5.0 -> 5.3.4`                                                            | `2021-08-17 15:29:11Z` |
| [`eea9d67b`](https://github.com/NixOS/nixpkgs/commit/eea9d67bb189d9a241384ce667914539bb4579e5) | `liburcu: 0.12.2 -> 0.13.0`                                                       | `2021-08-14 15:37:36Z` |