### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "46ff1961227eb9ff16875b48f4e3562497d0f0e7",
-        "sha256": "035nk778lx2dpx1spy8k8blan2768kd1px6znvxql096l5jsmqfc",
+        "rev": "9f75aabfb06346e7677fc3ad53cc9b6669eead61",
+        "sha256": "14xh7r0jbpjdvzxzys72z5260hladckcj0c2bpgpdi5gq2xbx6yi",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/46ff1961227eb9ff16875b48f4e3562497d0f0e7.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/9f75aabfb06346e7677fc3ad53cc9b6669eead61.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                               |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`47bbde4a`](https://github.com/NixOS/nixpkgs/commit/47bbde4a54bb43043e6a8bfa8fe5c1d379fb89a8) | `zellij: 0.16.0 -> 0.17.0`                                                                   |
| [`70b65c28`](https://github.com/NixOS/nixpkgs/commit/70b65c281df5cfcf98cbe7dc3531b0ece0b5afd7) | `dua: 2.14.4 -> 2.14.6`                                                                      |
| [`4828eb7a`](https://github.com/NixOS/nixpkgs/commit/4828eb7ae4f1105dcebf7245f453c607b9c77c1d) | `vscodium: 1.60.0 -> 1.60.1`                                                                 |
| [`cf755399`](https://github.com/NixOS/nixpkgs/commit/cf755399718e2d1a1c7f36b48d95c56450f5ecef) | `nixos/home-assistant: allow serial access for usb discovery and zwave_js`                   |
| [`5de4afa6`](https://github.com/NixOS/nixpkgs/commit/5de4afa614032055405cb234ca98e541c7f55307) | `home-assistant: 2021.8.8 -> 2021.9.6`                                                       |
| [`b63e4fc8`](https://github.com/NixOS/nixpkgs/commit/b63e4fc84b0aa9fb29887530a1ea11f8ba13aeda) | `python3Packages.stdlib-list: init at 0.8.0`                                                 |
| [`f702a640`](https://github.com/NixOS/nixpkgs/commit/f702a64062abfa6fe2d5aeb8eb30eb88025be1cf) | `python3Packages.async-upnp-client: 0.21.0 -> 0.21.3`                                        |
| [`15259dfa`](https://github.com/NixOS/nixpkgs/commit/15259dfa2c1eee31963060482973142f63f03650) | `python3Packages.herepy: relax requests constraint`                                          |
| [`2d9604be`](https://github.com/NixOS/nixpkgs/commit/2d9604be7e9af0e980bf7df243208eaa71c82f66) | `python3Packages.zwave-js-server-python: 0.28.0 -> 0.30.0`                                   |
| [`a9de5531`](https://github.com/NixOS/nixpkgs/commit/a9de55317e3f0a6a43cedf3b8db9cb94a60dea2c) | `python3Packages.zigpy-deconz: 0.12.1 -> 0.13.0`                                             |
| [`3296526c`](https://github.com/NixOS/nixpkgs/commit/3296526c34b7e2409469b9d0f368fc4538c6772c) | `python3Packages.zha-quirks: 0.0.59 -> 0.0.61`                                               |
| [`2d33f52f`](https://github.com/NixOS/nixpkgs/commit/2d33f52f474e6250fe61ea353b11b44feade2ef3) | `python3Packages.pymodbus: 2.5.2 -> 2.5.3rc1`                                                |
| [`1cf568ae`](https://github.com/NixOS/nixpkgs/commit/1cf568ae28121b17b0a3c5c9615a7394b08d8e9d) | `python3Packages.bellows: 0.26.0 -> 0.27.0`                                                  |
| [`716f05ea`](https://github.com/NixOS/nixpkgs/commit/716f05ea514ee561b4e52a1b5093ae91f4523228) | `python3Packages.snitun: 0.27.0 -> 0.30.0`                                                   |
| [`465ec543`](https://github.com/NixOS/nixpkgs/commit/465ec543658691b12b43cfb236033bc6047564e8) | `python3Packages.pymyq: 3.1.3 -> 3.1.4`                                                      |
| [`677c17fe`](https://github.com/NixOS/nixpkgs/commit/677c17fe74c9f9961231e563fdb527e4ce28141c) | `python3Packages.aioswitcher: 2.0.4 -> 2.0.5`                                                |
| [`251ff92d`](https://github.com/NixOS/nixpkgs/commit/251ff92d53fd89e0b9b39a3a5e1d5bf1f753a3a5) | `python3Packages.soco: 0.23.3 -> 0.24.0`                                                     |
| [`9f76c53a`](https://github.com/NixOS/nixpkgs/commit/9f76c53a301cdafe641894608891abf7a76a742f) | `python3Packages.env-canada: 0.5.0 -> 0.5.1`                                                 |
| [`19c8d521`](https://github.com/NixOS/nixpkgs/commit/19c8d521bb43cff4c46aeea7ff56ba5de98dd794) | `python3Packages.yeelight: 0.7.2 -> 0.7.4`                                                   |
| [`7b779214`](https://github.com/NixOS/nixpkgs/commit/7b77921490b9fb8d08ecc0ed7d986a71c3a51e66) | `python3Packages.pyopenuv: 2.1.0 -> 2.2.0`                                                   |
| [`dc85b1cb`](https://github.com/NixOS/nixpkgs/commit/dc85b1cbda47f1f52cae98958248670b675dc8f4) | `python3Packages.pyiqvia: 1.0.1 -> 1.1.0`                                                    |
| [`a84555ba`](https://github.com/NixOS/nixpkgs/commit/a84555ba2e332b5d51e1a19eab105229c0dd7a76) | `python3Packages.aioambient: 1.2.6 -> 1.3.0`                                                 |
| [`d3e7c6df`](https://github.com/NixOS/nixpkgs/commit/d3e7c6df189612be0ba0eb08e56ccee10b51a953) | `owncloud-client: 2.8.4 -> 2.9.0  (#135876)`                                                 |
| [`ff342ae2`](https://github.com/NixOS/nixpkgs/commit/ff342ae23b60d8427d5e2a7a98f3e5ba70d5cdea) | `ffmpeg-normalize: 1.22.1 -> 1.22.3`                                                         |
| [`f52575c0`](https://github.com/NixOS/nixpkgs/commit/f52575c06b8d22263c78d0efba32b396e5422a31) | `tflint: 0.32.0 -> 0.32.1`                                                                   |
| [`159c59a6`](https://github.com/NixOS/nixpkgs/commit/159c59a6b97c8dccdeced3d4eb772717d6bf4306) | `terracognita: 0.7.2 -> 0.7.3`                                                               |
| [`7566d367`](https://github.com/NixOS/nixpkgs/commit/7566d3679a0a74a9ad9b242693b9b25ddd9d9e51) | `esphome: 2021.8.2 -> 2021.9.0`                                                              |
| [`c706ca58`](https://github.com/NixOS/nixpkgs/commit/c706ca58e06328c98a9dfc8e9e069a60f2864237) | `rpg-cli: 0.6.0 -> 1.0.0`                                                                    |
| [`9574e574`](https://github.com/NixOS/nixpkgs/commit/9574e57471eeb85b9a214eca7445c0ac13069c6e) | `resvg: 0.17.0 -> 0.18.0`                                                                    |
| [`70945040`](https://github.com/NixOS/nixpkgs/commit/709450400c762ab70f023f00ad37dfb6b8e6b27d) | `pueue: 0.12.2 -> 1.0.2`                                                                     |
| [`132593e3`](https://github.com/NixOS/nixpkgs/commit/132593e334377251bb178d93c107fbb644630742) | `session-desktop-appimage: 1.6.11 -> 1.7.1`                                                  |
| [`ca831be5`](https://github.com/NixOS/nixpkgs/commit/ca831be54c1588b44d3452f79a4cfa540a341856) | `miniserve: 0.15.0 -> 0.17.0`                                                                |
| [`4872d2ed`](https://github.com/NixOS/nixpkgs/commit/4872d2ed2a2b5cfb9ac0d2503b0650128a114ba3) | `nushell: 0.36.0 -> 0.37.0`                                                                  |
| [`ea1775ee`](https://github.com/NixOS/nixpkgs/commit/ea1775eeee16627ddaa8c9f04776303ea9144421) | `strace: remove strace-graph stuff`                                                          |
| [`93d5531b`](https://github.com/NixOS/nixpkgs/commit/93d5531b29a9464033b5742dc988dfa4a9413699) | `macchina: 1.1.3 -> 1.1.4`                                                                   |
| [`3c4b11f2`](https://github.com/NixOS/nixpkgs/commit/3c4b11f25dcd0bb6a060872a63b08d1f6087bd40) | `python3Packages.migen: init at unstable-2021-09-14`                                         |
| [`5196b3df`](https://github.com/NixOS/nixpkgs/commit/5196b3df7c687195388986b440934b7b2068ee72) | `tree-sitter: update grammars`                                                               |
| [`f8cea6b5`](https://github.com/NixOS/nixpkgs/commit/f8cea6b5bc823b5e416fc4f615c97b57f14ac942) | `treefmt: 0.2.5 -> 0.2.6 (#137951)`                                                          |
| [`c6574c86`](https://github.com/NixOS/nixpkgs/commit/c6574c8664d39f6eede326d8348d21cbe1fd3f97) | `khronos: clarify license`                                                                   |
| [`20b905a8`](https://github.com/NixOS/nixpkgs/commit/20b905a8dfe4a65e18fce7fa9bd919f00ff3a9bd) | `alternatives/blas: fix ILP64 check`                                                         |
| [`52e9be9a`](https://github.com/NixOS/nixpkgs/commit/52e9be9ada16376c5d9ff981be68715cdd195d52) | `goreleaser: 0.176.0 -> 0.179.0`                                                             |
| [`dc34788a`](https://github.com/NixOS/nixpkgs/commit/dc34788a25664926a04393d5f20a266c4a884385) | `nixos/lock-kernel-modules: use `udevadm settle``                                            |
| [`ddbbf5d8`](https://github.com/NixOS/nixpkgs/commit/ddbbf5d80bcee06ff62b0fb53d926e9c8b1174d6) | `coqPackages.parsec: init at 0.1.0`                                                          |
| [`28bf99d3`](https://github.com/NixOS/nixpkgs/commit/28bf99d3cf2b42e03b5e5507b7ae3d8c487881fd) | `coqPackages.ceres: init at 0.4.0`                                                           |
| [`88531b67`](https://github.com/NixOS/nixpkgs/commit/88531b67a2a5f969c4803b37a66c7d6303fdc6b9) | `python38Packages.node-semver: 0.7.0 -> 0.8.1`                                               |
| [`82397b84`](https://github.com/NixOS/nixpkgs/commit/82397b844d8bf4e84e694e2be836cadd3ab6be31) | `multimc: user-provided client ID`                                                           |
| [`7ac53ad7`](https://github.com/NixOS/nixpkgs/commit/7ac53ad7b954c1b349d4172c38767e8e77ac4640) | `ocamlPackages.mdx: 1.10.1 -> 1.11.0`                                                        |
| [`0b93a433`](https://github.com/NixOS/nixpkgs/commit/0b93a433c456404ab9e5b033fdea912789cd1ae3) | `python38Packages.snowflake-sqlalchemy: 1.3.1 -> 1.3.2`                                      |
| [`c2d97ef7`](https://github.com/NixOS/nixpkgs/commit/c2d97ef72de1b96dfd0e4f51fb7253f9aaf5cf7d) | `exoscale-cli: 1.40.5 -> 1.41.0`                                                             |
| [`8a7a1b06`](https://github.com/NixOS/nixpkgs/commit/8a7a1b06bac0025919eb92ea8ea671932feb8274) | `python38Packages.pg8000: 1.21.1 -> 1.21.2`                                                  |
| [`b7eb0b99`](https://github.com/NixOS/nixpkgs/commit/b7eb0b990b054146a7f6280725c08add4257642b) | `esbuild: 0.12.27 -> 0.12.28`                                                                |
| [`a293c865`](https://github.com/NixOS/nixpkgs/commit/a293c865425287c3098da223495bb77233c789f8) | `python38Packages.pex: 2.1.49 -> 2.1.50`                                                     |
| [`2de65a80`](https://github.com/NixOS/nixpkgs/commit/2de65a8061cc23589cc4329079a9ef79ac030c6b) | `electrs: 0.8.10 -> 0.8.11`                                                                  |
| [`2742598f`](https://github.com/NixOS/nixpkgs/commit/2742598f99872df6be44082f12421acb27677a89) | `ocamlPackages.parany: 12.0.3 -> 12.1.1`                                                     |
| [`443fa7db`](https://github.com/NixOS/nixpkgs/commit/443fa7dbd5b37044b6a4facd87991c9d1b8c951e) | `cointop: 1.6.6 -> 1.6.8`                                                                    |
| [`473c9001`](https://github.com/NixOS/nixpkgs/commit/473c90014fbbe65dab653260d648084276219301) | `cobalt: 0.17.0 -> 0.17.4`                                                                   |
| [`898bc910`](https://github.com/NixOS/nixpkgs/commit/898bc910e86123e2c5ab86d15264378ef1edf4e5) | `cmark-gfm: 0.29.0.gfm.0 -> 0.29.0.gfm.1`                                                    |
| [`30df428d`](https://github.com/NixOS/nixpkgs/commit/30df428d7e7b7f92b1000689921f5e82aa064439) | `cloudflared: 2021.8.7 -> 2021.9.0`                                                          |
| [`f840898e`](https://github.com/NixOS/nixpkgs/commit/f840898e8530ff44625b00b418072e52c97b426c) | `python38Packages.google-cloud-firestore: 2.3.1 -> 2.3.2`                                    |
| [`fe034d33`](https://github.com/NixOS/nixpkgs/commit/fe034d33be5ccf3efc850a6021a1ab41cf5831d1) | `nixos/gitlab: Enable roation of log files`                                                  |
| [`f27bedec`](https://github.com/NixOS/nixpkgs/commit/f27bedec56dc32ba4253ae05434a1a46156010a9) | `python38Packages.dataclasses-json: 0.5.5 -> 0.5.6`                                          |
| [`51e8290b`](https://github.com/NixOS/nixpkgs/commit/51e8290b19b376d6432cf7e6c6039d8da0db23d9) | `xmrig-mo: 6.14.1-mo2 -> 6.15.0-mo1`                                                         |
| [`5545104c`](https://github.com/NixOS/nixpkgs/commit/5545104ce310a43f4a23935754392bd81fa8f9f0) | `xcolor: 0.5.0 -> 0.5.1`                                                                     |
| [`ed74ad63`](https://github.com/NixOS/nixpkgs/commit/ed74ad630c05b43b6af685a5e1eeba6136b8f04f) | `vale: 2.10.5 -> 2.10.6`                                                                     |
| [`3b61e2c2`](https://github.com/NixOS/nixpkgs/commit/3b61e2c2b972505ccb77fd5e4d4c607dc1371148) | `tree-sitter: add rydesun/tree-sitter-dot`                                                   |
| [`1172c99c`](https://github.com/NixOS/nixpkgs/commit/1172c99c506ed4c3c7c8f47d3b51fb195eca5d96) | `nlohmann_json: enable checkPhase`                                                           |
| [`1628a1c7`](https://github.com/NixOS/nixpkgs/commit/1628a1c78b3cf6564c82993fe7d6cebebb8791e6) | `numberstation: 0.4.0 -> 0.5.0`                                                              |
| [`e9afd042`](https://github.com/NixOS/nixpkgs/commit/e9afd04202c745a0a251a530634e122d92550c2a) | `mit-scheme: set MITSCHEME_LIBRARY_PATH properly`                                            |
| [`8465eb74`](https://github.com/NixOS/nixpkgs/commit/8465eb7493d949c3a8020e814d2f8a5fca08137d) | `vscx/ms-vsliveshare-vsliveshare: 1.0.4673 -> 1.0.4836`                                      |
| [`4e52d933`](https://github.com/NixOS/nixpkgs/commit/4e52d93305204d3ddb084d241f4d14c55bfdd404) | `emacs.pkgs.ement: Fix meta.description`                                                     |
| [`23837756`](https://github.com/NixOS/nixpkgs/commit/23837756205f6ca8ecc1f531323d0a842572b40e) | `nextdns: 1.36.0 -> 1.37.2`                                                                  |
| [`964b74f6`](https://github.com/NixOS/nixpkgs/commit/964b74f6b47b0ffb82d59856eaf527b3b1a8c129) | `gitui: do not compile openssl`                                                              |
| [`2ecd21c1`](https://github.com/NixOS/nixpkgs/commit/2ecd21c1cce634960584c6310b7cca158962e98e) | `thicket: 0.1.4 -> 0.1.5`                                                                    |
| [`82510b5a`](https://github.com/NixOS/nixpkgs/commit/82510b5a519a44b76ac6db84861b5fcdb989d2a2) | `the-powder-toy: 96.1.349 -> 96.2.350`                                                       |
| [`1dc2e2aa`](https://github.com/NixOS/nixpkgs/commit/1dc2e2aa8c3b3dd12cfc407faf1ba5c145a5599f) | `terragrunt: 0.31.7 -> 0.31.11`                                                              |
| [`f4383bca`](https://github.com/NixOS/nixpkgs/commit/f4383bcab4eef33cfbde4b2ac8aeedfb59d6d087) | `terraformer: 0.8.15 -> 0.8.16`                                                              |
| [`f7a04bdd`](https://github.com/NixOS/nixpkgs/commit/f7a04bddd8e7c28936e314f55f1302ca68506aba) | `telescope: 0.5.1 -> 0.5.2`                                                                  |
| [`40d83a9a`](https://github.com/NixOS/nixpkgs/commit/40d83a9a2159809d2d47fc6598665c184578f1cf) | `electron_12: 12.1.0 -> 12.1.1`                                                              |
| [`3f26111f`](https://github.com/NixOS/nixpkgs/commit/3f26111fb81f4d8ee2d28816b632935564b293bc) | `electron_13: 13.3.0 -> 13.4.0`                                                              |
| [`304dffb1`](https://github.com/NixOS/nixpkgs/commit/304dffb16092a017d88a1577fbe304bea5e73375) | `electron_14: 14.0.0 -> 14.0.1`                                                              |
| [`d1f3ce25`](https://github.com/NixOS/nixpkgs/commit/d1f3ce25cb71ece73de8a067d97fd71f29ffa362) | `khronos: 1.0.8 -> 3.5.9`                                                                    |
| [`268c8d77`](https://github.com/NixOS/nixpkgs/commit/268c8d77ca7302dd8c72370532e5158a0a3e4a2e) | `vscode: 1.60.0 -> 1.60.1`                                                                   |
| [`313e03f4`](https://github.com/NixOS/nixpkgs/commit/313e03f4fb55ef46f6474fba981f8d25bb7b0ea8) | `spaceship-prompt: 3.14.0 -> 3.14.1`                                                         |
| [`e2cce9e0`](https://github.com/NixOS/nixpkgs/commit/e2cce9e0ca53578229099d08baf0b52794bbad4b) | `sniffglue: 0.13.0 -> 0.13.1`                                                                |
| [`d37f5847`](https://github.com/NixOS/nixpkgs/commit/d37f5847d3a536fe00b144b84858ffe8de6dd956) | `rtsp-simple-server: 0.17.2 -> 0.17.3`                                                       |
| [`a7f71cd4`](https://github.com/NixOS/nixpkgs/commit/a7f71cd419821adc5e3d7b9ae9e5b0f558370b28) | `emacs.pkgs.ement: init at unstable-2021-09-08`                                              |
| [`38a96d81`](https://github.com/NixOS/nixpkgs/commit/38a96d8148f966934f85fe222593477be8094e71) | `emacs.pkgs.plz: init at unstable-2021-08-22`                                                |
| [`92cc52ac`](https://github.com/NixOS/nixpkgs/commit/92cc52acb8c05609978769edd94772ffa9dba4a1) | `pyradio: 0.8.7.2 -> 0.8.9.9`                                                                |
| [`0c31bd3d`](https://github.com/NixOS/nixpkgs/commit/0c31bd3d4efda50128ffedfe1daaceeaf90d5763) | `yq-go: 4.12.1 -> 4.12.2`                                                                    |
| [`82367d85`](https://github.com/NixOS/nixpkgs/commit/82367d8543e8c3b703911e1a429896d54b805c84) | `pure-prompt: 1.17.1 -> 1.17.2`                                                              |
| [`8f6aa1f1`](https://github.com/NixOS/nixpkgs/commit/8f6aa1f1daaf171d2ca068804228a96fff2e69c0) | `pt2-clone: 1.32 -> 1.33`                                                                    |
| [`a5d5f32f`](https://github.com/NixOS/nixpkgs/commit/a5d5f32f9018fcafb203437740964ab574aef8ab) | `csvs-to-sqlite: added override for `click` dependency to version `7` in order to fix build` |
| [`e676fdcb`](https://github.com/NixOS/nixpkgs/commit/e676fdcb901455956acd04e58e88dd777871f73e) | `picard-tools: 2.26.0 -> 2.26.2`                                                             |
| [`1c9cbe8a`](https://github.com/NixOS/nixpkgs/commit/1c9cbe8a05567e918c3b12941569a7e63d54e539) | `opensmt: 2.1.0 -> 2.1.1`                                                                    |
| [`90b0fda3`](https://github.com/NixOS/nixpkgs/commit/90b0fda38eb250505aa027e8ae4ebbf746eb96e6) | `opencolorio: 2.0.1 -> 2.0.2`                                                                |
| [`6957f6cb`](https://github.com/NixOS/nixpkgs/commit/6957f6cb1efd2a3b9b85683bd2b3cae6c0b1068c) | `python3Packages.google-resumable-media: fix google-crc32c bounds`                           |
| [`afc91f5f`](https://github.com/NixOS/nixpkgs/commit/afc91f5fefe5d159001238feb56c3267f65357c5) | `graphite2: fixup build on aarch64-darwin after PR #123420`                                  |
| [`d5c8c843`](https://github.com/NixOS/nixpkgs/commit/d5c8c84384fe710727b1be0fbb1ef7572aadd97e) | `qbittorrent: 4.3.5 -> 4.3.8`                                                                |
| [`b471773d`](https://github.com/NixOS/nixpkgs/commit/b471773d5749365f01cb89079d476b34c58ddce6) | `python3Packages.aioesphomeapi: 9.0.0 -> 9.1.0`                                              |
| [`f3aeba71`](https://github.com/NixOS/nixpkgs/commit/f3aeba71a3381672dfe60ef34c561605bd2afd7a) | `python38Packages.xmlsec: 1.3.11 -> 1.3.12`                                                  |
| [`b62c799d`](https://github.com/NixOS/nixpkgs/commit/b62c799d04d89f9ac9002cfd3886ce919a056a5c) | `ajour: 1.3.0 -> 1.3.1`                                                                      |
| [`7bea76e0`](https://github.com/NixOS/nixpkgs/commit/7bea76e0d219c6ca81677cfa318927628fd70263) | `nats-server: 2.4.0 -> 2.5.0`                                                                |
| [`92042a28`](https://github.com/NixOS/nixpkgs/commit/92042a285e45c40936a3813b95f2e1079a51ecf9) | `python3Packages.jupyter-server: 1.10.2 -> 1.11.0, fix build and tests`                      |
| [`60ab0ab2`](https://github.com/NixOS/nixpkgs/commit/60ab0ab2db14e405ac6f019229b88ca4ff3e8883) | `devpi-server: 6.0.0.dev0 -> 6.2.0, override pyramid version`                                |
| [`3f5ad2d3`](https://github.com/NixOS/nixpkgs/commit/3f5ad2d345abac18d99b1b98bfd69cef536072d2) | `minify: 2.9.21 -> 2.9.22`                                                                   |
| [`c55a7ebc`](https://github.com/NixOS/nixpkgs/commit/c55a7ebc5728765b6c0b2854d1f68560d81692db) | `linode-cli: 5.8.2 -> 5.9.0`                                                                 |
| [`d9d3ea62`](https://github.com/NixOS/nixpkgs/commit/d9d3ea6278a78a657c772784f92f404e0bfd1b20) | `gnome.file-roller: avoid wrapping the program twice`                                        |
| [`ac74b423`](https://github.com/NixOS/nixpkgs/commit/ac74b42351e671d45949341fe5b9dac5bb69f574) | `csvs-to-sqlite: removed from `python-package` since it's an command line application`       |
| [`f7978d72`](https://github.com/NixOS/nixpkgs/commit/f7978d726a881a6911a596b19d246604ad8bab75) | `exploitdb: 20221-09-10 -> 2021-09-14`                                                       |
| [`2dcab2aa`](https://github.com/NixOS/nixpkgs/commit/2dcab2aa335b91ad761f0dfb5e03007ea5432c38) | `python38Packages.pytest-snapshot: 0.6.1 -> 0.6.3`                                           |
| [`cd641476`](https://github.com/NixOS/nixpkgs/commit/cd641476cfcf8d5494e661debac9a3fe40f4cf32) | `github-runner: 2.281.1 -> 2.282.0`                                                          |
| [`54cca755`](https://github.com/NixOS/nixpkgs/commit/54cca75528fafcd8a45413b1323820c9128d01ef) | `python39Packages.cliff: fix missing dependency, tests and adopt to openstack team`          |
| [`0242a364`](https://github.com/NixOS/nixpkgs/commit/0242a3641bc783d2fcd8009cfd1b300f40b3bd1a) | `libsForQt5.qtutilities: 6.3.3 -> 6.5.0`                                                     |
| [`01bd54a0`](https://github.com/NixOS/nixpkgs/commit/01bd54a0aa3f4f6ca23efbe0a9592fe578eefe16) | `python3Packages: rename passthru test for openstack team`                                   |
| [`82652bcc`](https://github.com/NixOS/nixpkgs/commit/82652bcc2c7440ee4432975fbb9e0ac8b0ea3551) | `cpp-utilities: 5.11.0 -> 5.11.1`                                                            |
| [`919a4ab5`](https://github.com/NixOS/nixpkgs/commit/919a4ab53750f4108a5476ecf03f8886ef52200a) | `tts: 0.2.2 -> 0.3.0`                                                                        |
| [`451f4f9f`](https://github.com/NixOS/nixpkgs/commit/451f4f9f5c6c05a4fd1b1d89032eb8e07dd02b9f) | `python38Packages.coqpit: 0.0.13 -> 0.0.14`                                                  |
| [`c2743d7e`](https://github.com/NixOS/nixpkgs/commit/c2743d7e787b7e0e19edd219f28136a33b25d87a) | `tendermint: 0.34.12 -> 0.34.13`                                                             |
| [`f3735c9d`](https://github.com/NixOS/nixpkgs/commit/f3735c9dd709d5a428117f5b1baf38675b4b7bf3) | `symfony-cli: 4.25.5 -> 4.26.0`                                                              |
| [`09def9cc`](https://github.com/NixOS/nixpkgs/commit/09def9cc2fccd6aca204a4f034be32437d4b262a) | `nomino: init at 1.1.0`                                                                      |
| [`2bf7e53b`](https://github.com/NixOS/nixpkgs/commit/2bf7e53bc3044575fcb69a27942ed355d2ce0d1d) | `wtf: 0.38.0 -> 0.39.2`                                                                      |
| [`ab13dc43`](https://github.com/NixOS/nixpkgs/commit/ab13dc4381e6fd6430a5d33cf71fae66f458dc5a) | `vnstat: 2.7 -> 2.8`                                                                         |
| [`e8bbcc79`](https://github.com/NixOS/nixpkgs/commit/e8bbcc79fd07014b146835dfd7f5eba2079d9a55) | `github-runner: prevent self-updates`                                                        |
| [`cc5c902f`](https://github.com/NixOS/nixpkgs/commit/cc5c902fdf94b798c3b68e55ebb7e1a1185113a1) | `github-runner: use dummy SHA-1 as `GitInfoCommitHash``                                      |
| [`f3fba3c3`](https://github.com/NixOS/nixpkgs/commit/f3fba3c3361ef0c03180af77852ba60ab501e2cc) | `azure-cli/azure-cli-core: update requests substitution`                                     |
| [`f76136e1`](https://github.com/NixOS/nixpkgs/commit/f76136e109acdcd5b64451a08b478e13bd5e19a4) | `gnunet: 0.15.0 -> 0.15.3`                                                                   |
| [`34d91e67`](https://github.com/NixOS/nixpkgs/commit/34d91e675bfac9cfed653b88ae3093357bd6d59f) | `ntttcp: init at 1.4.0`                                                                      |
| [`28b6a910`](https://github.com/NixOS/nixpkgs/commit/28b6a91047e796b1578120342701dcb89838e4ed) | `libssh2: temporarily add separate 1.10.0`                                                   |
| [`a6294ed2`](https://github.com/NixOS/nixpkgs/commit/a6294ed2932216d1fd4dcde4f7bd818705d388e2) | `python38Packages.pynanoleaf: 0.1.0 -> 0.1.1`                                                |
| [`4c30cd11`](https://github.com/NixOS/nixpkgs/commit/4c30cd112cce47cace1ac424072ef360c35a3349) | `vscode-extensions.tobiasalthoff.atom-material-theme: init at 1.10.7`                        |
| [`03111112`](https://github.com/NixOS/nixpkgs/commit/03111112cc69ed3a90d5b538c5c73d3f565da247) | `qgroundcontrol: 4.1.3 -> 4.1.4`                                                             |
| [`6b48a031`](https://github.com/NixOS/nixpkgs/commit/6b48a031d9cc47356b4e7e3e2cb8967446890261) | `fcl: 0.6.1 -> 0.7.0`                                                                        |
| [`3ca47430`](https://github.com/NixOS/nixpkgs/commit/3ca47430513672fc42f1bb9f85bfecdb1618df05) | `python38Packages.bitarray: 2.3.3 -> 2.3.4`                                                  |
| [`bd6c0565`](https://github.com/NixOS/nixpkgs/commit/bd6c0565b2947c58d951046ecfd4718489c9b515) | `python39Packages.pbr: enable tests, adopt into openstack team`                              |