### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6511f4cb3e3222ba6a9b7cb0ae03d66b28465102",
-        "sha256": "02i00p96761510ypp0wc3wlajygqwg1sy6afvv0rfzzbi3nysl5s",
+        "rev": "c0e9cb30cc891e0e866d9b71aa891d9281e72fb6",
+        "sha256": "0ixc2xiqb3ip30lgv9vrb0fk7w0vd9wyhgsadhpgxyzdzvz3vkaj",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/6511f4cb3e3222ba6a9b7cb0ae03d66b28465102.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/c0e9cb30cc891e0e866d9b71aa891d9281e72fb6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                        |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`70a469d8`](https://github.com/NixOS/nixpkgs/commit/70a469d855e0b42c7a1d946f339edcee44f92cbe) | `ocamlPackages.js_of_ocaml: 3.9.1 → 3.10.0`                           |
| [`f7cef10c`](https://github.com/NixOS/nixpkgs/commit/f7cef10c90e9f09f87c013db7f627370df2e2668) | `liburing: 2.0 -> 2.1`                                                |
| [`c9ce275a`](https://github.com/NixOS/nixpkgs/commit/c9ce275aa4e7176d8e480e4b8bafe76f9c837162) | `treewide: "does not exists" -> "does not exist"`                     |
| [`bbdb34ab`](https://github.com/NixOS/nixpkgs/commit/bbdb34ab0416970de9bc2c4e19c9b4972f79b8a7) | `python3Packages.pulsectl: add comment for substitution`              |
| [`2938a58f`](https://github.com/NixOS/nixpkgs/commit/2938a58f2d3a9946772c56b1927aea04759b16d2) | `linux_lqx: 5.13.9 -> 5.13.15`                                        |
| [`042d1c54`](https://github.com/NixOS/nixpkgs/commit/042d1c5497e58572e2eae46fffb22b8d0c9eafbb) | `python38Packages.sphinxcontrib-bibtex: 2.3.0 -> 2.4.0`               |
| [`48a54cc8`](https://github.com/NixOS/nixpkgs/commit/48a54cc8203c3a7dab60e3e87132087a9e3d946f) | `hip: add update script`                                              |
| [`9d269a87`](https://github.com/NixOS/nixpkgs/commit/9d269a87e1284ef7a9816fef7bc62e93e9dc1f4e) | `rocminfo: add update script`                                         |
| [`6e93fa31`](https://github.com/NixOS/nixpkgs/commit/6e93fa31f27d49787448f20c7ebe1c16656e7ad4) | `rocclr: add update script`                                           |
| [`61a2864b`](https://github.com/NixOS/nixpkgs/commit/61a2864b18b0a79e701650a7b517b06aa4efcb3b) | `llvmPackages_rocm: add update script`                                |
| [`dd50512f`](https://github.com/NixOS/nixpkgs/commit/dd50512f677aed11088ff227e7b3b8801841abed) | `fishPlugins.fzf-fish: 5.6 -> 7.3 (#137153)`                          |
| [`f6eb933d`](https://github.com/NixOS/nixpkgs/commit/f6eb933d1c695eb4f1444508c7210c09b92359e9) | `python38Packages.robotframework: 4.1 -> 4.1.1`                       |
| [`0247d6f9`](https://github.com/NixOS/nixpkgs/commit/0247d6f9228789ee440d89ac60c3dd81d80e64c6) | `firefox-bin-unwrapped: 91.0.2 -> 92.0`                               |
| [`21c5ff78`](https://github.com/NixOS/nixpkgs/commit/21c5ff7850dfbaa002f47297960436cb98cf8dc1) | `firefox-unwrapped: 91.0.2 -> 92.0`                                   |
| [`e079a9b4`](https://github.com/NixOS/nixpkgs/commit/e079a9b46d37184d5b2a79f452310069dad2672a) | `nss: 3.68 -> 3.70`                                                   |
| [`ca4e1d10`](https://github.com/NixOS/nixpkgs/commit/ca4e1d109552ffb334a5d84e4d426cc975124175) | `CODEOWNERS: add myself to lib/systems`                               |
| [`d61ba986`](https://github.com/NixOS/nixpkgs/commit/d61ba9863c07f268fe53b78159ab76c3183c6ca1) | `nodePackages.prisma: init at 2.30.2`                                 |
| [`d99dfe58`](https://github.com/NixOS/nixpkgs/commit/d99dfe5821103299c7b37cbbf1d9fc674ae5b135) | `rocm-comgr: add update script`                                       |
| [`1ab7362a`](https://github.com/NixOS/nixpkgs/commit/1ab7362a4e1c3176a1a6a5fec8c0ab1c9541e767) | `rocm-device-libs: add update script`                                 |
| [`c3aa2d2e`](https://github.com/NixOS/nixpkgs/commit/c3aa2d2e27f365779fce182b6b70d3cd961bbb3b) | `rocm-opencl-runtime: add update script`                              |
| [`315631df`](https://github.com/NixOS/nixpkgs/commit/315631dfe3645fd92f75de90c39932164a38ebbd) | `rocm-runtime: add update script`                                     |
| [`ea2a723c`](https://github.com/NixOS/nixpkgs/commit/ea2a723c00f7c3f083042aa45b967655a74ab6a3) | `rocm-thunk: add update script`                                       |
| [`f7381193`](https://github.com/NixOS/nixpkgs/commit/f73811932b7e149babbbf157a0c29d3b81e144be) | `rocm-cmake: add update script`                                       |
| [`52e1574f`](https://github.com/NixOS/nixpkgs/commit/52e1574f251cafac2c8520bf48db6353178b0f12) | `rocm-smi: add update script and fix url`                             |
| [`d4ff22be`](https://github.com/NixOS/nixpkgs/commit/d4ff22bee83b9428a8994a8ec32fc4a8f39d9345) | `qmk: 0.0.52 -> 1.0.0`                                                |
| [`9e3fee07`](https://github.com/NixOS/nixpkgs/commit/9e3fee0724f66c7505dc63fa4bb584e3014ac251) | `qmk-dotty-dict: init at 1.3.0.post1`                                 |
| [`34e468dc`](https://github.com/NixOS/nixpkgs/commit/34e468dc4268cee86aa019ae9bc52768e60fb5f7) | `lib/systems: add minimal s390x-linux cross-compile support`          |
| [`3e788570`](https://github.com/NixOS/nixpkgs/commit/3e788570514ec7098f2e7fd00edc673fc89b3a21) | `josm: 18118 → 18193`                                                 |
| [`c9d8b264`](https://github.com/NixOS/nixpkgs/commit/c9d8b264d63392afd8cb388feae1ce9c7ab83654) | `pulumi-bin: 3.10.0 -> 3.12.0`                                        |
| [`68ed5911`](https://github.com/NixOS/nixpkgs/commit/68ed591187356ed90cde04b500e4e236d612c7e8) | `postgresqlPackages.pg_auto_failover: 1.6.1 -> 1.6.2`                 |
| [`52731e1d`](https://github.com/NixOS/nixpkgs/commit/52731e1d01f9d2eabe55b4ab3f1caa28971e6bea) | `tv: init at 0.5.1`                                                   |
| [`90ec05be`](https://github.com/NixOS/nixpkgs/commit/90ec05be8f7475d0f7f8c8c5e81545d5689f6ab1) | `csview: init at 0.3.8`                                               |
| [`0ad75c87`](https://github.com/NixOS/nixpkgs/commit/0ad75c87c9b92f853b8e11f939373615aafc64d9) | `hydrus: 452 -> 454`                                                  |
| [`a2955cd3`](https://github.com/NixOS/nixpkgs/commit/a2955cd3325c6afa4317d354cc2ee46808e29755) | `python38Packages.pulsectl: 21.5.18 -> 21.9.1`                        |
| [`12c40d99`](https://github.com/NixOS/nixpkgs/commit/12c40d9972f698042cfaf63342ce6beca5c62a5d) | `knot-dns: 3.1.1 -> 3.1.2`                                            |
| [`b32e2cfc`](https://github.com/NixOS/nixpkgs/commit/b32e2cfc1dd21bbcf05fb1c313a112f18306693d) | `plexamp: 3.5.0 -> 3.7.0`                                             |
| [`c2073fcb`](https://github.com/NixOS/nixpkgs/commit/c2073fcb1a41f2ceb2d8bdbbb2132609eed70ead) | `singularity: 3.8.2 -> 3.8.3`                                         |
| [`c9c16335`](https://github.com/NixOS/nixpkgs/commit/c9c16335d3fce0a1edc8e9fb6a9cb192e1663dfd) | `libplacebo: 3.120.3 -> 4.157.0`                                      |
| [`a583c3dd`](https://github.com/NixOS/nixpkgs/commit/a583c3ddad44456cd778c5fec762c6286f98cd30) | `nvidia-container-toolkit: 1.3.0 -> 1.5.0`                            |
| [`0f7d54ab`](https://github.com/NixOS/nixpkgs/commit/0f7d54ab97781cf41c001e4a9bb73d841583b464) | `nvidia-container-runtime: 3.4.0 -> 3.5.0`                            |
| [`f77daccd`](https://github.com/NixOS/nixpkgs/commit/f77daccd528ddc8db479a744b7588fa2da39fb96) | `libnvidia-container: 1.3.3 -> 1.5.0`                                 |
| [`8f06bd48`](https://github.com/NixOS/nixpkgs/commit/8f06bd48f26af655d9c112b27eb3d22a874685c4) | `python3Packages.jaxlib: add cudatoolkit_11 to rpaths`                |
| [`3ea5dbdd`](https://github.com/NixOS/nixpkgs/commit/3ea5dbdd720abec9a48665a69e69e5486bfe0fa0) | `python3Packages.jaxlib: add cudatoolkit_11 in propagatedBuildInputs` |
| [`0ff98615`](https://github.com/NixOS/nixpkgs/commit/0ff986154ea140f256e47a78233579ad27d8387a) | `python3Packages.jaxlib: add CUDA support`                            |
| [`6f44416c`](https://github.com/NixOS/nixpkgs/commit/6f44416cf2655b87378d3752eda00dfccb39dea6) | `python3Packages.jax: remove meta.description period`                 |
| [`a16117f1`](https://github.com/NixOS/nixpkgs/commit/a16117f1c042d4772d750077fa3c21421cf4a199) | `maintainer-list.nix: add samuela`                                    |
| [`426569a0`](https://github.com/NixOS/nixpkgs/commit/426569a04174720817242de5e8d9157582595055) | `python3Packages.jax: init at 0.2.19`                                 |
| [`1f868637`](https://github.com/NixOS/nixpkgs/commit/1f8686373abe21bf6b1ce972f0ea55405b449329) | `python3Packages.jaxlib: init at 0.1.70`                              |
| [`3f0fb761`](https://github.com/NixOS/nixpkgs/commit/3f0fb761044413e4d4f2c1d3d34e89726860d701) | `spotifyd: generate TOML config via formats`                          |
| [`bf185eaa`](https://github.com/NixOS/nixpkgs/commit/bf185eaa6935c4ab58f079a7a5c3e09ce5a123f9) | `nixos-rebuild: add --use-substitutes option`                         |