### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "db88608d8c811a93b74c99cfa1224952afc78200",
-        "sha256": "078nmdgsqb5khza9bifs29h6lw6n2m38y699g27yrwyp7jhsv74m",
+        "rev": "46ff1961227eb9ff16875b48f4e3562497d0f0e7",
+        "sha256": "035nk778lx2dpx1spy8k8blan2768kd1px6znvxql096l5jsmqfc",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/db88608d8c811a93b74c99cfa1224952afc78200.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/46ff1961227eb9ff16875b48f4e3562497d0f0e7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                                                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
| [`6875f62e`](https://github.com/NixOS/nixpkgs/commit/6875f62e49839cc52ead5b197a08fecd3710d775) | `teleport: 7.0.3 -> 7.1.0`                                                                                                                  |
| [`38384e4c`](https://github.com/NixOS/nixpkgs/commit/38384e4c75ffbd560eef6befd7b938e27446b70f) | `libadwaita: 1.0.0-alpha.1 -> 1.0.0-alpha.2`                                                                                                |
| [`dc03eeaa`](https://github.com/NixOS/nixpkgs/commit/dc03eeaab1df10dc4044ba9bfad1877a8a2b1360) | `slop: 7.5 -> 7.6`                                                                                                                          |
| [`5f191ca8`](https://github.com/NixOS/nixpkgs/commit/5f191ca827afaa4487a4234c6fbd6138985506f3) | `freecad: Allow opening .dwg files`                                                                                                         |
| [`61e54424`](https://github.com/NixOS/nixpkgs/commit/61e54424baa413ca1a8efa805813d07e3f1ff00f) | `chromium: 93.0.4577.63 -> 93.0.4577.82`                                                                                                    |
| [`5a9d8315`](https://github.com/NixOS/nixpkgs/commit/5a9d8315c368d9a67947ca7902137a94c930e7a8) | `pyupgrade: 2.25.0 -> 2.25.1`                                                                                                               |
| [`b5074c90`](https://github.com/NixOS/nixpkgs/commit/b5074c90f803fee4101349fa9712a86c448f139d) | `operator-sdk: 1.11.0 -> 1.12.0`                                                                                                            |
| [`9c81cbac`](https://github.com/NixOS/nixpkgs/commit/9c81cbace1a74dc599af642f7e9e87954a184114) | `open-policy-agent: 0.31.0 -> 0.32.0`                                                                                                       |
| [`4b24b544`](https://github.com/NixOS/nixpkgs/commit/4b24b5445c45356aca133da7a8d44c42f213b9b0) | `mob: 1.10.0 -> 1.12.0`                                                                                                                     |
| [`e3f62ec1`](https://github.com/NixOS/nixpkgs/commit/e3f62ec19aaeb5cf5121b0921db64df234acd115) | `swtpm: 0.5.2 -> 0.6.0`                                                                                                                     |
| [`a9a2bb26`](https://github.com/NixOS/nixpkgs/commit/a9a2bb267751fab783178f91f3f988b745c06500) | `qbs: 1.19.1 -> 1.20.0`                                                                                                                     |
| [`eb37bdb2`](https://github.com/NixOS/nixpkgs/commit/eb37bdb2ae677f7dde2abdb716e3028fe2009d2c) | `libatomic_ops: 7.6.10 -> 7.6.12`                                                                                                           |
| [`9113a4c1`](https://github.com/NixOS/nixpkgs/commit/9113a4c12eec4db735d58ead37e487fa3ee53d22) | `kubescape: 1.0.64 -> 1.0.77`                                                                                                               |
| [`d849b5dd`](https://github.com/NixOS/nixpkgs/commit/d849b5dd138790825b30846be1d2b46979b86623) | `kubedb-cli: 0.20.0 -> 0.21.0`                                                                                                              |
| [`4c6e4850`](https://github.com/NixOS/nixpkgs/commit/4c6e4850f50d160934c158fda1a101b9b6d1adfb) | `kube-score: 1.11.0 -> 1.12.0`                                                                                                              |
| [`8fbb242e`](https://github.com/NixOS/nixpkgs/commit/8fbb242e40206083d351744938c627a44caa4b2a) | `kapp: 0.38.0 -> 0.39.0`                                                                                                                    |
| [`2a613005`](https://github.com/NixOS/nixpkgs/commit/2a61300544faeabd1c2a836e7f319b953fce9930) | `qcad: 3.26.1.0 -> 3.26.4.7`                                                                                                                |
| [`9cdc7e7a`](https://github.com/NixOS/nixpkgs/commit/9cdc7e7ae87f1410c139e56a46886f61676f339e) | `bitcoin: 0.21.1 -> 22.0`                                                                                                                   |
| [`43ea1028`](https://github.com/NixOS/nixpkgs/commit/43ea10289da3228c801fe7048b0681558de5b280) | `k0sctl: 0.9.0 -> 0.10.2`                                                                                                                   |
| [`a4dcfb40`](https://github.com/NixOS/nixpkgs/commit/a4dcfb400cbf3d61624c83cbd6183aec17f9e559) | `qsynth: 0.9.1 -> 0.9.4`                                                                                                                    |
| [`7fb09163`](https://github.com/NixOS/nixpkgs/commit/7fb09163a248695f87ba075d513870000d630ca6) | `python39Packages.python-swiftclient: adopt into openstack team, fix missing keystone client, remove duplicated propagations, enable tests` |
| [`9b0e2591`](https://github.com/NixOS/nixpkgs/commit/9b0e2591b738f0ae37eba864d62cbfc60384ab05) | `python38Packages.ntc-templates: 2.3.1 -> 2.3.2`                                                                                            |
| [`a05c3143`](https://github.com/NixOS/nixpkgs/commit/a05c3143e30d056530ae5434e447ca33ba20bd63) | `qt5ct: 1.1 -> 1.3`                                                                                                                         |
| [`1c804c47`](https://github.com/NixOS/nixpkgs/commit/1c804c475a6267dbe4c3f38a8f8d98067802daa0) | `istioctl: 1.11.0 -> 1.11.2`                                                                                                                |
| [`cfe77d5e`](https://github.com/NixOS/nixpkgs/commit/cfe77d5e87faa26a11b56bcb2e4a92b2c1290393) | `qtractor: 0.9.19 -> 0.9.23`                                                                                                                |
| [`d26fd428`](https://github.com/NixOS/nixpkgs/commit/d26fd428bc3afe1010229864df05bacbfa67230a) | `qjackctl: 0.9.0 -> 0.9.4`                                                                                                                  |
| [`9739ba6b`](https://github.com/NixOS/nixpkgs/commit/9739ba6baf77bcbb39ead2d443019fb930d9a42d) | `nixos/systemd: create a group for systemd-coredump`                                                                                        |
| [`eb328077`](https://github.com/NixOS/nixpkgs/commit/eb328077c3a3f01c5d0c27f0b95fe4f544dbd9ad) | `nixos/vsftpd: allocate group; fix fallout of #133166`                                                                                      |
| [`93af22c6`](https://github.com/NixOS/nixpkgs/commit/93af22c6c41483f3ec2935e9864fa6bfd8457a2f) | `imgproxy: 2.16.7 -> 2.17.0`                                                                                                                |
| [`2fee9816`](https://github.com/NixOS/nixpkgs/commit/2fee9816d29cf44e04feffebbb244e692c6c350e) | `python39Packages.ledgerblue: add import check`                                                                                             |
| [`43764442`](https://github.com/NixOS/nixpkgs/commit/43764442240c6b64c36931d57cf6f61901d9ca03) | `tiny: enable desktop notifications on Linux`                                                                                               |
| [`5a3f567d`](https://github.com/NixOS/nixpkgs/commit/5a3f567d20cf5b13cf9eaf6667ffcb7d8388878f) | `hyper: 3.1.2 -> 3.1.3`                                                                                                                     |
| [`1a05f690`](https://github.com/NixOS/nixpkgs/commit/1a05f6904729cf5aceb5636786889990ae8e5f0a) | `ucx: 1.11.0 -> 1.11.1`                                                                                                                     |
| [`0c8e2ce8`](https://github.com/NixOS/nixpkgs/commit/0c8e2ce81be5da344171024aad0b6e877663a8fd) | `hurl: 1.3.0 -> 1.3.1`                                                                                                                      |
| [`17d1c041`](https://github.com/NixOS/nixpkgs/commit/17d1c041284844c731f61cb3ecb3735f2bf33aab) | `hugo: 0.88.0 -> 0.88.1`                                                                                                                    |
| [`600aa020`](https://github.com/NixOS/nixpkgs/commit/600aa0207ee1c7e06554176cd20c55393cae034d) | `qownnotes: 21.8.12 -> 21.9.2`                                                                                                              |
| [`504529d6`](https://github.com/NixOS/nixpkgs/commit/504529d628bea4b0c8a173b0008f4fb6d3326bec) | `horizon-eda: 2.0.0 -> 2.1.0`                                                                                                               |
| [`4de6fe6a`](https://github.com/NixOS/nixpkgs/commit/4de6fe6a9d728407c65e4edf88528d29ee6fdaa0) | `python38Packages.recoll: 1.28.6 -> 1.31.0`                                                                                                 |
| [`9db8c0be`](https://github.com/NixOS/nixpkgs/commit/9db8c0be81c170d41339ff62f48dc868e4d56d42) | `gitui: 0.17 -> 0.17.1`                                                                                                                     |
| [`e48701e9`](https://github.com/NixOS/nixpkgs/commit/e48701e9046bf639e19f7f3b56c29fffb3d9f7de) | `rustup: 1.24.2 -> 1.24.3`                                                                                                                  |
| [`e1d6d813`](https://github.com/NixOS/nixpkgs/commit/e1d6d8138c27da86dd2b7ad7da2c2bf6a495ac2f) | `git-cliff: 0.2.6 -> 0.3.0`                                                                                                                 |
| [`fbbf1733`](https://github.com/NixOS/nixpkgs/commit/fbbf1733763f30ad614fa813b34dd94f62698b81) | `gobgpd: 2.30.0 -> 2.31.0`                                                                                                                  |
| [`d8addd6b`](https://github.com/NixOS/nixpkgs/commit/d8addd6bcf554ddddc1daa922cae0e58b656a28a) | `socket_wrapper: switch to pname+version`                                                                                                   |
| [`db53f8a2`](https://github.com/NixOS/nixpkgs/commit/db53f8a289a50ee784598a8601fb6a9f3747a350) | `go-toml: 1.9.3 -> 1.9.4`                                                                                                                   |
| [`537298a4`](https://github.com/NixOS/nixpkgs/commit/537298a437808d37b9e98f6ca5a8cd608a18d51e) | `go-mockery: 2.9.0 -> 2.9.2`                                                                                                                |
| [`19310411`](https://github.com/NixOS/nixpkgs/commit/19310411f58c7f73a1c9cd60ba0ccc659103ebf4) | `python38Packages.lazr-uri: 1.0.5 -> 1.0.6`                                                                                                 |
| [`73f18436`](https://github.com/NixOS/nixpkgs/commit/73f18436e7739fbb2ff79e0c726ea53c2aec9f48) | `meilisearch: enable flake usage`                                                                                                           |
| [`3fbb2a85`](https://github.com/NixOS/nixpkgs/commit/3fbb2a8549b340730ac86ccf90330ecddebb039d) | `reiser4progs: 2.0.4 -> 2.0.5`                                                                                                              |
| [`b206d6af`](https://github.com/NixOS/nixpkgs/commit/b206d6afc13c087034203b636c9ab22fce0588d9) | `rust-bindgen: 0.57.0 -> 0.59.1`                                                                                                            |
| [`92a5311c`](https://github.com/NixOS/nixpkgs/commit/92a5311c17887d26b36194d33e7e242d1364d8ca) | `python3Packages.aiogithubapi: init at 21.8.1`                                                                                              |
| [`44d045f7`](https://github.com/NixOS/nixpkgs/commit/44d045f7d3e40c769f211d7e369cd279479bd11b) | `saga: 7.9.0 -> 7.9.1`                                                                                                                      |
| [`9c1f6a9c`](https://github.com/NixOS/nixpkgs/commit/9c1f6a9c45437fa6a4427d293ef9340a14ca6b2b) | `gpscorrelate: enable on darwin`                                                                                                            |
| [`8bae8e70`](https://github.com/NixOS/nixpkgs/commit/8bae8e70f59e881cd7fa7facc8f42191379e6898) | `s3backer: 1.6.1 -> 1.6.2`                                                                                                                  |
| [`192bb496`](https://github.com/NixOS/nixpkgs/commit/192bb4968e39017df41cda8879d551f12438f9bc) | `rspamd: 2.7 -> 3.0`                                                                                                                        |
| [`71fc678c`](https://github.com/NixOS/nixpkgs/commit/71fc678cac34c7555fca731a4af0355e330e427e) | `fluxcd: 0.17.0 -> 0.17.1`                                                                                                                  |
| [`bcfd20bf`](https://github.com/NixOS/nixpkgs/commit/bcfd20bf2dfc0712bd93206f0a09bfa022e990ec) | `rsnapshot: 1.4.3 -> 1.4.4`                                                                                                                 |
| [`8c11f9fc`](https://github.com/NixOS/nixpkgs/commit/8c11f9fc691b0771dbd7a457dfbfbe158f77cc21) | `esbuild: 0.12.25 -> 0.12.27`                                                                                                               |
| [`e2d831ad`](https://github.com/NixOS/nixpkgs/commit/e2d831ad9afff803671ed911cd954370842e44c1) | `argocd: 2.1.1 -> 2.1.2`                                                                                                                    |
| [`b9608ec7`](https://github.com/NixOS/nixpkgs/commit/b9608ec767fd61a18c3bc4020ddbf6308a7f819d) | `opentsdb: fix CVE-2020-35476`                                                                                                              |
| [`64361afd`](https://github.com/NixOS/nixpkgs/commit/64361afd5c5e3d9cf0c99dfc1fadbd6d33181a27) | `python38Packages.launchpadlib: 1.10.13 -> 1.10.14`                                                                                         |
| [`f4abc736`](https://github.com/NixOS/nixpkgs/commit/f4abc73689a28539a87129c1fe5c8ca106e3f42f) | `resvg: 0.16.0 -> 0.17.0`                                                                                                                   |
| [`5c133e0a`](https://github.com/NixOS/nixpkgs/commit/5c133e0acce9a0f401073411665ee661d0ef734d) | `gdal: 3.3.1 -> 3.3.2`                                                                                                                      |
| [`3cc437a3`](https://github.com/NixOS/nixpkgs/commit/3cc437a3dacee85c64ca82865a636a9d5b0eeac3) | `gbenchmark: 1.5.6 -> 1.6.0`                                                                                                                |
| [`03e61e35`](https://github.com/NixOS/nixpkgs/commit/03e61e35dd911a43690342d4721f3c964d1bd621) | `basex: fix Icon= store path to point to nix store.`                                                                                        |
| [`4c5522ff`](https://github.com/NixOS/nixpkgs/commit/4c5522ff0f6bb1dcc3f6bd4939085e66b797fa41) | `folly: 2021.08.30.00 -> 2021.09.13.00`                                                                                                     |
| [`008cd509`](https://github.com/NixOS/nixpkgs/commit/008cd50917dd17584bf590d9c762abc0cb7b1a20) | `flyctl: 0.0.233 -> 0.0.238`                                                                                                                |
| [`21f1fcdf`](https://github.com/NixOS/nixpkgs/commit/21f1fcdf8bedf239df336f53f51466d3fb23d251) | `rsyslog: 8.2102.0 -> 8.2108.0`                                                                                                             |
| [`2266969e`](https://github.com/NixOS/nixpkgs/commit/2266969e8b2ef3faffed8cf2b765fc473aeec3f1) | `rssguard: 3.9.2 -> 4.0.2`                                                                                                                  |
| [`e0c20557`](https://github.com/NixOS/nixpkgs/commit/e0c205578dbcb457c76e1439161b04fe4be30f75) | `snd: 21.1 -> 21.7`                                                                                                                         |
| [`e3c0374d`](https://github.com/NixOS/nixpkgs/commit/e3c0374da4ff8c9a0ad65a429c6ab030e4ae8cc3) | `signal-desktop: 5.17.0 -> 5.17.1`                                                                                                          |
| [`77c881aa`](https://github.com/NixOS/nixpkgs/commit/77c881aa82a5a1dbaa2d67f174d108ab9d49b4d3) | `python38Packages.lazr-restfulclient: 0.14.3 -> 0.14.4`                                                                                     |
| [`6763102a`](https://github.com/NixOS/nixpkgs/commit/6763102a3c3015678f47ad79e8ce73b5e9577021) | `songrec: 0.1.9 -> 0.2.0`                                                                                                                   |
| [`2ada84ac`](https://github.com/NixOS/nixpkgs/commit/2ada84ac2fccd8bc57b3e1be712b6f621ace1b8a) | `socket_wrapper: 1.2.5 -> 1.3.3`                                                                                                            |
| [`15abcd7e`](https://github.com/NixOS/nixpkgs/commit/15abcd7ecaf910954c66a76864ee2f885ca63e9b) | `duckdb: 0.2.8 -> 0.2.9`                                                                                                                    |
| [`0bcd90ec`](https://github.com/NixOS/nixpkgs/commit/0bcd90ecd7777811c04ef983bbd0e5e4d1991b7a) | `simdjson: 0.9.7 -> 1.0.0`                                                                                                                  |
| [`4d25b19c`](https://github.com/NixOS/nixpkgs/commit/4d25b19c2b605c118c17e1eaab182ec17d70ee88) | `sayonara: 1.6.0-beta7 -> 1.7.0-stable3`                                                                                                    |
| [`eb01aaa9`](https://github.com/NixOS/nixpkgs/commit/eb01aaa9d4fa85ed528e30049592c02fe25c5aa3) | `drone-cli: 1.3.1 -> 1.4.0`                                                                                                                 |
| [`9d3086d8`](https://github.com/NixOS/nixpkgs/commit/9d3086d862fe10508c1e5685125d3fe0ab308b51) | `jwhois: fix on aarch64-darwin`                                                                                                             |
| [`a04e858d`](https://github.com/NixOS/nixpkgs/commit/a04e858da4b111636f758f01e1ddc726780b1e52) | `dash: fix on aarch64-darwin`                                                                                                               |
| [`1875c031`](https://github.com/NixOS/nixpkgs/commit/1875c0312e2e4e58035b9e55a6783a4812c26514) | `dash: 0.5.11.2 -> 0.5.11.4`                                                                                                                |
| [`e9ca9aac`](https://github.com/NixOS/nixpkgs/commit/e9ca9aac71a3d2ea2dd71869d5a9fd1e5d6a4bea) | `dnsproxy: 0.39.4 -> 0.39.5`                                                                                                                |
| [`34f26a5b`](https://github.com/NixOS/nixpkgs/commit/34f26a5b87cb297f7dc89d3c46e09210b303e697) | `stripe-cli: 1.7.0 -> 1.7.1`                                                                                                                |
| [`46dc4188`](https://github.com/NixOS/nixpkgs/commit/46dc41882bdc543d81a5c7cf5c2fbf13d42f7fbc) | `python38Packages.ledgerblue: 0.1.37 -> 0.1.38`                                                                                             |
| [`b47ac5a7`](https://github.com/NixOS/nixpkgs/commit/b47ac5a77c93bebc86eebaa2e2faa4ca4cb0c375) | `stress-ng: 0.13.00 -> 0.13.01`                                                                                                             |
| [`ddb3f2b4`](https://github.com/NixOS/nixpkgs/commit/ddb3f2b4639dafd561efa9daff550953e2393a57) | `coordgenlibs: 2.0.3 -> 3.0.0`                                                                                                              |
| [`4748cc25`](https://github.com/NixOS/nixpkgs/commit/4748cc258a30a9003636146bfbac92fad5396a1e) | `convbin: 3.4 -> 3.7`                                                                                                                       |
| [`f5276159`](https://github.com/NixOS/nixpkgs/commit/f5276159d9e346c84796c22de5a4f4048653985e) | `shutter: 0.98 -> 0.99`                                                                                                                     |
| [`ae2196da`](https://github.com/NixOS/nixpkgs/commit/ae2196daa645de14adfee07e2e10e0424dafe551) | `cobalt: 0.16.5 -> 0.17.0`                                                                                                                  |
| [`90732f5b`](https://github.com/NixOS/nixpkgs/commit/90732f5be0ba8ebdc87987f72f8baba14ec821bd) | `stern: 1.20.0 -> 1.20.1`                                                                                                                   |
| [`24fb8cbf`](https://github.com/NixOS/nixpkgs/commit/24fb8cbf8075c806d2fb76ecaaac8ff8bf411699) | `smartdns: 33 -> 35`                                                                                                                        |
| [`d9d051ec`](https://github.com/NixOS/nixpkgs/commit/d9d051ecd9c8fa5d32644f41a695f4d95645a61d) | `dash: use fetchpatch`                                                                                                                      |
| [`b6fc3dff`](https://github.com/NixOS/nixpkgs/commit/b6fc3dff4d685526d17a9fdbc5738af26568b91a) | `bsequencer: 1.8.8 -> 1.8.10`                                                                                                               |
| [`c13796af`](https://github.com/NixOS/nixpkgs/commit/c13796af38650b7ad2180473899ddc133a186538) | `bschaffl: 1.4.6 -> 1.4.8`                                                                                                                  |
| [`916a0c8d`](https://github.com/NixOS/nixpkgs/commit/916a0c8d30a8f399e29f2bc52d694dc6f4890f18) | `python38Packages.cucumber-tag-expressions: 4.0.0 -> 4.0.2`                                                                                 |
| [`b014bcf4`](https://github.com/NixOS/nixpkgs/commit/b014bcf4163af5bcbee3e18de645c0d3ea9aedc0) | `bosh-cli: 6.4.5 -> 6.4.6`                                                                                                                  |
| [`b4d780dd`](https://github.com/NixOS/nixpkgs/commit/b4d780dd8f5ae5e7ab882657c73c582e93c50cc2) | `bjumblr: 1.6.6 -> 1.6.8`                                                                                                                   |
| [`78400f07`](https://github.com/NixOS/nixpkgs/commit/78400f073378f52c9a2595c6d3d67005ed7e851d) | `smcroute: 2.5.1 -> 2.5.2`                                                                                                                  |
| [`83c4c7ea`](https://github.com/NixOS/nixpkgs/commit/83c4c7ea5b400ec19052d6aff08d1424bcd33504) | `rpm: fix on aarch64-darwin`                                                                                                                |
| [`35a1ca8a`](https://github.com/NixOS/nixpkgs/commit/35a1ca8a0a8fb680affc784c20415f47b067d296) | `darwin.trash: fix on aarch64-darwin`                                                                                                       |
| [`9bd2d91e`](https://github.com/NixOS/nixpkgs/commit/9bd2d91ec5abea0a70c6ddf50b2621a194246775) | `texmaker: 5.1.1 -> 5.1.2`                                                                                                                  |
| [`053eff5a`](https://github.com/NixOS/nixpkgs/commit/053eff5a4670022b048eae0308d3632b5cf3ed27) | `top-git: 0.19.12 -> 0.19.13`                                                                                                               |
| [`5538096c`](https://github.com/NixOS/nixpkgs/commit/5538096c8ea1603f599580ffc8d00a69189edba1) | `bchoppr: 1.10.8 -> 1.10.10`                                                                                                                |
| [`c9e42a65`](https://github.com/NixOS/nixpkgs/commit/c9e42a65d2b438ceb93666a4a02db79539692818) | `bazel-buildtools: 4.0.1 -> 4.2.0`                                                                                                          |
| [`22fda0d9`](https://github.com/NixOS/nixpkgs/commit/22fda0d90a0d46c3c49b5c927e5f0b342d0bdf67) | `bazarr: 0.9.8 -> 0.9.9`                                                                                                                    |
| [`b549e583`](https://github.com/NixOS/nixpkgs/commit/b549e58359627ce211f9c3f5f2e6cf8783a7f39a) | `babashka: 0.6.0 -> 0.6.1`                                                                                                                  |
| [`011fa8a4`](https://github.com/NixOS/nixpkgs/commit/011fa8a4f3677e2ac4748a672f1a19e06bdc51bd) | `tautulli: 2.7.5 -> 2.7.6`                                                                                                                  |
| [`cf5db339`](https://github.com/NixOS/nixpkgs/commit/cf5db339eb232bdcad503ee9543e123b8f39ab60) | `alembic: 1.8.2 -> 1.8.3`                                                                                                                   |
| [`7bd5754a`](https://github.com/NixOS/nixpkgs/commit/7bd5754a353b12bf53df824c59281e56703f0c89) | `xfce.thunar: 4.16.8 -> 4.16.9`                                                                                                             |
| [`230e2670`](https://github.com/NixOS/nixpkgs/commit/230e26705196aa14c7395a11b04683b3429ab1d1) | `dust: fix`                                                                                                                                 |
| [`37ae37e8`](https://github.com/NixOS/nixpkgs/commit/37ae37e8b783517b96516e415164e608a888249d) | `trealla: 1.9.37 -> 1.12.0`                                                                                                                 |
| [`48d69227`](https://github.com/NixOS/nixpkgs/commit/48d692274882500f3a32c8e212d0d381e00b1949) | `system76-firmware: 1.0.28 -> 1.0.29`                                                                                                       |
| [`1fbdd700`](https://github.com/NixOS/nixpkgs/commit/1fbdd7003dba2f00fc83e312c7d40b9800c09122) | `swappy: 1.3.1 -> 1.4.0`                                                                                                                    |
| [`11e662a2`](https://github.com/NixOS/nixpkgs/commit/11e662a2feef5305f9d0aae494394bb54a371ba0) | `navidrome: 0.44.1 -> 0.45.1 and added aarch64 support`                                                                                     |
| [`4b7e41b6`](https://github.com/NixOS/nixpkgs/commit/4b7e41b6ee8d87a012ca3f318f5d1f5ce5f14b06) | `tty-solitaire: 1.3.0 -> 1.3.1`                                                                                                             |
| [`13297f4c`](https://github.com/NixOS/nixpkgs/commit/13297f4cb76419ca8e419b4b06f63f6b6bd96808) | `vultr-cli: 2.8.0 -> 2.8.2`                                                                                                                 |
| [`0aafa261`](https://github.com/NixOS/nixpkgs/commit/0aafa261e3d5e53881688a224fb81feca8c374a2) | `vkquake: 1.05.3 -> 1.11.0`                                                                                                                 |