### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "39b0c5ecc5f2991470e5fba4bd83935d88ee0016",
-        "sha256": "079f6adsk4qk40xicr8ibjncd74206aqyigpbb4xfgmkj7jm8ma8",
+        "rev": "ab9569913ad347f8adcd9f80f3d14e6c26f0a1d5",
+        "sha256": "0lhzvx28fx508s82j6j9cc95ia4694cv5fiid0jskc0k9gq5rq13",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/39b0c5ecc5f2991470e5fba4bd83935d88ee0016.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/ab9569913ad347f8adcd9f80f3d14e6c26f0a1d5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                           |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`86682241`](https://github.com/NixOS/nixpkgs/commit/86682241081f7e291b8df454f60c0200b7f26050) | `libsixel: 1.8.6 -> 1.10.1`                                                              |
| [`bdd04def`](https://github.com/NixOS/nixpkgs/commit/bdd04deff52fd6eb0d34e08ac8193ddb96c84a96) | `meilisearch: module cleanup`                                                            |
| [`6903737a`](https://github.com/NixOS/nixpkgs/commit/6903737a8cab8e572ab28799377a28dd3785efa9) | `meilisearch: nixpkgs-fmt`                                                               |
| [`be72fadd`](https://github.com/NixOS/nixpkgs/commit/be72fadd548864f60fbb69dcb3d3b389ec79979c) | `nixosTests.meilisearch: init`                                                           |
| [`811fe35a`](https://github.com/NixOS/nixpkgs/commit/811fe35a665fa47cf88c97e9e6aa395526d3a9b6) | `nixos/meilisearch: init`                                                                |
| [`b51e8131`](https://github.com/NixOS/nixpkgs/commit/b51e813153d87636526c6ab2ca02dc3466f05a26) | `elasticsearch: support version 6`                                                       |
| [`c9845d4d`](https://github.com/NixOS/nixpkgs/commit/c9845d4d32fa4fe2b7e7c439b25b68df5dcfc005) | `cargo-dephell: init at 0.5.1`                                                           |
| [`0adf50ee`](https://github.com/NixOS/nixpkgs/commit/0adf50eefec9fb0122682a178659d6e2593f8e89) | `haskellPackages: mark builds failing on hydra as broken`                                |
| [`abbbc072`](https://github.com/NixOS/nixpkgs/commit/abbbc072b1353d8c8dbc58a6d8f3fdf83a48fa03) | `cargo-tally: init at 1.0.0`                                                             |
| [`c0423f63`](https://github.com/NixOS/nixpkgs/commit/c0423f6304aa5aec46aa3eb55b8937b4932dcf03) | `python38Packages.emoji: 1.4.2 -> 1.5.0`                                                 |
| [`aeee80f1`](https://github.com/NixOS/nixpkgs/commit/aeee80f10e1861eea15d64b3848cfb3cb343767a) | `python38Packages.databricks-connect: 8.1.12 -> 8.1.13`                                  |
| [`f5c3ef77`](https://github.com/NixOS/nixpkgs/commit/f5c3ef776243bfcbb8a00494fa6d2aa6fe7af8a2) | `python38Packages.gensim: 4.1.1 -> 4.1.2`                                                |
| [`9bc67194`](https://github.com/NixOS/nixpkgs/commit/9bc67194e06875f888bedc3bae1d1062b7a4faec) | `weechat: 3.2.1 -> 3.3`                                                                  |
| [`cab1a84f`](https://github.com/NixOS/nixpkgs/commit/cab1a84f28cf61d6a5c4a167afb5e712ca8d88c7) | `cargo-llvm-lines: init at 0.4.11`                                                       |
| [`1e7edcb2`](https://github.com/NixOS/nixpkgs/commit/1e7edcb21f13bfb959cf7fd0d41d52fdb9931164) | `cawbird: 1.4.1 -> 1.4.2`                                                                |
| [`d0dde619`](https://github.com/NixOS/nixpkgs/commit/d0dde6199f29417aa48423644db5b259ab8dc95e) | `hck: 0.6.3 -> 0.6.4`                                                                    |
| [`cdea486e`](https://github.com/NixOS/nixpkgs/commit/cdea486e7a79995cb029ce61bbec8715572fba4d) | `cargo-diet: init at 1.2.2`                                                              |
| [`88cddfbf`](https://github.com/NixOS/nixpkgs/commit/88cddfbfb5accf02f357a42835f5e7d26ca6db82) | `gocryptfs: support fstab mount`                                                         |
| [`7e399b70`](https://github.com/NixOS/nixpkgs/commit/7e399b70a70cd8ff6e15af37813edf9726d4a26b) | `exploitdb: 2021-09-17 -> 2021-09-18`                                                    |
| [`242ab4de`](https://github.com/NixOS/nixpkgs/commit/242ab4debd0eca13d579d824c2d993e5ee5f0cda) | `haskell-language-server: Disable several plugin checks on arm`                          |
| [`6b84305e`](https://github.com/NixOS/nixpkgs/commit/6b84305e5cc0efe58ae3af0ba939c4f414b34305) | `python37Packages.py-air-control-exporter: 0.3.0 -> 0.3.1`                               |
| [`3389aab8`](https://github.com/NixOS/nixpkgs/commit/3389aab889719081e240ce169ec5bc0d5ccd60d0) | `haskell.compiler.ghcjs: mark hydraPlatforms as none because output is too large`        |
| [`f65bd7a8`](https://github.com/NixOS/nixpkgs/commit/f65bd7a8a7c3af6d40d4943483e68a7b76c4c750) | `libopenmpt: default to supporting pulseaudio`                                           |
| [`77adbb9c`](https://github.com/NixOS/nixpkgs/commit/77adbb9ce7e9f3585102d23614e7c3a596d83b71) | `maintainers/scripts/haskell/hydra-report: Add traffic light`                            |
| [`3fd2e2b7`](https://github.com/NixOS/nixpkgs/commit/3fd2e2b7f83a55dabfe39c7ac68e619dc216b643) | `sabnzbd: 3.3.1 -> 3.4.0`                                                                |
| [`ed2b0923`](https://github.com/NixOS/nixpkgs/commit/ed2b092333626b75e3ab70229934d576cc82a4bd) | `maintainers/scripts/haskell: Add r-deps information to build-report`                    |
| [`8aa960d5`](https://github.com/NixOS/nixpkgs/commit/8aa960d561cedb103661b64df041f88717523cdf) | `nerdctl: 0.11.1 -> 0.11.2`                                                              |
| [`b8b88612`](https://github.com/NixOS/nixpkgs/commit/b8b88612ff31b5b640d9c177c016c54d23c38983) | `haskell: update HACKING.md document to describe merge-and-open-pr.sh maintainer script` |
| [`b95e5014`](https://github.com/NixOS/nixpkgs/commit/b95e501450ee49f46456f6a91626ec168654f749) | `vimUtils.buildVimPlugin: fix cross compiles`                                            |
| [`e13d2792`](https://github.com/NixOS/nixpkgs/commit/e13d27929ce46247dccf963dd1d6226c1c2e0360) | `vim_configurable: fix cross compile`                                                    |
| [`cade060d`](https://github.com/NixOS/nixpkgs/commit/cade060da3482363560d6890efd1c9e2fcc54beb) | `vim: remove unneeded cross flag`                                                        |
| [`ecce26dd`](https://github.com/NixOS/nixpkgs/commit/ecce26dd5aef112994caf31642200e6fdd3f2d46) | `haskell: Add a maintainer script for opening a new haskell-updates PR`                  |
| [`27873366`](https://github.com/NixOS/nixpkgs/commit/27873366b9536b892e16c477abd38c68accfda46) | `smartdns: Fix systemd service`                                                          |
| [`a4b769cb`](https://github.com/NixOS/nixpkgs/commit/a4b769cb8b4d0aa10c0b494b3d35fb2524dceba6) | `calamares: 3.2.42 -> 3.2.43`                                                            |
| [`d71129e1`](https://github.com/NixOS/nixpkgs/commit/d71129e1af35fb3975d6c7ac5607561452b68216) | `haskell.packages.ghc901.haskell-language-server: Fix build`                             |
| [`d9b9e0f9`](https://github.com/NixOS/nixpkgs/commit/d9b9e0f9ae8467f1a3de21320bd791516aae9de9) | `haskellPackages.haskell-language-server: Use default plugin set`                        |
| [`325e25e0`](https://github.com/NixOS/nixpkgs/commit/325e25e0ca74d40d7e8ede93e534e85e8031a671) | `haskellPackages.hls-stylish-haskell-plugin: Jailbreak to fix build`                     |
| [`48b1bb48`](https://github.com/NixOS/nixpkgs/commit/48b1bb4867cbd8f95fe5ca6aac692c290125e3b2) | `haskellPackages: regenerate package set based on current config`                        |
| [`548e93f7`](https://github.com/NixOS/nixpkgs/commit/548e93f7a1337d48241c9f097549772d65cd7afa) | `all-cabal-hashes: 2021-09-10T22:56:58Z -> 2021-09-17T18:08:40Z`                         |
| [`164ccf3d`](https://github.com/NixOS/nixpkgs/commit/164ccf3d60b715c54d8b14689ba6e4eb90f4f17e) | `haskellPackages: stackage-lts 18.9 -> 18.10`                                            |
| [`88917249`](https://github.com/NixOS/nixpkgs/commit/88917249ba2694a06d2a2e4e3e0de0eb15d20a49) | `ruffle: nightly-2021-05-14 -> nightly-2021-09-17`                                       |
| [`52cb4bd6`](https://github.com/NixOS/nixpkgs/commit/52cb4bd6a220156ba0a1d0561c57e7470fb1e84e) | `terragrunt: 0.31.11 -> 0.32.2`                                                          |
| [`9d721859`](https://github.com/NixOS/nixpkgs/commit/9d721859ebc195814b376efe46b6e1a79daca080) | `skaffold: 1.31.0 -> 1.32.0`                                                             |
| [`ff95c481`](https://github.com/NixOS/nixpkgs/commit/ff95c481e6bd4ff1b72d8ff606629bbd906cc102) | `python3Packages.zeroconf: 0.36.2 -> 0.36.4`                                             |
| [`37c32f26`](https://github.com/NixOS/nixpkgs/commit/37c32f26b8da2f8052fa76289c45c0a5b909e922) | `flyctl: 0.0.238 -> 0.0.240`                                                             |
| [`c256b391`](https://github.com/NixOS/nixpkgs/commit/c256b391faa0d8de851abba043cfb12478615ca9) | `erigon: 2021.08.05 -> 2021.09.02`                                                       |
| [`01889691`](https://github.com/NixOS/nixpkgs/commit/018896912ac2f7eba0863067345920948922ca53) | `teleport: 7.1.0 -> 7.1.2`                                                               |
| [`cee18277`](https://github.com/NixOS/nixpkgs/commit/cee18277c6531babefc157c813154890c293e18e) | `sjasmplus: 1.18.2 -> 1.18.3`                                                            |
| [`d303157b`](https://github.com/NixOS/nixpkgs/commit/d303157b6d01c234595d23759f06c706b992fa02) | `py-spy: 0.3.8 -> 0.3.9`                                                                 |
| [`8e2b07b4`](https://github.com/NixOS/nixpkgs/commit/8e2b07b401333f3ee083f4d0ac718bc721c5d280) | `mlvwm: 0.9.3 -> 0.9.4`                                                                  |
| [`b417e6ec`](https://github.com/NixOS/nixpkgs/commit/b417e6ec80a331403d8e6d4228ca5c60535c1056) | `ristate: init at unstable-2021-09-10`                                                   |
| [`6def1716`](https://github.com/NixOS/nixpkgs/commit/6def171697d2804b55b3959c53b02c153e888022) | `i2pd: 2.38.0 -> 2.39.0`                                                                 |