### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9df8a8489e39cb0b7d43c3c07d413132b31db351",
-        "sha256": "0shfdx0gx8690wh56dsyv9msjyi0wmzaq1vibl6jfa5h49jv5c9m",
+        "rev": "509699b37ef172654ed3566028a7e38d3cad6070",
+        "sha256": "1ihhdhgd0zy3mmb59jfas16d8wmz56kjgaz26cbmgn4320949s6a",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/9df8a8489e39cb0b7d43c3c07d413132b31db351.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/509699b37ef172654ed3566028a7e38d3cad6070.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                              | Timestamp              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | ---------------------- |
| [`cff78eba`](https://github.com/NixOS/nixpkgs/commit/cff78ebaf61e3b13e46735707904e980deaf0614) | `vscode: 1.59.1 -> 1.60.0`                                                                  | `2021-09-03 03:01:30Z` |
| [`5f6a5d5c`](https://github.com/NixOS/nixpkgs/commit/5f6a5d5c5f52c5accbf109872bb4957c53dc1e7e) | `ran: init at 0.1.6`                                                                        | `2021-09-03 02:44:03Z` |
| [`8cbcf42a`](https://github.com/NixOS/nixpkgs/commit/8cbcf42add31ded197b5789cb0959e8abc40654c) | `inetutils: 2.0 -> 2.2`                                                                     | `2021-09-03 01:33:46Z` |
| [`5480cb98`](https://github.com/NixOS/nixpkgs/commit/5480cb98ecadbad9a981d7becb0988a8d7e46612) | `materialize: 0.8.1 -> 0.8.3`                                                               | `2021-09-03 01:31:26Z` |
| [`3f2bdc19`](https://github.com/NixOS/nixpkgs/commit/3f2bdc19c135ce1489f36259e1766263337588af) | `python3Packages.policyuniverse: 1.4.0.20210816 -> 1.4.0.20210819`                          | `2021-09-02 21:07:25Z` |
| [`754d0362`](https://github.com/NixOS/nixpkgs/commit/754d0362cc247115719fcc642dc6c7a6f2e38326) | `tealdeer: add meta.mainProgram`                                                            | `2021-09-02 20:58:23Z` |
| [`a9667fc8`](https://github.com/NixOS/nixpkgs/commit/a9667fc80fbd5b7ba49c025fbf8cfe121acef68d) | `luarocks: add bash/zsh completion`                                                         | `2021-09-02 20:57:06Z` |
| [`225637dd`](https://github.com/NixOS/nixpkgs/commit/225637dd596c14f63a5b9ebf54accd6e44997df1) | `yt-dlp: 2021.08.10 -> 2021.9.2`                                                            | `2021-09-02 20:49:03Z` |
| [`ab1d85c0`](https://github.com/NixOS/nixpkgs/commit/ab1d85c0b1393e6cd513770166613e105aa4ac8d) | `Revert "linuxPackages.zfs: fix m4 script when not using GCC"`                              | `2021-09-02 20:45:53Z` |
| [`a12606be`](https://github.com/NixOS/nixpkgs/commit/a12606bef42e79184c18e89146df6319e4715884) | `linuxPackages.zfs: use the kernel's stdenv when possible`                                  | `2021-09-02 20:45:52Z` |
| [`379f0308`](https://github.com/NixOS/nixpkgs/commit/379f030887d67a2bd610e95ef402a016a0a89d78) | `cope: fix version number`                                                                  | `2021-09-02 18:31:27Z` |
| [`ecbecedb`](https://github.com/NixOS/nixpkgs/commit/ecbecedb0d140c4e2ca0c2b26ce7750d5883aabd) | `python3Packages.haversine: 2.4.0 -> 2.5.1`                                                 | `2021-09-02 18:31:06Z` |
| [`682ed181`](https://github.com/NixOS/nixpkgs/commit/682ed1816c728f184164d099b6097317951640c8) | `python3Packages.time-machine: 2.3.1 -> 2.4.0`                                              | `2021-09-02 17:06:17Z` |
| [`4194d02d`](https://github.com/NixOS/nixpkgs/commit/4194d02deb6c3bd60dffe752b4b788570553a649) | `jitsi-meet-electron: 2.8.10 -> 2.8.11 (#136197)`                                           | `2021-09-02 16:35:46Z` |
| [`9ce8df12`](https://github.com/NixOS/nixpkgs/commit/9ce8df127d6d0b21ec3fc3864625677bb2fa73f6) | `nixos/etc: make sure local "source" files are imported to the store`                       | `2021-09-02 13:50:44Z` |
| [`7ca49a70`](https://github.com/NixOS/nixpkgs/commit/7ca49a701a7b6a9b90738af132f6b57e4160facd) | `ntfs-3g: update homepage`                                                                  | `2021-09-02 10:28:36Z` |
| [`0c35c72e`](https://github.com/NixOS/nixpkgs/commit/0c35c72ed4d85da1fa3f953aa2882716bb8d6332) | `ntfs-3g: 2017.3.23 -> 2021.8.22`                                                           | `2021-09-02 10:26:47Z` |
| [`0bab87d2`](https://github.com/NixOS/nixpkgs/commit/0bab87d2428f67aa4a6f0aca4e85aa63e8510dfb) | `flexget: 3.1.135 -> 3.1.136`                                                               | `2021-09-02 05:01:51Z` |
| [`3309bddc`](https://github.com/NixOS/nixpkgs/commit/3309bddc4061253df4e4d99399d926244e9807de) | `discord-canary: 0.0.128 -> 0.0.129`                                                        | `2021-09-01 23:46:06Z` |
| [`407ee9b0`](https://github.com/NixOS/nixpkgs/commit/407ee9b0edd1ff1c9d786fcccd3f0f66f68cbb13) | `notmuch: 0.32.2 -> 0.32.3`                                                                 | `2021-09-01 04:20:00Z` |
| [`c0b25025`](https://github.com/NixOS/nixpkgs/commit/c0b250259c084f4e1f33b44eefb33b28d30a693d) | `intel-media-driver: enable x11 only on linux, split dev output, move meta to the file end` | `2021-08-31 15:50:46Z` |
| [`0a8c01cf`](https://github.com/NixOS/nixpkgs/commit/0a8c01cfdf4fa663c57cb136b535bdf5deb55421) | `cope: init at unstable-2021-01-29`                                                         | `2021-08-31 15:49:54Z` |
| [`6032a2af`](https://github.com/NixOS/nixpkgs/commit/6032a2af13026299a5b9724c905f6aec3e186843) | `perlPackages.IOStty: init 0.04`                                                            | `2021-08-31 15:48:49Z` |
| [`7af45d85`](https://github.com/NixOS/nixpkgs/commit/7af45d854c4af872125126580e6135779de564cd) | `python38Packages.sparse: 0.12.0 -> 0.13.0`                                                 | `2021-08-29 18:40:51Z` |
| [`740b698e`](https://github.com/NixOS/nixpkgs/commit/740b698ea1a66b1a89dd974b50ef82f5f1908871) | `zeroad: 0.0.25 -> 0.0.25b`                                                                 | `2021-08-29 15:47:04Z` |
| [`58a40e05`](https://github.com/NixOS/nixpkgs/commit/58a40e05b2cdd366726b55fd6c077d97a8f6fc03) | `nixos/distccd: init`                                                                       | `2021-08-29 09:58:03Z` |
| [`b0d63741`](https://github.com/NixOS/nixpkgs/commit/b0d637413543afddb462fc1be1141004273feb17) | `python38Packages.qcelemental: 0.21.0 -> 0.22.0`                                            | `2021-08-28 14:07:19Z` |
| [`420f41f1`](https://github.com/NixOS/nixpkgs/commit/420f41f13c8acaedd351ed56bd57a7414f784129) | `python38Packages.flexmock: 0.10.5 -> 0.10.8`                                               | `2021-08-28 03:39:05Z` |
| [`00682a56`](https://github.com/NixOS/nixpkgs/commit/00682a56b9708b9dca5eb7320c746a9599d4e570) | `perlPackages.IOPty: init at 1.16`                                                          | `2021-08-27 21:48:01Z` |
| [`819b35aa`](https://github.com/NixOS/nixpkgs/commit/819b35aa85a32150c071e53264341660985e629f) | `nats-server: 2.3.4 -> 2.4.0`                                                               | `2021-08-27 09:03:41Z` |
| [`df07d4e1`](https://github.com/NixOS/nixpkgs/commit/df07d4e1a1204b4f204c4fd47d0b2f1d46a2403a) | `python39Packages.pglast: 3.3 -> 3.4`                                                       | `2021-08-26 03:45:34Z` |
| [`40a68ca8`](https://github.com/NixOS/nixpkgs/commit/40a68ca8e6dc0929154920deef51d22217b2a55f) | `ipfs-cluster: 0.14.0 -> 0.14.1`                                                            | `2021-08-16 17:10:06Z` |