### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b3c692172e5b5241b028a98e1977f9fb12eeaf42",
-        "sha256": "0623b89yb9qlj63awsfjdj8xfc0d8sqm1jzc3qqrlnq66l411l06",
+        "rev": "7a08a9b2fba56b23d4a076727ffa0c1e74f083e5",
+        "sha256": "0frzh8imwamgqi7m6w5j4nyarkvrgm80ic22wbbzci4nnn9p8h8q",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/b3c692172e5b5241b028a98e1977f9fb12eeaf42.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/7a08a9b2fba56b23d4a076727ffa0c1e74f083e5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                               | Timestamp              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------ | ---------------------- |
| [`d5327b6d`](https://github.com/NixOS/nixpkgs/commit/d5327b6de285eaff4d525daa8203467c990f61db) | `reddsaver: 0.3.3 -> 0.4.0`                                  | `2021-09-05 06:25:06Z` |
| [`96f5319a`](https://github.com/NixOS/nixpkgs/commit/96f5319abb2195c877453696c6a906c0b29df3d3) | `hck: 0.6.1 -> 0.6.2`                                        | `2021-09-05 01:09:53Z` |
| [`2837f7a6`](https://github.com/NixOS/nixpkgs/commit/2837f7a6944432c7e38365681859635dd81288dc) | `python3Packages.deprecated: remove unused tox dependency`   | `2021-09-04 23:22:30Z` |
| [`c879a416`](https://github.com/NixOS/nixpkgs/commit/c879a416bbcf94f2895bc80ec970f8dd2b4f3cf8) | `super-slicer: 2.3.56.5 -> 2.3.56.8`                         | `2021-09-04 20:00:11Z` |
| [`287383c6`](https://github.com/NixOS/nixpkgs/commit/287383c61e51b1e11f933550e4a9acfe9d3477c5) | `emacs.pkgs.bqn-mode: init at unstable-2021-09-04`           | `2021-09-04 17:57:51Z` |
| [`a7bf9ea8`](https://github.com/NixOS/nixpkgs/commit/a7bf9ea8b5e773d9b4f49a7c28d63f636f07e181) | `grafana: support darwin`                                    | `2021-09-04 17:27:07Z` |
| [`4fef4315`](https://github.com/NixOS/nixpkgs/commit/4fef4315e8ea3f56b69880298bab7bb7d212b3be) | `bundler-audit: 0.8.0 → 0.9.0.1`                             | `2021-09-04 14:06:53Z` |
| [`5f84dad7`](https://github.com/NixOS/nixpkgs/commit/5f84dad75d24322ffe361a635e76839eee4aaa1f) | `kak-lsp: 10.0.0 -> 11.0.0`                                  | `2021-09-04 11:02:34Z` |
| [`08fee95d`](https://github.com/NixOS/nixpkgs/commit/08fee95dce40525555d902f740da05d2b53091e5) | `heisenbridge: 1.0.0 -> 1.0.1`                               | `2021-09-03 20:50:53Z` |
| [`7cfd9fcd`](https://github.com/NixOS/nixpkgs/commit/7cfd9fcd8f61a6c01591988ccb8f884736cd4719) | `credential-detector: init at 1.7.0`                         | `2021-09-03 20:01:11Z` |
| [`439c6eb7`](https://github.com/NixOS/nixpkgs/commit/439c6eb770c50277b977e70a8600868c9af705e1) | `scilla: 20210118 -> 1.1.1`                                  | `2021-09-03 18:29:43Z` |
| [`cfd5c585`](https://github.com/NixOS/nixpkgs/commit/cfd5c58596a5d38459f0c4245598c21fc63282dc) | `vimPlugins.crates-nvim: init at 2021-09-03`                 | `2021-09-03 17:19:00Z` |
| [`ca899bfe`](https://github.com/NixOS/nixpkgs/commit/ca899bfe66b54b6a982f8ddfb960786564e581e6) | `hck: 0.5.4 -> 0.6.1`                                        | `2021-09-03 15:55:19Z` |
| [`5111ac57`](https://github.com/NixOS/nixpkgs/commit/5111ac576445177a7b0edf9a53960f95b0dfb130) | `jibri: init at 8.0-93-g51fe7a2`                             | `2021-09-03 03:13:35Z` |
| [`c7b320cc`](https://github.com/NixOS/nixpkgs/commit/c7b320cc3943b5c4fdd5408628bdbe6f8a3f1498) | `python38Packages.google-cloud-bigquery: 2.25.1 -> 2.26.0`   | `2021-09-02 08:53:02Z` |
| [`1e93f306`](https://github.com/NixOS/nixpkgs/commit/1e93f306ad3d865c36e5765b3a14197acb5562f0) | `python38Packages.google-resumable-media: 2.0.0 -> 2.0.1`    | `2021-09-01 13:22:48Z` |
| [`5c3289c3`](https://github.com/NixOS/nixpkgs/commit/5c3289c3580a01f00a28ec18d0b093a1c7aa4656) | `python38Packages.google-cloud-translate: 3.3.2 -> 3.4.0`    | `2021-08-31 21:35:39Z` |
| [`d84b3e68`](https://github.com/NixOS/nixpkgs/commit/d84b3e685deeede364adb1ee5f1c0d1398c48e5f) | `python38Packages.google-cloud-monitoring: 2.4.2 -> 2.5.0`   | `2021-08-31 21:28:10Z` |
| [`5acfdf2c`](https://github.com/NixOS/nixpkgs/commit/5acfdf2ce072838c475c9929462b75c0bb205073) | `python38Packages.google-cloud-firestore: 2.3.0 -> 2.3.1`    | `2021-08-31 21:23:14Z` |
| [`b00e4cb9`](https://github.com/NixOS/nixpkgs/commit/b00e4cb942648fef36a30617e9fc4197652e10d0) | `python38Packages.google-cloud-kms: 2.5.0 -> 2.6.0`          | `2021-08-31 19:36:37Z` |
| [`f4333041`](https://github.com/NixOS/nixpkgs/commit/f4333041545ed41ba350f40b6cf5588e7982f7c5) | `python38Packages.google-cloud-os-config: 1.3.2 -> 1.4.0`    | `2021-08-31 19:31:44Z` |
| [`f42ac9bd`](https://github.com/NixOS/nixpkgs/commit/f42ac9bd1f3bc223507c34b28d55eb41cd5315f4) | `python38Packages.google-cloud-spanner: 3.8.0 -> 3.9.0`      | `2021-08-31 18:04:02Z` |
| [`38d0c7c3`](https://github.com/NixOS/nixpkgs/commit/38d0c7c35a407cff1ce95621ed68ac72090dc18f) | `python38Packages.google-cloud-speech: 2.7.0 -> 2.8.0`       | `2021-08-31 17:59:06Z` |
| [`7a750b53`](https://github.com/NixOS/nixpkgs/commit/7a750b53e53804b971d9b197473b2dc460e28a47) | `pipes-rs: init at 1.4.4`                                    | `2021-08-31 09:17:56Z` |
| [`e1ce3ce0`](https://github.com/NixOS/nixpkgs/commit/e1ce3ce0c457ef2e46e66947f657705793c51707) | `tfk8s: 0.1.6 -> 0.1.7`                                      | `2021-08-30 21:21:26Z` |
| [`4f7012be`](https://github.com/NixOS/nixpkgs/commit/4f7012bef7c767b46027ef885e6e3c0ad914189d) | `sonic-pi: wrap sonic-pi-server.rb as standalone executable` | `2021-08-27 17:01:51Z` |
| [`c460e15a`](https://github.com/NixOS/nixpkgs/commit/c460e15a46bb3c0655400e7a309542b0c2f31df1) | `fluxcd: 0.16.2 -> 0.17.0`                                   | `2021-08-27 15:25:07Z` |