### PR TITLE
chore(deps): update home-manager

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "208e310e9409d0d54ae5e19cb52f8d0f3c7f4771",
-        "sha256": "004sg46fqr0qzjbrb561fiv8w73hqksm13sjggb98npbv3daysjk",
+        "rev": "5199bc841aa9ebafc567a1f5c498682650f68973",
+        "sha256": "03m1z2fv6a94pj9513lj6gvzalj21y40wkr02a3yannjka4kp6vy",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/208e310e9409d0d54ae5e19cb52f8d0f3c7f4771.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/5199bc841aa9ebafc567a1f5c498682650f68973.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixos-hardware": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                     |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`5199bc84`](https://github.com/nix-community/home-manager/commit/5199bc841aa9ebafc567a1f5c498682650f68973) | `ci: bump cachix/install-nix-action from 13 to 14` |