### PR TITLE
chore(deps): update sops-nix

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "9d47d2e3e4ab5e7d8907e2ea977b69afab7312d5",
-        "sha256": "0ga528x3sci1y10vd8m5l2wnsl7kkf14whwp7dkwcbkvm34n88yx",
+        "rev": "64235a958b9ceedf98a3212c13b0dea3a504598f",
+        "sha256": "0672hz2ap0ljani5vm1yq9h92596ad7smmkl5rixmi878m6x1agr",
         "type": "tarball",
-        "url": "https://github.com/Mic92/sops-nix/archive/9d47d2e3e4ab5e7d8907e2ea977b69afab7312d5.tar.gz",
+        "url": "https://github.com/Mic92/sops-nix/archive/64235a958b9ceedf98a3212c13b0dea3a504598f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                                 |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`0b99142c`](https://github.com/Mic92/sops-nix/commit/0b99142c900663a08e1500734405fdca7b83a9c7) | `Rename ssh-*-to-age to ssh-to-age`            |
| [`77d0fa59`](https://github.com/Mic92/sops-nix/commit/77d0fa5920f788bc5e30667693e3d23d7c00fe81) | `Simplify age logic in sops-install-secrets`   |
| [`0cad90d7`](https://github.com/Mic92/sops-nix/commit/0cad90d7637caa76d125f4b953f10c16df227ee5) | `Update all go dependencies`                   |
| [`f636296a`](https://github.com/Mic92/sops-nix/commit/f636296aff0adb3a620d4125e8e8c1a2443ad2cd) | `Switch the libs to now external ones`         |
| [`6c916c1f`](https://github.com/Mic92/sops-nix/commit/6c916c1f57cde50e4115b608c9e1a67b6bdde8f7) | `Add a converter from private ssh keys to age` |
| [`45681626`](https://github.com/Mic92/sops-nix/commit/45681626296b4f6efa52cfda8db5f38bcf94a48b) | `Import age ssh keys by default`               |
| [`44d91e88`](https://github.com/Mic92/sops-nix/commit/44d91e885e8cc730912c7951c42687930a7409d6) | `Add review suggestions`                       |
| [`19089e58`](https://github.com/Mic92/sops-nix/commit/19089e588f21ab1a44be9451749c56ee9e4fb0a8) | `Document age usage in the README`             |
| [`c980f254`](https://github.com/Mic92/sops-nix/commit/c980f2547e927a845f12d2bad9fa89c0b619563f) | `Add sops-ssh-to-age tool`                     |
| [`db8fcb50`](https://github.com/Mic92/sops-nix/commit/db8fcb50a30d9ce52c5fba87369eb487e3b8b7e4) | `Add support for ssh-generated age keys`       |
| [`b21c0ce3`](https://github.com/Mic92/sops-nix/commit/b21c0ce3a82dd9c6663e1668710b78a726b1b5b2) | `Group gnupg and age in the module`            |
| [`f5a2ba21`](https://github.com/Mic92/sops-nix/commit/f5a2ba217ba4778cec6602e1d647e2f5113fdf42) | `Add age support`                              |