### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f96ba73ac0057f5da7920b9635b25938508ad39b",
-        "sha256": "1i7yd58843k2gpyl59flrlh09wr7877x8sda5rxfcm77lbxid05i",
+        "rev": "dbea1a132b2f07f3e8c5908c3fb67f64cfce6744",
+        "sha256": "0lkl8grivhf6mrr7lzqslw66z7ps8y3bff5m96jm582v5g6j77im",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/f96ba73ac0057f5da7920b9635b25938508ad39b.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/dbea1a132b2f07f3e8c5908c3fb67f64cfce6744.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                         | Pull Requests                                                                        |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`40d49815`](https://github.com/NixOS/nixpkgs/commit/40d49815f227c88407c2f450c30dc06a40c8b5de) | `oh-my-zsh: 2021-08-27 → 2021-09-07`                                   | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136582">#136582</a></li></ul> |
| [`1fb4400c`](https://github.com/NixOS/nixpkgs/commit/1fb4400c912004a2f83a1c493737165fa9d3b6d8) | `linuxPackages.perf-tools: clarify license`                            | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136187">#136187</a></li></ul> |
| [`5c14c688`](https://github.com/NixOS/nixpkgs/commit/5c14c688d2603581b536dd9ff0a6bce867aa2c91) | `linuxPackages.bbswitch: add license`                                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136178">#136178</a></li></ul> |
| [`0e02dd4f`](https://github.com/NixOS/nixpkgs/commit/0e02dd4f10d70f11b889ca6fbd059e1007b4d6e3) | `diffoscope: 182 -> 183`                                               | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137112">#137112</a></li></ul> |
| [`e740711c`](https://github.com/NixOS/nixpkgs/commit/e740711cf6a18d9e2d2965e07b6f6913e6b62d8b) | `virtualbox: remove components/VBoxREM.so when`                        | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137114">#137114</a></li></ul> |
| [`427403fc`](https://github.com/NixOS/nixpkgs/commit/427403fc3bf0e4b6b5bec7a882d2e2fe6890f5dd) | `grafana: 8.1.2 -> 8.1.3`                                              | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137111">#137111</a></li></ul> |
| [`c524608d`](https://github.com/NixOS/nixpkgs/commit/c524608dca14c8716eaefa88d2aa8c757af48daa) | `mkshell: small fix for #137005 (#137105)`                             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137105">#137105</a></li></ul> |
| [`63389636`](https://github.com/NixOS/nixpkgs/commit/6338963691a3c8693a8a428605dfcb2428a2d540) | `python39Packages.pomegranate: disable two failing tests`              | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137081">#137081</a></li></ul> |
| [`4ad1d0ea`](https://github.com/NixOS/nixpkgs/commit/4ad1d0ea31e0cbb4eebac7e00571247dedb3c562) | `vimPlugins.neorg: fix owner`                                          | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137108">#137108</a></li></ul> |
| [`a296b8f9`](https://github.com/NixOS/nixpkgs/commit/a296b8f92948cef750bf49e5826e9271903c88a9) | `python38Packages.trezor: 0.12.3 -> 0.12.4`                            | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137109">#137109</a></li></ul> |
| [`71360607`](https://github.com/NixOS/nixpkgs/commit/7136060765c03921e438c2a4032cb25f40607a11) | `mkCoqDerivation: use COQMF_COQLIB for dev versions of Coq`            | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136908">#136908</a></li></ul> |
| [`087513bc`](https://github.com/NixOS/nixpkgs/commit/087513bc11ed548a98587a7ac6b69472e3323231) | `mkShell: exclude inputsFrom from merged inputs (#137005)`             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137005">#137005</a></li></ul> |
| [`1eebd963`](https://github.com/NixOS/nixpkgs/commit/1eebd96344d1603a87263b1709590a5539fd6fbe) | `coqPackages.corn: c366d3f01ec1812b145117a4da940518b092d3a6 -> 8.13.0` | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136989">#136989</a></li></ul> |
| [`dc3060a0`](https://github.com/NixOS/nixpkgs/commit/dc3060a012775510579b8a36a8112bbb750c0ac8) | `libxc: 5.1.5 -> 5.1.6`                                                | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137091">#137091</a></li></ul> |
| [`3e9f6d7e`](https://github.com/NixOS/nixpkgs/commit/3e9f6d7e99806a16c6a2b76fcba11dca64091f6d) | `exaile: init at 4.1.1 (#120761)`                                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/120761">#120761</a></li></ul> |
| [`c43a2609`](https://github.com/NixOS/nixpkgs/commit/c43a2609a30e5b81a7b81d59fdda36bcb137a382) | `cni-plugins: 1.0.0 -> 1.0.1`                                          | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137075">#137075</a></li></ul> |
| [`a49177e0`](https://github.com/NixOS/nixpkgs/commit/a49177e0ce2a057bc7429e207db043639d06bfb8) | `maintainers: remove bricewge`                                         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137088">#137088</a></li></ul> |
| [`50793c3c`](https://github.com/NixOS/nixpkgs/commit/50793c3c457d6383b66b352ff185c612617be16f) | `foreman: 0.78.0 -> 0.87.2`                                            | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137086">#137086</a></li></ul> |
| [`61ce506b`](https://github.com/NixOS/nixpkgs/commit/61ce506bda30291739c7cd6bca4b5ff07987ed12) | `python3Packages.xmlschema: migrate to pytestCheckHook`                | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136913">#136913</a></li></ul> |
| [`5d56aee6`](https://github.com/NixOS/nixpkgs/commit/5d56aee6dab00fe60e9e24ae88aea141ec64ee0c) | `python38Packages.google-cloud-asset: 3.4.0 -> 3.5.0`                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137083">#137083</a></li></ul> |
| [`aa8d87c7`](https://github.com/NixOS/nixpkgs/commit/aa8d87c790ea883475da73baeaa67475f8edd707) | `python3Packages.elementpath: update disable`                          | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137072">#137072</a></li></ul> |
| [`377848dc`](https://github.com/NixOS/nixpkgs/commit/377848dc23514878d90b55752fa3c9fb8eff5a68) | `python38Packages.google-resumable-media: 2.0.1 -> 2.0.2`              | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137074">#137074</a></li></ul> |
| [`21cb9e80`](https://github.com/NixOS/nixpkgs/commit/21cb9e808d03c0bef999648a1b40ac6dc0e6f533) | `spoof-mac: init at unstable-2018-01-27`                               | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137071">#137071</a></li></ul> |
| [`43a153c6`](https://github.com/NixOS/nixpkgs/commit/43a153c671dc5f1917869bd194500a48c58f91e7) | `python38Packages.elementpath: 2.3.0 -> 2.3.1`                         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137072">#137072</a></li></ul> |
| [`4e5fc40f`](https://github.com/NixOS/nixpkgs/commit/4e5fc40fd90b4acc4bf23524bf2699f31bc52608) | `gnome-network-displays: 0.90.4 -> 0.90.5`                             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137044">#137044</a></li></ul> |
| [`f4c654f2`](https://github.com/NixOS/nixpkgs/commit/f4c654f240308e0db6d2bd70e198db2a1fa034db) | `difftastic: 0.6 -> 0.8`                                               | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137050">#137050</a></li></ul> |
| [`d90bafbc`](https://github.com/NixOS/nixpkgs/commit/d90bafbcad568697336790eebd9fd1a9d268a9ea) | `mylvmbackup: remove meta.homepage from fetch url`                     | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137033">#137033</a></li></ul> |
| [`714c90ee`](https://github.com/NixOS/nixpkgs/commit/714c90ee5f04c1a0628cb5a708c3c70b869e7c05) | `coqPackages.mathcomp-analysis: 0.3.9 -> 0.3.10`                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136938">#136938</a></li></ul> |
| [`8c6e887e`](https://github.com/NixOS/nixpkgs/commit/8c6e887e750ed2c184e6018a8c3504124a09b1b3) | `matrix-synapse: 1.41.1 -> 1.42.0`                                     | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136388">#136388</a></li></ul> |
| [`ea0f9ce7`](https://github.com/NixOS/nixpkgs/commit/ea0f9ce7634112cbdaaec81a1b7f152f48331867) | `upower: 0.99.11 -> 0.99.13`                                           | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136982">#136982</a></li></ul> |
| [`a851b4d2`](https://github.com/NixOS/nixpkgs/commit/a851b4d20ee0dad33395f85a092df47ac9b1cc3e) | `nixos/users-groups: Add dry mode`                                     | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136605">#136605</a></li></ul> |
| [`aec12877`](https://github.com/NixOS/nixpkgs/commit/aec12877d3776403e64028c5146b27e85aae883d) | `lollypop: 1.4.17 -> 1.4.23`                                           | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136954">#136954</a></li></ul> |
| [`75125b85`](https://github.com/NixOS/nixpkgs/commit/75125b85d0e7be6a59c374bb830ce05a79bd9df2) | `hip: init at 4.3.1`                                                   | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136445">#136445</a></li></ul> |
| [`633be57c`](https://github.com/NixOS/nixpkgs/commit/633be57c3928b0080f2aa72ab9a795734c1e03e3) | `python38Packages.xmlschema: 1.7.0 -> 1.7.1`                           | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136913">#136913</a></li></ul> |
| [`31567304`](https://github.com/NixOS/nixpkgs/commit/315673040200723568c562b68550a2f8b4fe6e6a) | `nixos/switch-to-configuration: Add dry activation scripts`            | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136605">#136605</a></li></ul> |
| [`715eea83`](https://github.com/NixOS/nixpkgs/commit/715eea832f66b5d81fd711afa307640e91870d27) | `rocminfo: init at 4.3.1`                                              | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136445">#136445</a></li></ul> |
| [`0a8c0cfa`](https://github.com/NixOS/nixpkgs/commit/0a8c0cfa8bc9456cc13a483b75ec68a331b8b687) | `rocm-opencl-icd: add lovesegfault as maintainer`                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136445">#136445</a></li></ul> |
| [`0bfc804d`](https://github.com/NixOS/nixpkgs/commit/0bfc804da20e1dd77a99568c9ea503fb1352ccf9) | `rocm-opencl-runtime: 4.1.0 -> 4.3.1`                                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136445">#136445</a></li></ul> |
| [`d212d1bb`](https://github.com/NixOS/nixpkgs/commit/d212d1bbb4b18892e3c29b8af278f69427ce8e94) | `rocclr: 4.1.0 -> 4.3.1`                                               | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136445">#136445</a></li></ul> |
| [`fae3bbca`](https://github.com/NixOS/nixpkgs/commit/fae3bbca9b273097e71aa8615422faff169d4a91) | `rocm-smi: 4.1.0 -> 4.3.1`                                             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136445">#136445</a></li></ul> |
| [`9d96c400`](https://github.com/NixOS/nixpkgs/commit/9d96c4004821ca5c97399bbfda65108c634d297c) | `rocm-runtime: 4.1.0 -> 4.3.1`                                         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136445">#136445</a></li></ul> |
| [`ff514b07`](https://github.com/NixOS/nixpkgs/commit/ff514b0737d549b0ed49e95ef8b04f54181a9c81) | `rocm-thunk: 4.1.0 -> 4.3.1`                                           | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136445">#136445</a></li></ul> |
| [`41657603`](https://github.com/NixOS/nixpkgs/commit/416576036e872330a68be44fd9b35016230bf357) | `rocm-device-libs: 4.1.0 -> 4.3.1`                                     | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136445">#136445</a></li></ul> |
| [`4fa55823`](https://github.com/NixOS/nixpkgs/commit/4fa55823c32762275b92efffc6266a5f1c389599) | `rocm-comgr: 4.1.0 -> 4.3.1`                                           | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136445">#136445</a></li></ul> |
| [`bd698dbd`](https://github.com/NixOS/nixpkgs/commit/bd698dbd7ee62c11bfc03a9d648c1caa98639fcf) | `rocm-cmake: 4.1.0 -> 4.3.1`                                           | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136445">#136445</a></li></ul> |
| [`e3b026fd`](https://github.com/NixOS/nixpkgs/commit/e3b026fdba25f31bf542148a11966e926809cf59) | `llvmPackages_rocm: 4.1.0 -> 4.3.1`                                    | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136445">#136445</a></li></ul> |
| [`e4459e59`](https://github.com/NixOS/nixpkgs/commit/e4459e59a2d29c63ec8cb669b47bdfe4ece59b36) | `llvmPackages_rocm: add compiler-rt`                                   | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136445">#136445</a></li></ul> |
| [`e21c64bb`](https://github.com/NixOS/nixpkgs/commit/e21c64bbf13975b326ab53361a4b665cd87a2380) | `perlPackages.DataSectionSimple: init at 0.07`                         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/135667">#135667</a></li></ul> |
| [`42c17f73`](https://github.com/NixOS/nixpkgs/commit/42c17f73417363746331b989c5eac25800a926ac) | `perlPackages.TestSnapshot: init at 0.06`                              | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/135667">#135667</a></li></ul> |
| [`67bcf059`](https://github.com/NixOS/nixpkgs/commit/67bcf059a2534796de614221c04865ee9935bb39) | `perlPackages.BarcodeZBar: init at 0.04pre`                            | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/135667">#135667</a></li></ul> |
| [`f358f732`](https://github.com/NixOS/nixpkgs/commit/f358f7326b811d1ad0694187b4ece53f8e56576e) | `tasks/lvm: add all tools from thin-provisioning-tools`                | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/132786">#132786</a></li></ul> |