### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ed4771d6e23001d55bf6b422699ad798dcd61d77",
-        "sha256": "0arkcdglczjw3r07p7plb50hvk8mhzxqa7jyr755phcs5ndqpk4i",
+        "rev": "abfdb24af00d88abff4ed7184f45b0c0b8abf268",
+        "sha256": "168hcq05kgzc1lqyf528zxl1w0vgjkwmsv4ika1h8349m0m56lgr",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/ed4771d6e23001d55bf6b422699ad798dcd61d77.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/abfdb24af00d88abff4ed7184f45b0c0b8abf268.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                               | Timestamp              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------ | ---------------------- |
| [`4ddc5c6b`](https://github.com/NixOS/nixpkgs/commit/4ddc5c6b2addbf03ee21fa5b51de15b2cded11c8) | `elasticsearch: remove logic for version less than 6`        | `2021-09-02 01:57:02Z` |
| [`d58fa9e4`](https://github.com/NixOS/nixpkgs/commit/d58fa9e445d171ba8a735165dc60706d54e9cc4f) | `elasticsearch: fix jvm gc log path`                         | `2021-09-02 01:57:02Z` |
| [`e13906ff`](https://github.com/NixOS/nixpkgs/commit/e13906fff009043e8982567ca6bc1a031b62f388) | `elasticsearch: nixpkgs-fmt`                                 | `2021-09-02 01:57:02Z` |
| [`3b7fa874`](https://github.com/NixOS/nixpkgs/commit/3b7fa8744ccb957ce20304f6b9ec68325671ae11) | `elasticsearch7: wrap elasticcearch-keystore`                | `2021-09-02 01:57:02Z` |
| [`070fa4ce`](https://github.com/NixOS/nixpkgs/commit/070fa4cefc5b7bd0c8f95850adfcb4f0bf4bd09a) | `elixir_ls: add update script`                               | `2021-09-02 01:55:45Z` |
| [`27a37154`](https://github.com/NixOS/nixpkgs/commit/27a37154dee56bd7eff4d33e0c1b9747e69cb4ac) | `monit: 5.27.2 -> 5.29.0; format`                            | `2021-09-01 23:53:21Z` |
| [`05a5144f`](https://github.com/NixOS/nixpkgs/commit/05a5144fa9032018b9aac3a5aaf9c368b8347a4f) | `build(deps): bump devmasx/merge-branch from 1.3.1 to 1.4.0` | `2021-09-01 21:08:00Z` |
| [`d4c75580`](https://github.com/NixOS/nixpkgs/commit/d4c75580c18c78bdf81810dc73aab76e10754190) | `mosquitto: 2.0.11 -> 2.0.12`                                | `2021-09-01 20:07:27Z` |
| [`05889803`](https://github.com/NixOS/nixpkgs/commit/0588980396372a33c4a5ba83ef7432fbff50f3aa) | `yarn-bash-completion: init at 0.17.0`                       | `2021-09-01 18:35:03Z` |
| [`d37ed0e5`](https://github.com/NixOS/nixpkgs/commit/d37ed0e5ada27a5712508b81e4cf0b63759bcaae) | `neovim: remove redundant -n in test`                        | `2021-09-01 18:21:43Z` |
| [`ba0b032b`](https://github.com/NixOS/nixpkgs/commit/ba0b032ba86bee76620735b8ff187c846fabf832) | `chatty: init at 0.3.2`                                      | `2021-09-01 16:28:30Z` |
| [`1bf2bb24`](https://github.com/NixOS/nixpkgs/commit/1bf2bb240d3566bfeda1805a02a3c85eca27c557) | `pidgin: add passthru.makePluginPath`                        | `2021-09-01 16:27:20Z` |
| [`1ea4c8dc`](https://github.com/NixOS/nixpkgs/commit/1ea4c8dc31aabdd20b77a3649573cc4cbab999f2) | `exploitdb: 2021-08-28 -> 2021-09-01`                        | `2021-09-01 13:35:02Z` |
| [`9e507a93`](https://github.com/NixOS/nixpkgs/commit/9e507a93148613753b87bf00b39d7bf218355170) | `clfswm: support custom package`                             | `2021-09-01 13:27:37Z` |
| [`080b1486`](https://github.com/NixOS/nixpkgs/commit/080b1486041d214754cf25f4f1e94e05cba36184) | `palemoon: 29.4.0.1 -> 29.4.0.2`                             | `2021-09-01 13:08:14Z` |
| [`aff25d4c`](https://github.com/NixOS/nixpkgs/commit/aff25d4cf0b0461cd2fc7790518593984822cb6c) | `nodejs-14_x: 14.17.5 -> 14.17.6`                            | `2021-09-01 12:37:51Z` |
| [`00fa834e`](https://github.com/NixOS/nixpkgs/commit/00fa834e558bca1feeedae4ec9b6cd55bfe4281d) | `nodejs-12_x: 12.22.5 -> 12.22.6`                            | `2021-09-01 12:37:23Z` |
| [`84774060`](https://github.com/NixOS/nixpkgs/commit/84774060184b49e883bf0e1da13a6ce89640ca57) | `neovim: allow extra Lua packages`                           | `2021-09-01 01:46:44Z` |
| [`0fec93a3`](https://github.com/NixOS/nixpkgs/commit/0fec93a3a55be9940f63400cfab2b1b0292a0102) | `elasticmq-server-bin: 0.15.7 -> 1.2.0`                      | `2021-08-31 23:04:40Z` |
| [`9c773516`](https://github.com/NixOS/nixpkgs/commit/9c773516d7abb4c394ecda92b44dd1f80b4e0f6e) | `elasticmq-server-bin: add passthru.tests.elasticmqTest`     | `2021-08-31 23:04:40Z` |
| [`3c0cf469`](https://github.com/NixOS/nixpkgs/commit/3c0cf469a12814b361f03ebcfafa96da43b6e50a) | `elasticmq-server-bin: 0.14.6 -> 0.15.7`                     | `2021-08-31 21:31:28Z` |
| [`7448cab5`](https://github.com/NixOS/nixpkgs/commit/7448cab54bba2b432d6e4115990a3fc6774f47db) | `python3Packages.spectral-cube: add missing dependencies`    | `2021-08-31 13:49:49Z` |
| [`5280cdee`](https://github.com/NixOS/nixpkgs/commit/5280cdee8d6c3ec3155150c703ccd50d038b2cdb) | `linuxPackages.zfs: fix m4 script when not using GCC`        | `2021-08-31 00:25:19Z` |
| [`d30ce301`](https://github.com/NixOS/nixpkgs/commit/d30ce301107248f30f24808708d3957dcc8cb219) | `libdeltachat: 1.59.0 -> 1.60.0`                             | `2021-08-30 22:22:12Z` |
| [`9d822d20`](https://github.com/NixOS/nixpkgs/commit/9d822d20472fd53b3f521e2780322446055bf010) | `nixos/soju: add 21.11 release notes entry`                  | `2021-08-30 14:28:07Z` |
| [`f4f2057a`](https://github.com/NixOS/nixpkgs/commit/f4f2057a76507fb23717ceb5cede2f80b4dfc77d) | `nixos/soju: add module`                                     | `2021-08-30 14:28:06Z` |
| [`88289998`](https://github.com/NixOS/nixpkgs/commit/882899981d4bc23cba35d30221b2281ec5d173ef) | `qgnomeplatform: 0.6.1 → 0.8.0`                              | `2021-08-29 02:25:07Z` |
| [`47afdc46`](https://github.com/NixOS/nixpkgs/commit/47afdc46275834f3d6ecb0021dbdda9b77f3729d) | `nixos/gnome: enable platform integration for Qt`            | `2021-08-29 02:23:34Z` |
| [`5564cb9c`](https://github.com/NixOS/nixpkgs/commit/5564cb9c6b19d68037dad229170f5fa0665ad80e) | `wordpress: 5.7.2 -> 5.8`                                    | `2021-08-14 14:11:53Z` |