### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ed332b0bc7440cc25de85a09fdb0491d3ad3343d",
-        "sha256": "1n8wcgm0wcng1mcgk1q6yfi1y951j2fc3n2dxgcrns9v9h7c552c",
+        "rev": "a54d2e72e282f2bc68c49f82c735cf664244ec75",
+        "sha256": "0wvd7s75ilbi7c91sp850l8akfkx70jd0yk7hc2r0v3hcyzf8ldw",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/ed332b0bc7440cc25de85a09fdb0491d3ad3343d.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/a54d2e72e282f2bc68c49f82c735cf664244ec75.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`12c65922`](https://github.com/NixOS/nixpkgs/commit/12c6592208ce632106b76c975789c617552547e6) | `adguardhome: 0.105.2 -> 0.106.3`                                  |
| [`556dcbe5`](https://github.com/NixOS/nixpkgs/commit/556dcbe51db6d9e7452bf211baf5e731554a0258) | `python3Packages.orjson: init at 3.6.3 (#137969)`                  |
| [`f13c1d94`](https://github.com/NixOS/nixpkgs/commit/f13c1d948a41d338127284670576c144c6656258) | `cargo-spellcheck: init at 0.8.13`                                 |
| [`cdd4d1ce`](https://github.com/NixOS/nixpkgs/commit/cdd4d1ceec76d727118ccec610832b7ba3e51de0) | `vector: disable flaky test`                                       |
| [`52187777`](https://github.com/NixOS/nixpkgs/commit/5218777714a09597ae3c35c94ee2096425266f1c) | `gitoxide: 0.7.0 -> 0.8.4`                                         |
| [`e98e088d`](https://github.com/NixOS/nixpkgs/commit/e98e088d4af3c41bf1a79d7135a360a0120f55d2) | `kubernetes: 1.22.1 -> 1.22.2`                                     |
| [`aa0b3b20`](https://github.com/NixOS/nixpkgs/commit/aa0b3b200df99315e55bea3357151705e11025cb) | `vimPlugins: update`                                               |
| [`1623e435`](https://github.com/NixOS/nixpkgs/commit/1623e435dd72ee71b33f2b9b7f70de3b1a0350db) | `tree-sitter: update grammars`                                     |
| [`e2600d44`](https://github.com/NixOS/nixpkgs/commit/e2600d4430f60f31b38c6164b6241b5ba742836a) | `tree-sitter-zig: switch to a maintained version`                  |
| [`bebdf982`](https://github.com/NixOS/nixpkgs/commit/bebdf9820cfc6da1bc1061c479440d65756e81ff) | `tree-sitter-vim: init`                                            |
| [`527933a7`](https://github.com/NixOS/nixpkgs/commit/527933a7d87a712f3b1568cb69db5e3f01494f57) | `tree-sitter-rst: init`                                            |
| [`b7fb2794`](https://github.com/NixOS/nixpkgs/commit/b7fb2794c4d45653027c4b2e3fb4f23dd8914112) | `tree-sitter-elisp: init`                                          |
| [`5d087332`](https://github.com/NixOS/nixpkgs/commit/5d087332634f434165c25cc06068f782638d740d) | `tree-sitter-dart: init`                                           |
| [`19bd423f`](https://github.com/NixOS/nixpkgs/commit/19bd423fadd91b900899959038cf7f6471434dcd) | `tree-sitter-clojure: init`                                        |
| [`ed55c1a4`](https://github.com/NixOS/nixpkgs/commit/ed55c1a44435d36eb4e35da67d0f1faa6e423f04) | `mmv-go: 0.1.3 -> 0.1.4`                                           |
| [`a53e02e3`](https://github.com/NixOS/nixpkgs/commit/a53e02e3ec3fa770e9449924c45fe99bc10a1cda) | `apache-jena-fuseki: 3.13.1 -> 4.2.0`                              |
| [`f54d2792`](https://github.com/NixOS/nixpkgs/commit/f54d2792e0bbfcd31900fd4a22cdd977d5bafad8) | `apache-jena: 3.7.0 -> 4.2.0`                                      |
| [`ef448795`](https://github.com/NixOS/nixpkgs/commit/ef448795997dd7bde63cdb1a50413e3f0f855af6) | `phoronix-test-suite: run missing hooks: preInstall, postInstall`  |
| [`0fd8cc39`](https://github.com/NixOS/nixpkgs/commit/0fd8cc390806ef15ded043e729816faa277120af) | `treewide: switch from pantheon.maintainers to lib.teams.pantheon` |
| [`70da1764`](https://github.com/NixOS/nixpkgs/commit/70da17646624c7d24daacc644c3c870a938b2f94) | `atftp: enable tests`                                              |
| [`10842338`](https://github.com/NixOS/nixpkgs/commit/108423388944d94a080fc5f04f213777f78f11b1) | `atftp: 0.7.4 -> 0.7.5`                                            |
| [`f126efd8`](https://github.com/NixOS/nixpkgs/commit/f126efd820273736a7910777641e4ed5563ba091) | `nixos/pantheon-tweaks: init`                                      |
| [`dde5b46c`](https://github.com/NixOS/nixpkgs/commit/dde5b46c5abd66198e56149157e591ae9d729707) | `pantheon-tweaks: init at 1.0.1`                                   |
| [`1b01b72d`](https://github.com/NixOS/nixpkgs/commit/1b01b72d85d78a4f586a35a141d062939682e897) | `maintainers: add iagoq`                                           |
| [`10c712ad`](https://github.com/NixOS/nixpkgs/commit/10c712ad4e964b02ff6cac3de4f7bd38218595b2) | `kubesec: 2.11.2 -> 2.11.3`                                        |
| [`886c6803`](https://github.com/NixOS/nixpkgs/commit/886c680318ba722703e4177dd54e50421aad74d6) | `md4c: fix generated pkg-config .pc files`                         |
| [`a8c48865`](https://github.com/NixOS/nixpkgs/commit/a8c48865533df76681541de3e9d629a7dc03b0df) | `prs: 0.2.13 -> 0.3.2`                                             |
| [`3026ff17`](https://github.com/NixOS/nixpkgs/commit/3026ff17ec700429967dda62401c788dba4e90da) | `nixos/doc: new progress in xserver.extraLayouts`                  |
| [`e4da1edf`](https://github.com/NixOS/nixpkgs/commit/e4da1edf8b6290c406051454820be7017ec2d7dc) | `nixos/extra-layouts: avoid all rebuilds`                          |
| [`0a976c01`](https://github.com/NixOS/nixpkgs/commit/0a976c018ac345bc190f01be4fdd303a6639d005) | `orocos-kdl: 1.5.0 -> 1.5.1`                                       |
| [`413dd292`](https://github.com/NixOS/nixpkgs/commit/413dd2929433301431627f7bbdbafe8ed9b2f352) | `cargo-udeps: 0.1.22 -> 0.1.23`                                    |
| [`7355684e`](https://github.com/NixOS/nixpkgs/commit/7355684e5ad5800d0a71482ee4ad0ca1fac3b815) | `portfolio-filemanager: 0.9.10 -> 0.9.12`                          |