### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9f75aabfb06346e7677fc3ad53cc9b6669eead61",
-        "sha256": "14xh7r0jbpjdvzxzys72z5260hladckcj0c2bpgpdi5gq2xbx6yi",
+        "rev": "f12fb7a7d2018fea693e765f1ba2eed585edc43e",
+        "sha256": "0n2bmhvzwf7h9fh4f5lcf79pg0ns5i6b1rpq0fzi48p6nijadqbq",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/9f75aabfb06346e7677fc3ad53cc9b6669eead61.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/f12fb7a7d2018fea693e765f1ba2eed585edc43e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                        |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`f837a27a`](https://github.com/NixOS/nixpkgs/commit/f837a27a8a7ae6e6bfeedc74fa6e39aea7a11f5d) | `ocaml-ng.ocamlPackages_4_13.ocaml: 4.13.0-rc1 → 4.13.0-rc2`          |
| [`662df6f4`](https://github.com/NixOS/nixpkgs/commit/662df6f4ab97ca3fd81822448def9d13e349076e) | `ansible_2_9: 2.9.25 -> 2.9.26`                                       |
| [`4156a551`](https://github.com/NixOS/nixpkgs/commit/4156a5516dd2b8ca19b5ecbf307a6024e8f4861b) | `ansible_2_10: 2.10.13 -> 2.10.14`                                    |
| [`31f932af`](https://github.com/NixOS/nixpkgs/commit/31f932af46864ad5b18d8837586b9e6b9e5f89a8) | `ansible_2_11: 2.11.4 -> 2.11.5`                                      |
| [`6cb6e67b`](https://github.com/NixOS/nixpkgs/commit/6cb6e67ba1133bbf4ce05d1b550dbc8c7140c0ae) | `ansible_2_11.collections: 4.4.0 -> 4.5.0`                            |
| [`4c313b9c`](https://github.com/NixOS/nixpkgs/commit/4c313b9cec0087c9ccef10835f30ea4e39eb982b) | `python3Packages.pypandoc: 1.6.3 -> 1.6.4`                            |
| [`f777dc4b`](https://github.com/NixOS/nixpkgs/commit/f777dc4bbefd5b704c24c1ec5c8f4ec9f1c9f71e) | `python39Packages.sphinx-argparse: 0.2.5 -> 0.3.1`                    |
| [`4e6980be`](https://github.com/NixOS/nixpkgs/commit/4e6980bee9b4e3e4e6af7626ed1dcfa1900692ff) | `python38Packages.azure-mgmt-storage: 18.0.0 -> 19.0.0`               |
| [`2f03483b`](https://github.com/NixOS/nixpkgs/commit/2f03483b816def22c0e1772e142b5e637545614d) | `python38Packages.python-sql: 1.2.2 -> 1.3.0`                         |
| [`ac02e3c7`](https://github.com/NixOS/nixpkgs/commit/ac02e3c7223d3609acf1e365955456cab8b0a081) | `python38Packages.breathe: 4.30.0 -> 4.31.0`                          |
| [`15fde52c`](https://github.com/NixOS/nixpkgs/commit/15fde52cbc8104de130460e42bd993d35979a398) | `python38Packages.ptpython: 3.0.19 -> 3.0.20`                         |
| [`cfcacac4`](https://github.com/NixOS/nixpkgs/commit/cfcacac4a978134170468f837892b3f77d220aa5) | `python3Packages.velbus-aio: init at 2021.9.1`                        |
| [`d6e39312`](https://github.com/NixOS/nixpkgs/commit/d6e393120ba2fc05d97c9ea8d4ac578f643d828a) | `python38Packages.gensim: 4.1.0 -> 4.1.1`                             |
| [`7829aee5`](https://github.com/NixOS/nixpkgs/commit/7829aee591112dfe78ec2805cf2991f8cf8c1101) | `python38Packages.agate-sql: 0.5.7 -> 0.5.8`                          |
| [`f422b9d3`](https://github.com/NixOS/nixpkgs/commit/f422b9d31c4c0da2e812b56291d86fc7685380c3) | `python38Packages.acme-tiny: 4.1.1 -> 5.0.1`                          |
| [`9567a448`](https://github.com/NixOS/nixpkgs/commit/9567a4481724f7d3e34c545944a10efada6027c9) | `python38Packages.teslajsonpy: 0.19.0 -> 0.21.0`                      |
| [`354207af`](https://github.com/NixOS/nixpkgs/commit/354207afa5f9e868c136d0a0143459c85f4fa896) | `python3Packages.lark-parser: 0.11.3 -> 0.12.0`                       |
| [`6d8ee524`](https://github.com/NixOS/nixpkgs/commit/6d8ee524d70158e512b5e399eb97ec4f63b67303) | `python38Packages.gssapi: 1.6.14 -> 1.7.0`                            |
| [`c4b5000f`](https://github.com/NixOS/nixpkgs/commit/c4b5000fac5822d6781f3d266b72a5bfc9a40441) | `python3Packages.mypy-protobuf: Add missing build inputs`             |
| [`585e61d4`](https://github.com/NixOS/nixpkgs/commit/585e61d40835c1f06a2b0b7d3cb139e0adf32dd0) | `python3Packages.types-protobuf: init at 3.17.4`                      |
| [`ce180d22`](https://github.com/NixOS/nixpkgs/commit/ce180d22e224d7fe513abd118aece9f4607afc9e) | `python3Packages.types-futures: init at 3.3.0`                        |
| [`392ea03d`](https://github.com/NixOS/nixpkgs/commit/392ea03d71d53f13e0c5b62f55e168ae8cdec1ab) | `bleachbit: 4.0.0 -> 4.4.0`                                           |
| [`d01b3446`](https://github.com/NixOS/nixpkgs/commit/d01b344633244097211b3019b30e2124a4e92a27) | `maintainers: add mbprtpmnr`                                          |
| [`d3677c22`](https://github.com/NixOS/nixpkgs/commit/d3677c2220c6f43fc1069db7789cb40fc7026808) | `python38Packages.google-cloud-secret-manager: 2.7.0 -> 2.7.1`        |
| [`3f6e7482`](https://github.com/NixOS/nixpkgs/commit/3f6e7482ee37808794c71625de8bed9317691e30) | `python3Packages.ytmusicapi: 0.19.1 -> 0.19.2`                        |
| [`5a8d17ad`](https://github.com/NixOS/nixpkgs/commit/5a8d17ad49934629cd1b715eaf03da7a774ad079) | `python3Packages.amcrest: 1.8.1 -> 1.9.2`                             |
| [`fb4ad10f`](https://github.com/NixOS/nixpkgs/commit/fb4ad10f1aad293fbffb5464381bb32ecf1d2b0e) | `haskell: remove ghcjs from pkgsMusl in release-haskell.nix`          |
| [`76606b4f`](https://github.com/NixOS/nixpkgs/commit/76606b4fcb4c97a5efe1cbd31ba9f04a5dec7b7f) | `python3Packages.pylitterbot: 2021.8.1 -> 2021.9.0`                   |
| [`6bfb753d`](https://github.com/NixOS/nixpkgs/commit/6bfb753d8aba337684501d590a881df2c119a016) | `python38Packages.elementpath: 2.3.1 -> 2.3.2`                        |
| [`db55ac31`](https://github.com/NixOS/nixpkgs/commit/db55ac3133a021e4c3bb0c56d715b775e5a4b15f) | `python38Packages.scikits-odes: 2.6.1 -> 2.6.2`                       |
| [`c9783d00`](https://github.com/NixOS/nixpkgs/commit/c9783d003902ab4edbf197cf1fefd86cb5e188eb) | `python3Packages.imap-tools: 0.46.0 -> 0.47.0`                        |
| [`e02262e2`](https://github.com/NixOS/nixpkgs/commit/e02262e299276755af5795ecc5c1c7a5672e93de) | `python.pkgs.r2pipe: fix hanging test`                                |
| [`d3407f1a`](https://github.com/NixOS/nixpkgs/commit/d3407f1a3bab0dd8c139272ee354175c0b489903) | `cc-wrapper: Add support for -mthumb / -marm`                         |
| [`d23ff4d6`](https://github.com/NixOS/nixpkgs/commit/d23ff4d6d9670036859d0eab4b397ca445be26fb) | `python-language-server: Update dependencies`                         |
| [`573e3931`](https://github.com/NixOS/nixpkgs/commit/573e3931f3fb30947e877f4beeb56dd5dc3f41fb) | `github-runner: Update dependencies`                                  |
| [`791cb92c`](https://github.com/NixOS/nixpkgs/commit/791cb92cf0fd8464d1ebd2a694563073ef5ca5b8) | `wasabibackend: Fix create_deps.sh script and update dependencies`    |
| [`1b97f5d0`](https://github.com/NixOS/nixpkgs/commit/1b97f5d00b97b42d3cde83763d4f4be990997ca2) | `dotnetCorePackages:*_3_1: 3.1.15 -> 3.1.19`                          |
| [`8a02206c`](https://github.com/NixOS/nixpkgs/commit/8a02206cf52fc12c749c7299c466a75104b843a4) | `discordchatexporter-cli: Update dependencies`                        |
| [`e1d03104`](https://github.com/NixOS/nixpkgs/commit/e1d0310472fe97fa8caa9a6fe4576be4f8adf1a6) | `osu-lazer: Update dependencies`                                      |
| [`5ebf9aec`](https://github.com/NixOS/nixpkgs/commit/5ebf9aec759df031f9844026c7434efab311d2cf) | `roslyn: Update dependencies`                                         |
| [`88fffac8`](https://github.com/NixOS/nixpkgs/commit/88fffac8c7bcc5cd284b779c970a96ef5fe88959) | `ryujinx: Update dependecies`                                         |
| [`77bd59ab`](https://github.com/NixOS/nixpkgs/commit/77bd59abcfe72623a8b26bccc2287dc69766385c) | `dotnetCorePackages.*_5*: 5.0.6 -> 5.0.10`                            |
| [`6c64820f`](https://github.com/NixOS/nixpkgs/commit/6c64820ffa95db07878b0f4750f4d933d06b52b1) | `dotnetCorePackages:*_3_1: 3.1.8 -> 3.1.15`                           |
| [`30076ecc`](https://github.com/NixOS/nixpkgs/commit/30076ecc154df86d2e4d4b9ab60137c83e872255) | `dotnetCorePackages.*_5*: 5.0.0 -> 5.0.6`                             |
| [`88845c14`](https://github.com/NixOS/nixpkgs/commit/88845c14ae92d59b1d5a18ad7a7d9ca294809c39) | `python38Packages.simplekml: 1.3.5 -> 1.3.6`                          |
| [`cf7ec8ec`](https://github.com/NixOS/nixpkgs/commit/cf7ec8ec5d48e7cb6729a1cf59a01f2f5d5bb052) | `python38Packages.pyglet: 1.5.20 -> 1.5.21`                           |
| [`1b7b1732`](https://github.com/NixOS/nixpkgs/commit/1b7b17325de7a4094c7bcea463425bbafc39fcb8) | `python38Packages.pytest-snapshot: 0.6.3 -> 0.7.0`                    |
| [`5230d895`](https://github.com/NixOS/nixpkgs/commit/5230d8951857f55d4e5f0515c71baa63d1077c2b) | `steam-acf: init at 0.1.0`                                            |
| [`357f3ca1`](https://github.com/NixOS/nixpkgs/commit/357f3ca127bdae12ea035e9f82d4d1b1d1efe2e7) | `starboard-octant-plugin: 0.11.0 -> 0.12.0`                           |
| [`a3bb4d88`](https://github.com/NixOS/nixpkgs/commit/a3bb4d888400d9d9bea0a9540704e1d0369df370) | `maintainers: add chisui`                                             |
| [`9e474d4f`](https://github.com/NixOS/nixpkgs/commit/9e474d4f8c7734b8076f332b715272984850df11) | `python3Packages.green: fix tests`                                    |
| [`33390f6b`](https://github.com/NixOS/nixpkgs/commit/33390f6bc795c29a40e0d10e4e9a69ac7adc8f65) | `alliance: 5.1.1 -> unstable-2021-09-15`                              |
| [`64ffacd5`](https://github.com/NixOS/nixpkgs/commit/64ffacd5143206779c38acfe612dcd8879a91f02) | `vimPlugins.completion-tabnine: fix build`                            |
| [`c6f9779a`](https://github.com/NixOS/nixpkgs/commit/c6f9779a2da881181b7eabda2da868bf8cc91e21) | `yubikey-touch-detector: init at 1.9.1`                               |
| [`0ed11f65`](https://github.com/NixOS/nixpkgs/commit/0ed11f655d71371c2860ca850ddeb99dc27c4b3e) | `ceres-solver: 2.0.0 propagate dependencies (#130268)`                |
| [`fb1348d4`](https://github.com/NixOS/nixpkgs/commit/fb1348d43303005605c8aed3983d8a921039f8d2) | `bintools-wrapper: check if bintools to wrap isGNU, not stdenv`       |
| [`c0a481b1`](https://github.com/NixOS/nixpkgs/commit/c0a481b1a3f9d2fb7fa82e5adb7d1b4edfed59cf) | `vscode-extensions.tabnine.tabnine-vscode: init at 3.4.27`            |
| [`cae999f7`](https://github.com/NixOS/nixpkgs/commit/cae999f7a36027deb00ff3ad77cf02a09de8f0b5) | `neovim.tests: add a test for tags generation`                        |
| [`22caffad`](https://github.com/NixOS/nixpkgs/commit/22caffad3a2b32a0be38cd2a3a1e1953f3d153f0) | `vimPlugins.minimap-vim: add test`                                    |
| [`57131f17`](https://github.com/NixOS/nixpkgs/commit/57131f173e4aeeb074715d64a34ced5eabcdc033) | `vimUtils.vimGenDocHook: fix tag generation`                          |
| [`eda7b3d0`](https://github.com/NixOS/nixpkgs/commit/eda7b3d00e380950e57ec6fb67d15f45deecb0f8) | `joplin-desktop: 2.3.5 -> 2.4.6`                                      |
| [`3a25a2e3`](https://github.com/NixOS/nixpkgs/commit/3a25a2e3f7494f0eac262f8a934679465a50c844) | `emacs.pkgs.youtube-dl: fix`                                          |
| [`b8ffae12`](https://github.com/NixOS/nixpkgs/commit/b8ffae12a01a8e06fa51ae34b0b012526145acfc) | `emacs.pkgs.isearch-prop: fix`                                        |
| [`39228a5f`](https://github.com/NixOS/nixpkgs/commit/39228a5f0bba7721c6b8a502f4e63e5e0e531b32) | `qtads: 3.0.0 -> 3.1.0`                                               |
| [`a3d011ee`](https://github.com/NixOS/nixpkgs/commit/a3d011eebcee9f70463a68c28b2252073336ed54) | `nixos-docs: improved the installation instructions of Pleroma`       |
| [`3342128e`](https://github.com/NixOS/nixpkgs/commit/3342128e06b66534436444dfdef285815a2581de) | `emacs.pkgs.git-undo: fix`                                            |
| [`b590bf70`](https://github.com/NixOS/nixpkgs/commit/b590bf7063cae685a3c3e0c5106b205ca204736b) | `parinfer-rust: fix vim plugin`                                       |
| [`df30b5d8`](https://github.com/NixOS/nixpkgs/commit/df30b5d8ebfb2e3909475c7081c78fc3fafcd038) | `emacs.pkgs.evil-markdown: fix`                                       |
| [`36e21638`](https://github.com/NixOS/nixpkgs/commit/36e21638f5f308d8985035bca9c14595c0a3b65f) | `linux/hardened/patches/5.4: 5.4.146-hardened1 -> 5.4.147-hardened1`  |
| [`9f34448a`](https://github.com/NixOS/nixpkgs/commit/9f34448a98ecc21726dd5e87b7a61daf76f954de) | `linux/hardened/patches/5.14: 5.14.4-hardened1 -> 5.14.5-hardened1`   |
| [`7c04d2e3`](https://github.com/NixOS/nixpkgs/commit/7c04d2e390a7dbb87a428f625839db42071b7b99) | `linux/hardened/patches/5.13: 5.13.17-hardened1 -> 5.13.18-hardened1` |
| [`031afe4f`](https://github.com/NixOS/nixpkgs/commit/031afe4faa1e390ebdc10eb145aaeab9be978cea) | `linux/hardened/patches/5.10: 5.10.65-hardened1 -> 5.10.66-hardened1` |
| [`5f03301d`](https://github.com/NixOS/nixpkgs/commit/5f03301dea3b585f56f747512f72d18377099ef7) | `emacs.pkgs.ess-R-object-popup: fix`                                  |
| [`6ef091d0`](https://github.com/NixOS/nixpkgs/commit/6ef091d07ae3a7587427fac0665d4d4a057d23d4) | `puNES: Fix a typo (#138242)`                                         |
| [`3f7b8b9e`](https://github.com/NixOS/nixpkgs/commit/3f7b8b9eac8a04803762d2be2bb79ee6c93ecc5e) | `emacs.pkgs.agda2-mode: fix`                                          |
| [`906da2ce`](https://github.com/NixOS/nixpkgs/commit/906da2ce263bac05b5755ba2ed0f57f5abbc0ed3) | `haskellPackages.crc: Builds with dontCheck`                          |
| [`18c4e026`](https://github.com/NixOS/nixpkgs/commit/18c4e0268911b01748a1be3ba93064087b1959da) | `mitmproxy: 7.0.2 -> 7.0.3`                                           |
| [`38431cf2`](https://github.com/NixOS/nixpkgs/commit/38431cf21c59a84c0ddedccc0cd66540a550ec26) | `nixos/wordpress: caddy support`                                      |
| [`29f8f30b`](https://github.com/NixOS/nixpkgs/commit/29f8f30b37c0fe0da9c64e38c9248e59869cb450) | `zfsStable, zfsUnstable: fix eval`                                    |
| [`f4463189`](https://github.com/NixOS/nixpkgs/commit/f4463189169f09b4741d81fd7323197f48667063) | `lib.cleanSource: ignore sockets`                                     |
| [`076bb671`](https://github.com/NixOS/nixpkgs/commit/076bb67140119547b17de0ed6597cf51fae55a13) | `macchina: 1.1.4 -> 1.1.5`                                            |
| [`a06e75c5`](https://github.com/NixOS/nixpkgs/commit/a06e75c518e711597bb1555fe25ba0115ba0fae4) | `libreddit: 0.15.1 -> 0.15.2`                                         |
| [`6ba60d5f`](https://github.com/NixOS/nixpkgs/commit/6ba60d5f81bd8ba884e7b052a7b9bf6df97c6637) | `cargo-audit: 0.15.1 -> 0.15.2`                                       |
| [`a96fe065`](https://github.com/NixOS/nixpkgs/commit/a96fe065eee37d61972386b96d1573102b12b4a2) | `nix-output-monitor: 1.0.3.1 -> 1.0.3.2`                              |
| [`8ef8a22e`](https://github.com/NixOS/nixpkgs/commit/8ef8a22ecc887e0550937af20685a24361cbae9c) | `kubeone: 1.2.3 -> 1.3.0`                                             |
| [`60f8a42d`](https://github.com/NixOS/nixpkgs/commit/60f8a42d3aa8fa095cb3830fb28a02d8ae3b4831) | `uudeview: don't hardeningDisable format`                             |
| [`7399c672`](https://github.com/NixOS/nixpkgs/commit/7399c67273ca74f61aa7da208cd75d51453731c4) | `exploitdb: 2021-09-14 -> 2021-09-17`                                 |
| [`c474fb2b`](https://github.com/NixOS/nixpkgs/commit/c474fb2ba311a3042224637c0271183b4f761114) | `fnm: 1.26.0 -> 1.27.0`                                               |
| [`b8dc5200`](https://github.com/NixOS/nixpkgs/commit/b8dc5200943cbafb0b7ca65150b2cd39c1a238cc) | `exoscale-cli: 1.41.0 -> 1.42.0`                                      |
| [`84f9192e`](https://github.com/NixOS/nixpkgs/commit/84f9192eb10a5146e162ead956422f69e8892995) | `vscode-extensions.mvllow.rose-pine: init at 1.3.6`                   |
| [`e98f72fe`](https://github.com/NixOS/nixpkgs/commit/e98f72fe8dc98ec2d652d9319d940f930df1435d) | `eksctl: 0.62.0 -> 0.66.0`                                            |
| [`66946247`](https://github.com/NixOS/nixpkgs/commit/669462478eed5e89637215a79b0870ff7a4e696e) | `tabnine: 3.5.49 -> 3.6.8`                                            |
| [`97bbfa3d`](https://github.com/NixOS/nixpkgs/commit/97bbfa3da434f205d02aa66ce335451a55b81f44) | `vscode-extensions.antfu.slidev: init at 0.3.2`                       |
| [`d5c3d469`](https://github.com/NixOS/nixpkgs/commit/d5c3d46935a13a7317b00dbb466c97097c21b444) | `plexamp: 3.7.0 -> 3.7.1`                                             |
| [`d6c2bb73`](https://github.com/NixOS/nixpkgs/commit/d6c2bb73fb47ea502caac8be9ed061a8ec4e7234) | `doc/python: fix typo in example`                                     |
| [`2a792443`](https://github.com/NixOS/nixpkgs/commit/2a79244302be9f4ad93ac51fe8aeff6df036c139) | `emacs.pkgs.agda-input: Fix syntax error`                             |
| [`087e816e`](https://github.com/NixOS/nixpkgs/commit/087e816e377d3ea22f427944b8c7ff6d74d3dec5) | `vimUtils: expose packDir`                                            |
| [`761b2c6f`](https://github.com/NixOS/nixpkgs/commit/761b2c6ff342425388db38b86f1c49cbdb232514) | `neovim.tests: complete plug test`                                    |
| [`344c501f`](https://github.com/NixOS/nixpkgs/commit/344c501f8831f46c08a9d5836c9b9c5920d1367b) | `qtile: 0.18.0 -> 0.18.1`                                             |
| [`b1aecac8`](https://github.com/NixOS/nixpkgs/commit/b1aecac8a1fc3d54e92cacc67dad4a459c9b86bc) | `python3Packages.mat2: remove unused fetchpatch`                      |
| [`4843b565`](https://github.com/NixOS/nixpkgs/commit/4843b5658f4d1cf61d740fd9e5e6f47196458947) | `yq-go: 4.12.2 -> 4.13.0`                                             |
| [`f1cae8a9`](https://github.com/NixOS/nixpkgs/commit/f1cae8a9148bed5ccaef8f5e7a645675846b07d2) | `python3Packages.minidump: 0.0.19 -> 0.0.20`                          |
| [`7f39537c`](https://github.com/NixOS/nixpkgs/commit/7f39537c8dc8bb357c818e4c2622d0d5c0739f64) | `python3Packages.slack-sdk: 3.10.1 -> 3.11.0`                         |
| [`7e59877f`](https://github.com/NixOS/nixpkgs/commit/7e59877fe11033330501b93e9b705fd393bfcb25) | `glm: 0.9.8.5 -> 0.9.9.8`                                             |
| [`97399a8a`](https://github.com/NixOS/nixpkgs/commit/97399a8a00bacca673fd330c1aceea174b0f3fd0) | `python3Packages.slowapi: 0.1.4 -> 0.1.5`                             |
| [`5ea9388a`](https://github.com/NixOS/nixpkgs/commit/5ea9388abc67ffc72204afcd519245ab69563a85) | `python3Packages.requests-pkcs12: 1.12 -> 1.13`                       |
| [`bb46e4f6`](https://github.com/NixOS/nixpkgs/commit/bb46e4f6fb5fb8ff80753a27585daa6f1c50b797) | `bash-preexec: init at 0.4.1`                                         |
| [`ff6fb898`](https://github.com/NixOS/nixpkgs/commit/ff6fb898ac11223e281cffac992246e3b6c31a97) | `symfony-cli: 4.26.0 -> 4.26.3`                                       |
| [`75e1910b`](https://github.com/NixOS/nixpkgs/commit/75e1910b90ba4f0b330f7fa7e31551e4ad6a2e5c) | `stripe-cli: 1.7.1 -> 1.7.3`                                          |
| [`689e6a88`](https://github.com/NixOS/nixpkgs/commit/689e6a88ad7fa423f307190b81bd109806f12ebd) | `starboard: 0.11.0 -> 0.12.0`                                         |
| [`af69a713`](https://github.com/NixOS/nixpkgs/commit/af69a713958cac3956123844906dae2f0d3af6be) | `linuxPackages.zfs: 2.1.0 -> 2.1.1`                                   |
| [`e5f5716a`](https://github.com/NixOS/nixpkgs/commit/e5f5716a3653844a99b106062fcbb53e286594a9) | `shipyard: 0.3.27 -> 0.3.30`                                          |
| [`03a1cf36`](https://github.com/NixOS/nixpkgs/commit/03a1cf3674bc9ab2722438b800302f76f6bc2cb7) | `python3Packages.mat2: 0.12.1 -> 0.12.2`                              |
| [`2182da1d`](https://github.com/NixOS/nixpkgs/commit/2182da1de8081da92f3c5c04e3fa5e5452266afc) | `bloop: 1.4.8 -> 1.4.9`                                               |
| [`0e23ab20`](https://github.com/NixOS/nixpkgs/commit/0e23ab20660758703ebd2f29a9d783bae986e838) | `anytype: 0.18.68 -> 0.19.0`                                          |
| [`ad79645e`](https://github.com/NixOS/nixpkgs/commit/ad79645effd17e93cdb1722205eb05180a5080ed) | `lemmy-server: 0.11.3 -> 0.12.2`                                      |
| [`62f24d0c`](https://github.com/NixOS/nixpkgs/commit/62f24d0c5711c44307912e8e4df62d430b8b6b98) | `lemmy-ui: init at 0.12.2`                                            |
| [`eeb2a590`](https://github.com/NixOS/nixpkgs/commit/eeb2a590b0d0d6008586cb0cb875e7b55e13902d) | `Maintainers: Add Bill Ewanick`                                       |
| [`00b7ced7`](https://github.com/NixOS/nixpkgs/commit/00b7ced782afc3c1d75f58717a5572ece64fc9b0) | `lemmy: move to server.nix`                                           |