### PR TITLE
chore(deps): update home-manager

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "21a2ff449620a9cb91802f9d1a9157b2ae8c6b39",
-        "sha256": "0q6q1i06cvksvk76ij5570nasa0wasp8qx7hxqwgi3h534kk5pnz",
+        "rev": "2952168ed59aa369a560563de2e00eab19f42d1b",
+        "sha256": "081bj9b3wwmc65gimkn6mwr40vjik6nl00gyqznfn59x6jj2nhhw",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/21a2ff449620a9cb91802f9d1a9157b2ae8c6b39.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/2952168ed59aa369a560563de2e00eab19f42d1b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixos-hardware": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                    | Timestamp              |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- | ---------------------- |
| [`2952168e`](https://github.com/nix-community/home-manager/commit/2952168ed59aa369a560563de2e00eab19f42d1b) | `docs: update session-vars info about fish shell` | `2021-09-04 21:12:17Z` |
| [`bd747c5a`](https://github.com/nix-community/home-manager/commit/bd747c5a53e6f0df368066788be26e9934620bcb) | `nixos: add timeout to hm-activate service`       | `2021-09-04 20:55:30Z` |