### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "abfdb24af00d88abff4ed7184f45b0c0b8abf268",
-        "sha256": "168hcq05kgzc1lqyf528zxl1w0vgjkwmsv4ika1h8349m0m56lgr",
+        "rev": "9df8a8489e39cb0b7d43c3c07d413132b31db351",
+        "sha256": "0shfdx0gx8690wh56dsyv9msjyi0wmzaq1vibl6jfa5h49jv5c9m",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/abfdb24af00d88abff4ed7184f45b0c0b8abf268.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/9df8a8489e39cb0b7d43c3c07d413132b31db351.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                          | Timestamp              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------- | ---------------------- |
| [`f2b50ffa`](https://github.com/NixOS/nixpkgs/commit/f2b50ffadb6b5365844003cf8f861e524ff44a8a) | `elixir-ls: 0.8.0 -> 0.8.1`                             | `2021-09-02 14:00:02Z` |
| [`35f292e3`](https://github.com/NixOS/nixpkgs/commit/35f292e38e2cdcb867a33c1f8ad2b9808fd072b0) | `strace: 5.13 -> 5.14`                                  | `2021-09-02 12:48:42Z` |
| [`55e9fc96`](https://github.com/NixOS/nixpkgs/commit/55e9fc96666eecd1d4fba29a37b6f474b60667c4) | `chromiumBeta: 94.0.4606.20 -> 94.0.4606.31`            | `2021-09-02 09:13:49Z` |
| [`e4a8bc9b`](https://github.com/NixOS/nixpkgs/commit/e4a8bc9b944a3f4370143ee282b6dd6568b60f23) | `arpa2common: init at 2.2.14`                           | `2021-09-02 08:34:41Z` |
| [`98659898`](https://github.com/NixOS/nixpkgs/commit/98659898959e00c285ab1711739757b19154d158) | `cargo-release: 0.17.0 -> 0.17.1`                       | `2021-09-02 07:20:42Z` |
| [`8d3527aa`](https://github.com/NixOS/nixpkgs/commit/8d3527aa887eb6ea4c0c2fc5a5cbe8cf0e81de2e) | `nixos/network-interfaces: Fix wlan interface mac`      | `2021-09-02 01:46:26Z` |
| [`ea4b37e6`](https://github.com/NixOS/nixpkgs/commit/ea4b37e6790b7d3e03ee29cb050e5c76f11245ac) | `buildFhsUserenv: inherit mounts from parent namespace` | `2021-09-02 01:37:54Z` |
| [`33df189f`](https://github.com/NixOS/nixpkgs/commit/33df189fae1c0909feb64462e067e405c7639f3a) | `pythonPackages.fiona: fix build`                       | `2021-09-01 22:51:41Z` |
| [`a9faf273`](https://github.com/NixOS/nixpkgs/commit/a9faf273fec06d38de8349dbfb494db82bb5f01b) | `python3Packages.tldextract: 3.1.1 -> 3.1.2`            | `2021-09-01 21:27:00Z` |
| [`023a3fae`](https://github.com/NixOS/nixpkgs/commit/023a3fae1809788f7c2dc8fc0ccf6abbb19508dc) | `python38Packages.pex: 2.1.46 -> 2.1.47`                | `2021-09-01 21:20:43Z` |
| [`1e3fe281`](https://github.com/NixOS/nixpkgs/commit/1e3fe281f9ee69359c53ab6f9f463d22844210b9) | `nuclei: 2.4.3 -> 2.5.0`                                | `2021-09-01 21:04:09Z` |
| [`8ee160c2`](https://github.com/NixOS/nixpkgs/commit/8ee160c2d452efc6acff0d4f286970f6f93e35ba) | `babashka: 0.5.1 -> 0.6.0`                              | `2021-09-01 20:36:21Z` |
| [`1bb91a23`](https://github.com/NixOS/nixpkgs/commit/1bb91a2329ec13d0dc3ae91b58b07287b254f35e) | `mutt: 2.1.1 -> 2.1.2`                                  | `2021-09-01 19:54:31Z` |
| [`96f02afb`](https://github.com/NixOS/nixpkgs/commit/96f02afbe58d243835c9b7da811c6bab61690ed9) | `wesnoth: fix license information`                      | `2021-09-01 19:49:06Z` |
| [`bbf089df`](https://github.com/NixOS/nixpkgs/commit/bbf089dfb7e5e99a571647bf29734f3f7babdec7) | `wesnoth: 1.4.16 -> 1.4.17`                             | `2021-09-01 19:44:21Z` |
| [`49a231ce`](https://github.com/NixOS/nixpkgs/commit/49a231cec776bc9166226f628658d151b8855799) | `python3Packages.angrop: 9.0.9572 -> 9.0.9684`          | `2021-09-01 18:56:11Z` |
| [`e97dfd62`](https://github.com/NixOS/nixpkgs/commit/e97dfd629a5b5a749814b20aa64781b900005399) | `python3Packages.angr: 9.0.9572 -> 9.0.9684`            | `2021-09-01 18:56:08Z` |
| [`7402e79b`](https://github.com/NixOS/nixpkgs/commit/7402e79b0aa3255f0f6bb68f68209f5a21699b59) | `python3Packages.cle: 9.0.9572 -> 9.0.9684`             | `2021-09-01 18:56:04Z` |
| [`13a4868e`](https://github.com/NixOS/nixpkgs/commit/13a4868e86e39edf7be8f4a39322ad4e85aed78a) | `python3Packages.claripy: 9.0.9572 -> 9.0.9684`         | `2021-09-01 18:56:01Z` |
| [`7fb0c124`](https://github.com/NixOS/nixpkgs/commit/7fb0c12444604ea26a347b612d907c355207f829) | `python3Packages.pyvex: 9.0.9572 -> 9.0.9684`           | `2021-09-01 18:55:58Z` |
| [`40b00086`](https://github.com/NixOS/nixpkgs/commit/40b0008639bf37ba01528c5fd86dd5ab8b726979) | `python3Packages.ailment: 9.0.9572 -> 9.0.9684`         | `2021-09-01 18:55:55Z` |
| [`84bbe656`](https://github.com/NixOS/nixpkgs/commit/84bbe65656960c8231486c933090ba191987d714) | `python3Packages.archinfo: 9.0.9572 -> 9.0.9684`        | `2021-09-01 18:55:52Z` |
| [`f8acdc76`](https://github.com/NixOS/nixpkgs/commit/f8acdc76e2826462f80533b43ebcd7d8571de932) | `perlPackages.SyntaxKeywordTry: init at 0.25`           | `2021-09-01 15:33:33Z` |
| [`c2120d6a`](https://github.com/NixOS/nixpkgs/commit/c2120d6a3874eb9ad2793566a051e53e9e20fc76) | `python38Packages.pubnub: 5.1.4 -> 5.2.0`               | `2021-09-01 06:14:17Z` |
| [`e02711df`](https://github.com/NixOS/nixpkgs/commit/e02711df7d0ec59984280986159ff99135bdd9a0) | `gthumb: 3.11.3 -> 3.11.4`                              | `2021-08-31 02:59:19Z` |
| [`f5e95757`](https://github.com/NixOS/nixpkgs/commit/f5e95757f22ba20b9977c7a3ae560f5773952bbe) | `xonotic: support user statistics reporting`            | `2021-08-30 15:13:00Z` |
| [`57b7e413`](https://github.com/NixOS/nixpkgs/commit/57b7e413531a89858374889c1f07645590a18d74) | `perldevel: 5.35.0 -> 5.35.3`                           | `2021-08-25 13:45:19Z` |
| [`9f74d336`](https://github.com/NixOS/nixpkgs/commit/9f74d336f86ad96c23147edfff3aabc4454c2bc7) | `perl.perl-cross: 1.3.6 -> 01c176ac0`                   | `2021-08-25 13:44:22Z` |
| [`720ba79a`](https://github.com/NixOS/nixpkgs/commit/720ba79a373bceabd44fd166f7f388316fad9e3b) | `krankerl: 0.13.1 -> 0.13.2`                            | `2021-08-25 07:05:54Z` |
| [`d7ed8cf0`](https://github.com/NixOS/nixpkgs/commit/d7ed8cf0cce20affd3f78f181236db88709a200a) | `yodl: 4.03.02 -> 4.03.03`                              | `2021-08-21 21:03:14Z` |