### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "841b22ab76741eb4d2edcb48117a688e7d7f1b24",
-        "sha256": "1jqr2x8sphppm8n8r49wdhqqsdfq3cqa0hmr4rai6j08gqcxnq0a",
+        "rev": "1737f98af6667560e3e4f930312f9b5002649d04",
+        "sha256": "0jdiw9wjyqvbrnigwjxinars6203ql550f0wlp70j1rr7cn7fmjz",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/841b22ab76741eb4d2edcb48117a688e7d7f1b24.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/1737f98af6667560e3e4f930312f9b5002649d04.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                              |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`9b5dd003`](https://github.com/NixOS/nixpkgs/commit/9b5dd00333775ca9be0d9ac67cc00755708ec494) | `wsdd: 0.6.2 -> 0.6.4`                                                      |
| [`8bf6ca43`](https://github.com/NixOS/nixpkgs/commit/8bf6ca43cbaef0de2bfa031f9c8f6dc2bff8001f) | `python38Packages.pytelegrambotapi: 4.0.0 -> 4.1.0`                         |
| [`7c86d105`](https://github.com/NixOS/nixpkgs/commit/7c86d10590ccc5330fed0866fe937faf3e36f7a3) | `texinfo6_8: init at 6.8 (without switching default)`                       |
| [`61da8692`](https://github.com/NixOS/nixpkgs/commit/61da86928406435694525d7b9553f6ee2703fd77) | `apostrophe: 2.4 -> 2.5`                                                    |
| [`fe6701ec`](https://github.com/NixOS/nixpkgs/commit/fe6701ec3ab3ede6f53d6f014fe1db80b83d0fa7) | `packer: 1.7.4 -> 1.7.5`                                                    |
| [`20706e94`](https://github.com/NixOS/nixpkgs/commit/20706e94085b79340cbdd28abcb9f5f4da9883f1) | `python3Packages.pytibber: update description`                              |
| [`d859c439`](https://github.com/NixOS/nixpkgs/commit/d859c439d20da9341d826768f0a830550fbf46d0) | `python3Packages.pytibber: 0.19.1 -> 0.20.0`                                |
| [`293c04c6`](https://github.com/NixOS/nixpkgs/commit/293c04c6a9898847f6c22d9bd4bc83e8f3434b8d) | `python3Packages.mypy-boto3-builder: 4.22.1 -> 5.4.0`                       |
| [`aef78fae`](https://github.com/NixOS/nixpkgs/commit/aef78fae439df7663e4e2268fc8230d5bedebb63) | `python3Packages.mypy-boto3-builder: 4.14.1 -> 4.22.1`                      |
| [`4e276096`](https://github.com/NixOS/nixpkgs/commit/4e27609642ce2a57539c103ca9a995ad761d53aa) | `exploitdb: 2021-09-22 -> 2021-09-25`                                       |
| [`2eb62bb9`](https://github.com/NixOS/nixpkgs/commit/2eb62bb92e78402557b9f7fe38561f1154ad1aee) | `tfsec: 0.58.9 -> 0.58.10`                                                  |
| [`33d3f1d8`](https://github.com/NixOS/nixpkgs/commit/33d3f1d8207a411d5b343c74e409cab3a2608788) | `python38Packages.fountains: 1.1.0 -> 1.1.1`                                |
| [`5fa508d9`](https://github.com/NixOS/nixpkgs/commit/5fa508d98fe3de78fe8e882ce703ea9ee7144468) | `python38Packages.fe25519: 0.2.0 -> 0.3.0`                                  |
| [`ecd33477`](https://github.com/NixOS/nixpkgs/commit/ecd334772cdf2a57bab4d88ec6f761e2ba38e420) | `python38Packages.emoji: 1.5.0 -> 1.5.2`                                    |
| [`628f61fe`](https://github.com/NixOS/nixpkgs/commit/628f61fe1a5830787ae359aa61be877858c36100) | `python38Packages.deezer-py: 1.2.3 -> 1.2.4`                                |
| [`d032f60c`](https://github.com/NixOS/nixpkgs/commit/d032f60c37ebdae3afd9a24212497ec8725ee4fb) | `ghcjs: Enable on darwin (#139067)`                                         |
| [`8d77e899`](https://github.com/NixOS/nixpkgs/commit/8d77e899e89f8828b211ee66265aa177ad038eca) | `sasquatch: drop blanket -Werror (fix gcc-11 build) (#139350)`              |
| [`f1a8d087`](https://github.com/NixOS/nixpkgs/commit/f1a8d087eb59b4513b37873c4b96bf7d63ec41b1) | `cargo-feature: 0.5.2 -> 0.5.3`                                             |
| [`bd0ea729`](https://github.com/NixOS/nixpkgs/commit/bd0ea72925ec64f0613240894313ad778871e477) | `python38Packages.casbin: 1.8.1 -> 1.9.0`                                   |
| [`383b3b36`](https://github.com/NixOS/nixpkgs/commit/383b3b36d06bddd730acbb466f66af5b7bee913a) | `mop: fix build on bash-5`                                                  |
| [`54cecf8b`](https://github.com/NixOS/nixpkgs/commit/54cecf8bdee6f4eeb9a9a3b4917ceebe51e8b18d) | `tailscale: 1.14.3 -> 1.14.4`                                               |
| [`f40924a4`](https://github.com/NixOS/nixpkgs/commit/f40924a499b405becc41b9c869f64ef0ac5b4b5b) | `vscode: apply postPatch on linux only`                                     |
| [`7a038d04`](https://github.com/NixOS/nixpkgs/commit/7a038d04c64c81470e8691e19ee371a4d1aac178) | `pantheon.gala: fix session crash when taking screenshots with mutter 3.38` |
| [`5fdb0a6c`](https://github.com/NixOS/nixpkgs/commit/5fdb0a6cafff7c41107fdd80e306b47a1bc54718) | `joshuto: 0.9.0 -> 0.9.1`                                                   |
| [`be3bc77e`](https://github.com/NixOS/nixpkgs/commit/be3bc77e3175f055e634ca1375d7cbdb60facfad) | `libnatpmp: make files in $out/lib executable`                              |
| [`d472c9d8`](https://github.com/NixOS/nixpkgs/commit/d472c9d87c6fea330660c2bc079e0e6b607e4c40) | `python3Packages.pyspcwebgw: init at 0.5.0`                                 |
| [`c9ebf4ed`](https://github.com/NixOS/nixpkgs/commit/c9ebf4ed8001e51fdbf976862a2f04d9d580f9b9) | `home-assistant: enable spc tests`                                          |
| [`9c0e8584`](https://github.com/NixOS/nixpkgs/commit/9c0e8584e9fd1ed8e1faa5e09097916f7e387730) | `home-assistant: update component-packages`                                 |
| [`4d7751ad`](https://github.com/NixOS/nixpkgs/commit/4d7751adb6ed5a7bec4a9930ff5f714cad48a995) | `home-assistant: update component-packages`                                 |
| [`5c8bd5a5`](https://github.com/NixOS/nixpkgs/commit/5c8bd5a5ef26da8a555e64c5e4e93efbf75c3b93) | ` python3Packages.streamlabswater: init at 0.3.2`                           |
| [`fb972569`](https://github.com/NixOS/nixpkgs/commit/fb9725692f7b765617a800bdc92d9b4cc37f69d0) | `python3Packages.asynccmd: init at 0.2.4`                                   |
| [`450c0ab5`](https://github.com/NixOS/nixpkgs/commit/450c0ab5e7686b8a595024a91a9b5a29d2209765) | `ocaml-ng.ocamlPackages_4_13.ocaml: 4.13.0-rc2 → 4.13.0`                    |
| [`d3e59373`](https://github.com/NixOS/nixpkgs/commit/d3e59373610389ff65ff025231c70695362b09dc) | `python3Packages.imdbpy: remove patch`                                      |
| [`e6cc081a`](https://github.com/NixOS/nixpkgs/commit/e6cc081a42c3f2dfe7fa363da6408fbc359648e5) | `github-backup: 0.40.0 -> 0.40.1`                                           |
| [`5a0c59bb`](https://github.com/NixOS/nixpkgs/commit/5a0c59bb4dd90bb6103822daaa30bf2fbc70da67) | `python3Packages.xml2rfc: 3.9.1 -> 3.10.0`                                  |
| [`6e20be97`](https://github.com/NixOS/nixpkgs/commit/6e20be978b1aea35bfb1da4ef39200d72a9a74ed) | `chatterino2: 2.3.0 -> 2.3.4`                                               |
| [`fce1ac0d`](https://github.com/NixOS/nixpkgs/commit/fce1ac0d62b496d11f5dd4700524f92c2b844905) | `sqlfluff: 0.6.5 -> 0.6.6`                                                  |
| [`1ae69f0d`](https://github.com/NixOS/nixpkgs/commit/1ae69f0dce7db8ea0494aacd2e302b5158ed0ec5) | `cutter: 2.0.2 -> 2.0.3`                                                    |
| [`63eb37d2`](https://github.com/NixOS/nixpkgs/commit/63eb37d2cade10d66a5c00f8da5e98adf7ed3b54) | `rizin: 0.2.1 -> 0.3.0`                                                     |
| [`cda1e497`](https://github.com/NixOS/nixpkgs/commit/cda1e49784034826eb04a67cfe6fff5e226cc609) | `foreman: add more platform support`                                        |
| [`c3330fa7`](https://github.com/NixOS/nixpkgs/commit/c3330fa752d2fa06d6f8ad68d535152fb9d1d778) | `cpio: clean up the nix expression`                                         |
| [`3194ce02`](https://github.com/NixOS/nixpkgs/commit/3194ce025c746acdc5460a7a7d4fff298ba6a3e5) | `cpio: add two subsequent upstream patches`                                 |
| [`5ad2ce9d`](https://github.com/NixOS/nixpkgs/commit/5ad2ce9dca210123762cb1dbb6f5c81c31c25f0d) | `vsce/asvetliakov.vscode-neovim: init at 0.0.82`                            |
| [`99b632b2`](https://github.com/NixOS/nixpkgs/commit/99b632b2208b69911f3ca48cc0f5fb095e2d2314) | `python38Packages.yt-dlp: 2021.9.2 -> 2021.9.25`                            |
| [`69cb5e3d`](https://github.com/NixOS/nixpkgs/commit/69cb5e3dc6bfd0ae2eb4d0eb9b8c2810d798cc05) | `nixos/owncast: release notes`                                              |
| [`e95a50a6`](https://github.com/NixOS/nixpkgs/commit/e95a50a64b4061ab2cb0572ac493f841e7b65b14) | `nixos/networkd: add ActivationPolicy option`                               |
| [`780415ce`](https://github.com/NixOS/nixpkgs/commit/780415ce5d5bf3df6e361178206cd1185c56c4b9) | `cargo-llvm-lines: 0.4.11 -> 0.4.12`                                        |
| [`539b9b26`](https://github.com/NixOS/nixpkgs/commit/539b9b26aa702e5114595ecb58ae36ebde6ee62b) | `home-assistant: update component-packages`                                 |
| [`048af0cd`](https://github.com/NixOS/nixpkgs/commit/048af0cd5ff53c31eff561b25b9b558e62f82817) | `python3Packages.niluclient: init at 0.1.2`                                 |
| [`0593b0a4`](https://github.com/NixOS/nixpkgs/commit/0593b0a4de51bfdbc3e2e8be368ee9012381afad) | `nomad_1_1: 1.1.4 -> 1.1.5`                                                 |
| [`f9756aa1`](https://github.com/NixOS/nixpkgs/commit/f9756aa1d9ad47c73198bebca8ef473f15305fca) | `nomad_1_0: 1.0.10 -> 1.0.11`                                               |
| [`de68426d`](https://github.com/NixOS/nixpkgs/commit/de68426db81f8061923b283118d5d7f6582b3c29) | `ocamlPackages.labltk: add version 8.06.11 for OCaml 4.13`                  |
| [`5ff1057e`](https://github.com/NixOS/nixpkgs/commit/5ff1057ec4134d76481d9761ebed76d1cb1d3452) | `python3Packages.types-requests: 2.25.8 -> 2.25.9`                          |
| [`5f7019ed`](https://github.com/NixOS/nixpkgs/commit/5f7019ed8a8ad8af7a4db18a12fe2fb8955a647a) | `prisma: 2.30.2 -> 3.1.1`                                                   |
| [`0f9a1d70`](https://github.com/NixOS/nixpkgs/commit/0f9a1d70fad4af54a0d411b306427823476dcced) | `meilisearch: add docs`                                                     |
| [`faef9593`](https://github.com/NixOS/nixpkgs/commit/faef95930b1b52b93d8c98cdf5032fdcbfb93a3f) | `meilisearch: add meta`                                                     |
| [`ec54e608`](https://github.com/NixOS/nixpkgs/commit/ec54e6081866b22bead1f4951c6af05b027724e9) | `home-assistant: enable flipr tests`                                        |
| [`b5802f42`](https://github.com/NixOS/nixpkgs/commit/b5802f427f0d7ad351d6e789fa4deb62f5838c62) | `home-assistant: update component-packages`                                 |
| [`d038da0a`](https://github.com/NixOS/nixpkgs/commit/d038da0ab4cf98699af1b5821172ce19a96c27fa) | `python3Packages.flipr-api: init at 1.4.1`                                  |
| [`b6678803`](https://github.com/NixOS/nixpkgs/commit/b6678803d1cb8baabb87939ff31735755ec08885) | `navi: 2.16.0 -> 2.17.0`                                                    |
| [`847bfb3d`](https://github.com/NixOS/nixpkgs/commit/847bfb3df34b42daca5203c4828af57a46538d8f) | `tdesktop: 3.1.0 -> 3.1.1`                                                  |
| [`8bc030eb`](https://github.com/NixOS/nixpkgs/commit/8bc030eb13ea2fd611e446042340e9f19aa218e4) | `llvmPackages_13: 13.0.0-rc3 -> 13.0.0-rc4`                                 |
| [`3bc4a574`](https://github.com/NixOS/nixpkgs/commit/3bc4a574dbb1674cf99eda99bb4af364c9c8472a) | `prisma: add pimeys as maintainer`                                          |
| [`47557e29`](https://github.com/NixOS/nixpkgs/commit/47557e2984cac84711bf3aad6213dade0907116f) | `nodesPackages.prisma: #135934 follow-up corrections`                       |
| [`d047d336`](https://github.com/NixOS/nixpkgs/commit/d047d336d60433a07c8e0de2dee45cfad8ceecef) | `prisma-engines: #135934 follow-up corrections`                             |
| [`48c21d8c`](https://github.com/NixOS/nixpkgs/commit/48c21d8c273dbe5427e22545073b58adc4fba930) | `python38Packages.ytmusicapi: 0.19.2 -> 0.19.3`                             |
| [`88cdb0a3`](https://github.com/NixOS/nixpkgs/commit/88cdb0a3c041ab6a401c6776de548e72bb332e22) | `wifite2: add pixiewps dependency`                                          |
| [`54051ba4`](https://github.com/NixOS/nixpkgs/commit/54051ba41855a1bbbe8ebe4d6f87386604fb6df9) | `comby: 1.5.1 -> 1.7.0`                                                     |
| [`29efb76a`](https://github.com/NixOS/nixpkgs/commit/29efb76ab6480426ce8c1f7bd8e341f0249a61cc) | `google-chrome: add pipewire dependency`                                    |
| [`fc43bfa5`](https://github.com/NixOS/nixpkgs/commit/fc43bfa5f452fd19e246a14fdab0ac0ce86d0ed4) | `home-assistant: enable hunterdouglas_powerview tests`                      |
| [`86690c93`](https://github.com/NixOS/nixpkgs/commit/86690c930c571860717de155162326e2a5afde1b) | `home-assistant: update component-packages`                                 |
| [`75f3b984`](https://github.com/NixOS/nixpkgs/commit/75f3b98431f89c0313a75447fec3e85419a85bee) | `python3Packages.aiopvapi: init at 1.6.14`                                  |
| [`2fb9f65c`](https://github.com/NixOS/nixpkgs/commit/2fb9f65c0a1c9d6624b5c0a237b3eaa9d14b8dcd) | `comby: nixpkgs-fmt`                                                        |
| [`3d650ad7`](https://github.com/NixOS/nixpkgs/commit/3d650ad7d17f49b9b5f8ae64c3463d410d6b0b43) | `home-assistant: update component-packages`                                 |
| [`e96405f6`](https://github.com/NixOS/nixpkgs/commit/e96405f686b7a4e1341c25f82c1300354819e0c4) | `home-assistant: update component-packages`                                 |
| [`ed04c57d`](https://github.com/NixOS/nixpkgs/commit/ed04c57df977cca53b702dac7268774a2560e2b4) | `python3Packages.eternalegypt: init at 0.0.13`                              |
| [`ccb5c228`](https://github.com/NixOS/nixpkgs/commit/ccb5c2285b2f8110ae469ac23e2cad63f761ed95) | `perlPackages.ConvertASN1: 0.27 -> 0.33`                                    |
| [`c4fc5f5d`](https://github.com/NixOS/nixpkgs/commit/c4fc5f5dda7a87317e7d9856c30a2e4f4c3f19cf) | `home-assistant: update component-packages`                                 |
| [`9d6fbb6b`](https://github.com/NixOS/nixpkgs/commit/9d6fbb6b2cb036c8206e3bfb18aafc13493f286a) | `python3Packages.pysdcp: init at 1`                                         |
| [`b9317c9e`](https://github.com/NixOS/nixpkgs/commit/b9317c9ed1c9261e3fbde8d16fac60ec665b02e5) | `home-assistant: enable renault tests`                                      |
| [`9aa02e78`](https://github.com/NixOS/nixpkgs/commit/9aa02e78e14a0ff1994574c50377184abf7237ab) | `home-assistant: update component-packages`                                 |
| [`f6ce10aa`](https://github.com/NixOS/nixpkgs/commit/f6ce10aac7c645f637997412c193eaea323499a9) | `python3Packages.renault-api: init at 0.1.4`                                |
| [`7a08ed05`](https://github.com/NixOS/nixpkgs/commit/7a08ed05f64a4ce14dfcf7c8a4f8db507a5d07a4) | `python3Packages.marshmallow-dataclass: init at 8.5.3`                      |
| [`d800b42d`](https://github.com/NixOS/nixpkgs/commit/d800b42dec422dcf09f908f2065ef310e5fb38b4) | `udunits: meta.platforms = lib.platforms.all`                               |
| [`df02d2b1`](https://github.com/NixOS/nixpkgs/commit/df02d2b17570f569c50e9e5fd340697d0272cd8c) | `python38Packages.goalzero: 0.1.59 -> 0.2.0`                                |
| [`29ba0603`](https://github.com/NixOS/nixpkgs/commit/29ba06034e1f9d17f260240a24020beb5ddddaad) | `python38Packages.fountains: 1.0.0 -> 1.1.0`                                |
| [`54974715`](https://github.com/NixOS/nixpkgs/commit/5497471572f8a8c4e0ca1b44bfd4de854023b85d) | `python38Packages.deemix: 3.5.1 -> 3.5.3`                                   |
| [`1bac76f0`](https://github.com/NixOS/nixpkgs/commit/1bac76f06fbdcb5d0ea0e18e9dae359c942825da) | `racket: unbreak on darwin`                                                 |
| [`5b2139ea`](https://github.com/NixOS/nixpkgs/commit/5b2139eadc55f9cbc09e19d6654132928992565b) | `python38Packages.filetype: 1.0.7 -> 1.0.8`                                 |
| [`e456e9b1`](https://github.com/NixOS/nixpkgs/commit/e456e9b1ae467c8f83b923dbd2fea337dfe9ff3c) | `sigtool: 0.1.0 -> 0.1.2`                                                   |
| [`28d8ad0b`](https://github.com/NixOS/nixpkgs/commit/28d8ad0be1a42ac439f4bfe84df1c1eac4c83506) | `firefox-bin: Don't reference gnome in expression`                          |
| [`8eeb28ff`](https://github.com/NixOS/nixpkgs/commit/8eeb28ffc3cb5265d080626faa76c6e600c32d33) | `firefox-devedition-bin: 90.0b6 -> 93.0b9`                                  |
| [`5a566e3e`](https://github.com/NixOS/nixpkgs/commit/5a566e3e7762bdc5ca5f6296f3d72e61dbd597ba) | `firefox-beta-bin: 90.0b6 -> 93.0b9`                                        |
| [`aec24826`](https://github.com/NixOS/nixpkgs/commit/aec248263991541bebfb781376543d26d6c79d7f) | `supertag: fix build caused by outdated lexical-core`                       |
| [`98fe3260`](https://github.com/NixOS/nixpkgs/commit/98fe3260c624d94726aec9ff7f7c4f2f456ceea1) | `nixos/gnome: Fix broken .gnome-shell-wrapped wrapper`                      |
| [`b7d6c648`](https://github.com/NixOS/nixpkgs/commit/b7d6c64871a68f76979015b7434233d84370686e) | `gotestsum: fix package name in ldflags`                                    |
| [`7704e229`](https://github.com/NixOS/nixpkgs/commit/7704e2298404057d0a89a5c1ee04cc20c134b0b7) | `home-assistant: enable p1_monitor tests`                                   |
| [`2d4c7f67`](https://github.com/NixOS/nixpkgs/commit/2d4c7f67cc404b2163c067bdbe738da9ea08bb27) | `home-assistant: update component-packages`                                 |
| [`28580344`](https://github.com/NixOS/nixpkgs/commit/28580344231bd73178a888430a36852292547e99) | `python3Packages.p1monitor: init at 1.0.0`                                  |
| [`eba807d5`](https://github.com/NixOS/nixpkgs/commit/eba807d5949801334cf4742423e8a7d5eb161d26) | `chromiumDev: 95.0.4638.17 -> 96.0.4651.0`                                  |
| [`f1ae15c4`](https://github.com/NixOS/nixpkgs/commit/f1ae15c4e7e5c58a8cafa0927ee9da19f76b4a4c) | `python3Packages.iotawattpy: init at 0.1.0`                                 |
| [`c3875017`](https://github.com/NixOS/nixpkgs/commit/c38750173d82346cfcc0c427c1dead5d691d611d) | `python3Packages.aiowatttime: init at 0.1.1`                                |
| [`3512d59e`](https://github.com/NixOS/nixpkgs/commit/3512d59e6c263adc82dabfe6effaa59d18fcd79c) | `python3Packages.velbus-aio: 2021.9.2 -> 2021.9.4`                          |
| [`a7943950`](https://github.com/NixOS/nixpkgs/commit/a79439501f2c40dde884f59b32ef0d5f8701b091) | `gdu: 5.8.0 -> 5.8.1`                                                       |
| [`bb083e62`](https://github.com/NixOS/nixpkgs/commit/bb083e6229266cda7561d64c2eb95f2f07670b91) | `python3Packages.pysiaalarm: 3.0.0 -> 3.0.1`                                |
| [`78d06ff3`](https://github.com/NixOS/nixpkgs/commit/78d06ff3f35376e0f104b6b1a92a2630572d1df8) | `python3Packages.aioymaps: 1.1.0 -> 1.2.0`                                  |
| [`6c3324e2`](https://github.com/NixOS/nixpkgs/commit/6c3324e245a25d9f3417e2f5e7c9c01aadbf7127) | `coqPackages.flocq: 3.3.1 → 3.4.2`                                          |
| [`1e4ccb74`](https://github.com/NixOS/nixpkgs/commit/1e4ccb742211dfef182fe9013cd6fd8c80111ed4) | `python3Packages.pyupgrade: 2.26.0 -> 2.27.0`                               |
| [`d9ef3f10`](https://github.com/NixOS/nixpkgs/commit/d9ef3f10e9dcf4ad1cdd55c186c9ae25773446e4) | `watson: Install fish completions.`                                         |
| [`1490399b`](https://github.com/NixOS/nixpkgs/commit/1490399beb4199a79a4a4b83a5bee974f1860f15) | `kanit-font: mirroring latest styling suggestions from chonburi-font`       |
| [`59740c03`](https://github.com/NixOS/nixpkgs/commit/59740c03de7f6e3820f6f91e88175df2058b0689) | `chonburi-font: init at unstable-2021-09-15`                                |
| [`37ec684a`](https://github.com/NixOS/nixpkgs/commit/37ec684a5c010aa7cf51abaf29691ef2333d6625) | `psi-notify: init at 1.2.1`                                                 |
| [`f779a0ff`](https://github.com/NixOS/nixpkgs/commit/f779a0ff03497e83dab5b04182c13cd2ef347274) | `nix-output-monitor: 1.0.3.2 -> 1.0.3.3`                                    |
| [`447e08c3`](https://github.com/NixOS/nixpkgs/commit/447e08c3dad83341f5c7473ab229e29f8aa129cc) | `sleuthkit: add build for JNI libraries`                                    |
| [`3cfee020`](https://github.com/NixOS/nixpkgs/commit/3cfee020814ceaa8a5a5a5ba2de87efcae62c2db) | `pythonPackages.python-osc: init at 1.7.7`                                  |
| [`868a8a52`](https://github.com/NixOS/nixpkgs/commit/868a8a5218542d352ef3abd743df92b291648544) | `python3Packages.aioapns: init 2.0.2`                                       |
| [`7fdded5c`](https://github.com/NixOS/nixpkgs/commit/7fdded5cd04540832738d2d440d8e876bff3e982) | `nodePackages.browser-sync: init at 2.27.5`                                 |
| [`25c840ed`](https://github.com/NixOS/nixpkgs/commit/25c840ed1bde9516670c591e31c4acdf660e9425) | `cloak: init at 0.2.0`                                                      |
| [`7b6eb919`](https://github.com/NixOS/nixpkgs/commit/7b6eb919617de0b184618df9cbf2d108b01abd06) | `align: init at 1.1.3`                                                      |
| [`b27698e0`](https://github.com/NixOS/nixpkgs/commit/b27698e075a2d8a9670adf51e98917a35f11392e) | `python3Packages.APScheduler: fix build`                                    |