### PR TITLE
chore(deps): update home-manager

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b0651cc2173427857b172604f85da6afe69e1d41",
-        "sha256": "1pnb2wrqfb25bz9widhk4j526w4z99havgqdmq49y3lyjv3jf5gp",
+        "rev": "cb09a968e9b4ab12a8f203f454a1fba372a9fd71",
+        "sha256": "0nva46aix2wjab4b7prxf4c540fajj8a4xjm3b33a1r0jqaq0z52",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/b0651cc2173427857b172604f85da6afe69e1d41.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/cb09a968e9b4ab12a8f203f454a1fba372a9fd71.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixos-hardware": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                   |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`cb09a968`](https://github.com/nix-community/home-manager/commit/cb09a968e9b4ab12a8f203f454a1fba372a9fd71) | `tests: add option `test.stubs`` |