### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c0e9cb30cc891e0e866d9b71aa891d9281e72fb6",
-        "sha256": "0ixc2xiqb3ip30lgv9vrb0fk7w0vd9wyhgsadhpgxyzdzvz3vkaj",
+        "rev": "c678e050c1978110badd975274785265fc953a66",
+        "sha256": "1lxra4sc8ldk8s6wlx35l5n0i8aqcqsdj42m3hns051rqbmyn7zl",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/c0e9cb30cc891e0e866d9b71aa891d9281e72fb6.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/c678e050c1978110badd975274785265fc953a66.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`336f829f`](https://github.com/NixOS/nixpkgs/commit/336f829fc43f3043693931b8b0b7ce626861bc7d) | `freetube: add alyaeanyx to maintainers`                                            |
| [`94a291a2`](https://github.com/NixOS/nixpkgs/commit/94a291a253f8cac60d83e651743cadc42477b3ba) | `maintainers: add alyaeanyx`                                                        |
| [`fdaa2f84`](https://github.com/NixOS/nixpkgs/commit/fdaa2f84fde6ac3dfd89ac91cb96c8b5277e6912) | `freetube: 0.13.2 -> 0.14.0`                                                        |
| [`75c7c16d`](https://github.com/NixOS/nixpkgs/commit/75c7c16df2e79d8128d83eaba7b773bb2c69888b) | `release-docs: add ipfs localdiscovery false change`                                |
| [`6a51087b`](https://github.com/NixOS/nixpkgs/commit/6a51087bba98e15ebae11c7e32b72f1eaffa6458) | `ipfs: default to not listen on the local network`                                  |
| [`9fe2e640`](https://github.com/NixOS/nixpkgs/commit/9fe2e640cc8540bacc4764892317f908d3562bc3) | `youtube-dl: remove maintainer`                                                     |
| [`6b75457c`](https://github.com/NixOS/nixpkgs/commit/6b75457c7f1e4a8a7352b53b23341a5e070267fa) | `tome4: 1.6.7 -> 1.7.4`                                                             |
| [`05c0b274`](https://github.com/NixOS/nixpkgs/commit/05c0b2743fb434ecf2d0b8446decdf4a0f9d1c4b) | `chromiumBeta: 94.0.4606.31 -> 94.0.4606.41`                                        |
| [`894ff4f2`](https://github.com/NixOS/nixpkgs/commit/894ff4f2e471f91de7ac54e432e9c9cbcb1830ec) | `signal-desktop: 5.16.0 -> 5.17.0`                                                  |
| [`8d06eef6`](https://github.com/NixOS/nixpkgs/commit/8d06eef6552058e9e719006371c9d27bd316012a) | `atasm: init at 1.09`                                                               |
| [`bc183fd4`](https://github.com/NixOS/nixpkgs/commit/bc183fd4796f6650ecd716a45bb81f4e6f41beae) | `swiftclient: add python-swiftclient alias to make it easily discoverable`          |
| [`8b0a2160`](https://github.com/NixOS/nixpkgs/commit/8b0a21605684b392302695f1e2c7e6e1e952ba3e) | `python39Packages.python-swiftclient: add SuperSandro2000 as maintainer`            |
| [`9141083a`](https://github.com/NixOS/nixpkgs/commit/9141083ab1c06149984e413cafa217d886738cf1) | `python39Packages.python-swiftclient: 3.11.0 -> 3.12.0, convert to python packages` |
| [`79861edf`](https://github.com/NixOS/nixpkgs/commit/79861edf65b54a2d8aa8e2197c0a3b5140e242a4) | `python3Packages.anyio: 3.3.0 -> 3.3.1`                                             |
| [`162b7df8`](https://github.com/NixOS/nixpkgs/commit/162b7df84006c23a920f40f2dae687804e991610) | `python3Packages.aioesphomeapi: 8.0.0 -> 9.0.0`                                     |
| [`143bf54f`](https://github.com/NixOS/nixpkgs/commit/143bf54f188b464c742c9573ac35aba80e0687a8) | `deltachat-desktop: unstable-2021-08-04 -> 1.21.0`                                  |
| [`4e0cf0e3`](https://github.com/NixOS/nixpkgs/commit/4e0cf0e34ed5c48c9817d520533fe5887f25520c) | `python3Packages.fakeredis: 1.6.0 -> 1.6.1`                                         |
| [`3bbef897`](https://github.com/NixOS/nixpkgs/commit/3bbef8974bff030bade45e7c6bdc428f78b40bc2) | `python38Packages.pubnub: 5.2.1 -> 5.3.1`                                           |
| [`f61b7729`](https://github.com/NixOS/nixpkgs/commit/f61b77292fdcb969489111c349c6ebeef5741eb5) | `libdeltachat: fix pkg-config file`                                                 |
| [`d11cd01a`](https://github.com/NixOS/nixpkgs/commit/d11cd01ad148d61d9ad364ac8d488b3eb8d75030) | `firefox-78-esr: 78.13.1esr -> 78.14.0esr`                                          |
| [`b31a7ba0`](https://github.com/NixOS/nixpkgs/commit/b31a7ba0029e6aac3ff6cf9b94df3e61a9ef4cf4) | `firefox-91-esr: 91.0.1esr -> 91.1.0esr`                                            |
| [`24458c55`](https://github.com/NixOS/nixpkgs/commit/24458c55fc8a897eb0745f5e4cfccd41400c31d9) | `arcan.pipeworld: 0.0.0+unstable=2021-05-27 -> 0.0.0+unstable=2021-08-01`           |
| [`ef4ca107`](https://github.com/NixOS/nixpkgs/commit/ef4ca107cbc14883980977f9e62008768953c279) | `arcan.arcan: 0.6.1pre1+unstable=2021-07-30 -> 0.6.1pre1+unstable=2021-09-05`       |
| [`30154ecd`](https://github.com/NixOS/nixpkgs/commit/30154ecd9518d645920bfed053f1888d22f2c6f0) | `arcan: rename everyone-wrapped to all-wrapped`                                     |
| [`38116932`](https://github.com/NixOS/nixpkgs/commit/38116932f7324070296a626b32cd48e3b79286fe) | `dorkscout: init at 1.0`                                                            |
| [`ae19d5c6`](https://github.com/NixOS/nixpkgs/commit/ae19d5c68b9ec6a886826d8f9389c7f18b582546) | `as31: init at 2.3.1`                                                               |
| [`827f4df4`](https://github.com/NixOS/nixpkgs/commit/827f4df4eb1e8047b5a2ccb6d35bd8934b9b35a8) | `checkmate: init at 0.4.1`                                                          |
| [`fca3b456`](https://github.com/NixOS/nixpkgs/commit/fca3b456edfec9bc0f8ea9ab4ebfe9c58e4bd45c) | `kubescape: init at 1.0.64`                                                         |
| [`3ad045ab`](https://github.com/NixOS/nixpkgs/commit/3ad045ab4dc52ac003671b845bd2f9029d8aee09) | `oshka: init at 0.4.0`                                                              |
| [`df972a3d`](https://github.com/NixOS/nixpkgs/commit/df972a3dde2d0a5564313b8de7ae85ab48530869) | `nixos/sanoid: allow zfs value for recursive`                                       |
| [`2eabda6f`](https://github.com/NixOS/nixpkgs/commit/2eabda6f39b79f6de759616a74544c28ee3d6d49) | `dasel: 1.19.0 -> 1.20.0`                                                           |
| [`43270a50`](https://github.com/NixOS/nixpkgs/commit/43270a5081c0fddb5a898a1b4661d3c2561da991) | `lgogdownloader: formatting`                                                        |
| [`bb877fad`](https://github.com/NixOS/nixpkgs/commit/bb877fadee32ab31d944e1a2e87827d6fd04a81d) | `lgogdownloader: add installCheck`                                                  |
| [`212cfed1`](https://github.com/NixOS/nixpkgs/commit/212cfed17cd2016d3d6872c34547b88e475f3eae) | `lgogdownloader: add myself as maintainer`                                          |