### PR TITLE
chore(deps): update home-manager

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "371576cdc2580ba93a38e28da8ece2129f558815",
-        "sha256": "0vwkmnvc4pggicgzii4gg22pv5whp2aiian0rs80srwzkxl2sz0n",
+        "rev": "58aa667e28ca4a6a2159b1f3258ef5d494d5ecb6",
+        "sha256": "0f3273hr8yfmyw3543l6m4bfd34513fbkc4lzzlkiaazi0mdjdps",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/371576cdc2580ba93a38e28da8ece2129f558815.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/58aa667e28ca4a6a2159b1f3258ef5d494d5ecb6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixos-hardware": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`58aa667e`](https://github.com/nix-community/home-manager/commit/58aa667e28ca4a6a2159b1f3258ef5d494d5ecb6) | `starship: initialize using command in profile`        |
| [`821299e9`](https://github.com/nix-community/home-manager/commit/821299e90e6e11b5db5dc258b2d85d3b01e95857) | `sbt: run passwordCommand without trailing newline`    |
| [`4320399a`](https://github.com/nix-community/home-manager/commit/4320399a3e5f3afb8a867324901a559f23be8178) | `flake: add docs to packages output`                   |
| [`7cb118c9`](https://github.com/nix-community/home-manager/commit/7cb118c9d232e36f8508686535dec8596c8c48a8) | `xdg: coerce XDG base directories settings to strings` |