### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dbea1a132b2f07f3e8c5908c3fb67f64cfce6744",
-        "sha256": "0lkl8grivhf6mrr7lzqslw66z7ps8y3bff5m96jm582v5g6j77im",
+        "rev": "6511f4cb3e3222ba6a9b7cb0ae03d66b28465102",
+        "sha256": "02i00p96761510ypp0wc3wlajygqwg1sy6afvv0rfzzbi3nysl5s",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/dbea1a132b2f07f3e8c5908c3fb67f64cfce6744.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/6511f4cb3e3222ba6a9b7cb0ae03d66b28465102.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                     | Pull Requests                                                                        |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`6511f4cb`](https://github.com/NixOS/nixpkgs/commit/6511f4cb3e3222ba6a9b7cb0ae03d66b28465102) | `tremc: fix crash with python 3.9 (#137107)`                                                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137107">#137107</a></li></ul> |
| [`f94193eb`](https://github.com/NixOS/nixpkgs/commit/f94193eb397a2dc12df1dc9fa46ad61864abec08) | `python39Packages.google-resumable-media: remove duplicated checkInput with propagatedBuildInputs` | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137166">#137166</a></li></ul> |
| [`4b05f319`](https://github.com/NixOS/nixpkgs/commit/4b05f3192eb1ff2ea07f26b8eeb09278a17f5be8) | `python39Packages.google-cloud-asset: remove unused input, outdated postPatch`                     | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137166">#137166</a></li></ul> |
| [`30769070`](https://github.com/NixOS/nixpkgs/commit/307690708af02db7c435367aa854cda623bb892b) | `build(deps): bump cachix/install-nix-action from 13 to 14`                                        | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137161">#137161</a></li></ul> |
| [`7e107157`](https://github.com/NixOS/nixpkgs/commit/7e10715778240535cc6e4db19bcdfb7c89378b71) | `ocamlPackages.ocaml-lsp: fix list of dependencies for 1.7.0`                                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136152">#136152</a></li></ul> |
| [`af82bb0a`](https://github.com/NixOS/nixpkgs/commit/af82bb0abf2b16f6b077bc48633e6daf68414c31) | `ocamlPackages.ocaml-lsp: fix minimum ocaml version`                                               | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136152">#136152</a></li></ul> |
| [`3080ccb1`](https://github.com/NixOS/nixpkgs/commit/3080ccb11a82776982368fb221428e039ed82ac6) | `ocamlPackages.jsonrpc: drop unnecesary dependencies for 1.7.0`                                    | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136152">#136152</a></li></ul> |
| [`80a925e7`](https://github.com/NixOS/nixpkgs/commit/80a925e7981e0689de04e42a3902dfe722a38a94) | `python38Packages.google-cloud-os-config: 1.4.0 -> 1.5.0`                                          | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137160">#137160</a></li></ul> |
| [`cfe9aad7`](https://github.com/NixOS/nixpkgs/commit/cfe9aad7f8d4a3b2a4c84934d36b1c4ca6e80e18) | `python38Packages.google-cloud-storage: 1.42.0 -> 1.42.1`                                          | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137158">#137158</a></li></ul> |
| [`5dd0e70d`](https://github.com/NixOS/nixpkgs/commit/5dd0e70d95cd282d4e4937b509e7d411d2c6fd84) | `exploitdb: 2021-09-03 -> 2021-09-08`                                                              | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137155">#137155</a></li></ul> |
| [`5c002b97`](https://github.com/NixOS/nixpkgs/commit/5c002b979bbe3c857ec87f2c84164d8266bc0781) | `mask: init at 0.11.0`                                                                             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137150">#137150</a></li></ul> |
| [`685621be`](https://github.com/NixOS/nixpkgs/commit/685621be34fecca351bf0b3af0c91b9d34a981cd) | `flexget: 3.1.136 -> 3.1.137`                                                                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137141">#137141</a></li></ul> |
| [`17bb4a04`](https://github.com/NixOS/nixpkgs/commit/17bb4a0492a081801d2d613599d3324aa56a9e4f) | `monero-gui: 0.17.2.2 -> 0.17.2.3`                                                                 | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137140">#137140</a></li></ul> |
| [`67173fba`](https://github.com/NixOS/nixpkgs/commit/67173fba04df8cf1c375d819a162f80adfe4b3d7) | `monero: 0.17.2.0 -> 0.17.2.3`                                                                     | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137140">#137140</a></li></ul> |
| [`2d42e76e`](https://github.com/NixOS/nixpkgs/commit/2d42e76e5befb12aca7cdf5c13c6d975fdd6ea46) | `vimPlugins.nvim-spectre: init at 2021-09-05`                                                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137012">#137012</a></li></ul> |
| [`7218e421`](https://github.com/NixOS/nixpkgs/commit/7218e4212681618ba301ecef9c37533d993684d7) | `vimPlugins.minsnip-nvim: init at 2021-09-06`                                                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137012">#137012</a></li></ul> |
| [`8609a1bc`](https://github.com/NixOS/nixpkgs/commit/8609a1bca3675a36f19552897961111eb1f19f73) | `zimg: 3.0.2 -> 3.0.3`                                                                             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137139">#137139</a></li></ul> |
| [`db6133ac`](https://github.com/NixOS/nixpkgs/commit/db6133acf173987e87ea1d0d98d7dea3563542b3) | `python3Packages.dpath: 2.0.2 -> 2.0.3`                                                            | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137138">#137138</a></li></ul> |
| [`d8dcebe5`](https://github.com/NixOS/nixpkgs/commit/d8dcebe5457e9294812b2aa3ee60bdb0bd56ecab) | `dune_2: 2.9.0 -> 2.9.1`                                                                           | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137049">#137049</a></li></ul> |
| [`cb1aa865`](https://github.com/NixOS/nixpkgs/commit/cb1aa865ab16bca3ac4d31c96eb42db67294d527) | `xine-ui: remove a unnecessary ; in desktop file`                                                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137128">#137128</a></li></ul> |
| [`60ac8a80`](https://github.com/NixOS/nixpkgs/commit/60ac8a804ffbef131bbbabef41d4ab2efbaa701d) | `cilium-cli: 0.8.6 -> 0.9.0`                                                                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137126">#137126</a></li></ul> |
| [`889fb370`](https://github.com/NixOS/nixpkgs/commit/889fb37036cac83a90f1b09f38f50c29e9d23a20) | `top-level/all-packages: remove redundant pkgs`                                                    | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137115">#137115</a></li></ul> |
| [`2bcd3dad`](https://github.com/NixOS/nixpkgs/commit/2bcd3dad866e70b0dc4943d3ff32ffcd487ec301) | `nixos/top-level: Check activation script syntax`                                                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137120">#137120</a></li></ul> |
| [`8276a5e6`](https://github.com/NixOS/nixpkgs/commit/8276a5e677128c1ca77b876e3ccc55603a427fad) | `notmuch: 0.32.3 -> 0.33`                                                                          | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136917">#136917</a></li></ul> |
| [`67834028`](https://github.com/NixOS/nixpkgs/commit/678340280141145c8d599ae92b357a80d970b586) | `hck: 0.6.2 -> 0.6.3`                                                                              | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137101">#137101</a></li></ul> |
| [`36a77bbe`](https://github.com/NixOS/nixpkgs/commit/36a77bbe7e0ec366ea8dd513f13a2339a2a18129) | `fluentd: remove fluent-plugin-scribe`                                                             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137076">#137076</a></li></ul> |
| [`14ffc3e3`](https://github.com/NixOS/nixpkgs/commit/14ffc3e3bef925374ccfdf43e68eb0f8eefe532f) | `python3Packages.youless-api: 0.12 -> 0.13`                                                        | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137073">#137073</a></li></ul> |
| [`c9507977`](https://github.com/NixOS/nixpkgs/commit/c9507977b0f1197b351c15ec35f5fe9e40e3916e) | `julia-mono: 0.041 -> 0.042`                                                                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137063">#137063</a></li></ul> |
| [`78c60fba`](https://github.com/NixOS/nixpkgs/commit/78c60fba0a680ce1d531fb08d508aed8d8e5efb5) | `age: install manpages`                                                                            | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137103">#137103</a></li></ul> |
| [`c1fe21db`](https://github.com/NixOS/nixpkgs/commit/c1fe21db9029c7bfce4be3c14b726220f72a3f1a) | `swi-prolog: 8.3.9 -> 8.3.29`                                                                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137061">#137061</a></li></ul> |
| [`2e0d1231`](https://github.com/NixOS/nixpkgs/commit/2e0d1231584451741f62fe810a8385040cfc6a9f) | `swi-prolog: set meta.mainProgram`                                                                 | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137061">#137061</a></li></ul> |
| [`e2c8dbe5`](https://github.com/NixOS/nixpkgs/commit/e2c8dbe58cca3ce8d6c0131d411301030304eba7) | `certbot: 1.18.0 -> 1.19.0`                                                                        | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137059">#137059</a></li></ul> |
| [`7df8ba40`](https://github.com/NixOS/nixpkgs/commit/7df8ba4012d0be57d8a4397ac4b1dd6f818e7023) | `ulauncher: patchShebangs and do not double wrap`                                                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137056">#137056</a></li></ul> |
| [`1614fc6e`](https://github.com/NixOS/nixpkgs/commit/1614fc6eb63d012b704cbb34b9c53c823d51c32c) | `github-runner: adapt to latest lttng-ust`                                                         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136988">#136988</a></li></ul> |
| [`ebcf2468`](https://github.com/NixOS/nixpkgs/commit/ebcf2468ac67b473821946a6d5539c001861b465) | `github-runner: 2.279.0 -> 2.281.1`                                                                | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136988">#136988</a></li></ul> |
| [`0d1e4278`](https://github.com/NixOS/nixpkgs/commit/0d1e42786e6bc5249248e50793f9f8537aaad857) | `github-runner: make derivation easier to override`                                                | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136988">#136988</a></li></ul> |
| [`51170e3c`](https://github.com/NixOS/nixpkgs/commit/51170e3cb823a804a67e9407a0db1cacbb9d3e99) | `python3Packages.envoy-reader: 0.19.0 -> 0.20.0`                                                   | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136877">#136877</a></li></ul> |
| [`14cd4bb1`](https://github.com/NixOS/nixpkgs/commit/14cd4bb1dd6c860f47457b295957915641cf7da0) | `python3Packages.envoy-utils: init at 0.0.1`                                                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136877">#136877</a></li></ul> |
| [`6ce6aae6`](https://github.com/NixOS/nixpkgs/commit/6ce6aae6743fcb4c923dc0c681e3252c6dcfafa6) | `pythonPackages.mysql-connector: Fix on darwin`                                                    | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/130734">#130734</a></li></ul> |
| [`eefaf905`](https://github.com/NixOS/nixpkgs/commit/eefaf9052053977856d95d916fa6f82379226e4f) | `mailspring: 1.9.1 -> 1.9.2`                                                                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136852">#136852</a></li></ul> |
| [`4f780884`](https://github.com/NixOS/nixpkgs/commit/4f7808842d194477d865393c705970a3bf4279f5) | `shen-sbcl: rewrite`                                                                               | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136660">#136660</a></li></ul> |
| [`fb1b0dc6`](https://github.com/NixOS/nixpkgs/commit/fb1b0dc6cd1e2b4357c79983e12d62619cb4789b) | `shen-sources: 22.3 -> 22.4`                                                                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136658">#136658</a></li></ul> |
| [`c584d0c4`](https://github.com/NixOS/nixpkgs/commit/c584d0c421df111c178bba55b1dfe47ddf04fa9e) | `pythonPackages.mysql-connector: Add turion and neosimsim to maintainers`                          | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/130734">#130734</a></li></ul> |