### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e0f52be5659343620d917e71c41e00acad6e3678",
-        "sha256": "05vwhjb0inj8m0kskyyzxr2jymjhwh5h4f2csvsjyp1rv62bcd64",
+        "rev": "96606addcedb821d311c701788062b8864346838",
+        "sha256": "1pja0yrwcj13nbbqakyfsfb90szi0m9lfz4wygm9c7s8gagqxd29",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/e0f52be5659343620d917e71c41e00acad6e3678.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/96606addcedb821d311c701788062b8864346838.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                    |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`aeaf1776`](https://github.com/NixOS/nixpkgs/commit/aeaf177696cc2c2f1f64aae08eb906ee3e08e3a2) | `onionshare: 2.3.3 -> 2.4 (#139606)`                                              |
| [`4b518f4a`](https://github.com/NixOS/nixpkgs/commit/4b518f4aa95b7fe3589c57e2c9604fb65d74b0af) | `n8n: remove systemd option incompatible with nodejs`                             |
| [`43bab0df`](https://github.com/NixOS/nixpkgs/commit/43bab0df9b347641ed5770bc464090d6284aa2fb) | `python3Packages.sense-energy: 0.9.0 -> 0.9.2`                                    |
| [`c71b84cc`](https://github.com/NixOS/nixpkgs/commit/c71b84cc981adc214240fd86016cde735bc83ece) | `terragrunt: 0.32.2 -> 0.33.0`                                                    |
| [`1d95cc33`](https://github.com/NixOS/nixpkgs/commit/1d95cc33926cde142d300b14ae8adf86def348e5) | `qimgv: 0.9.1 -> 1.0.1`                                                           |
| [`29d2581a`](https://github.com/NixOS/nixpkgs/commit/29d2581aad339ecd5a615dff88c95340876f996f) | `python3Packages.pyupgrade: 2.27.0 -> 2.29.0`                                     |
| [`d69583c6`](https://github.com/NixOS/nixpkgs/commit/d69583c6c26551d30e7dac024fb83a65e13e1f65) | `opencv2: don't build unfree libraries by default`                                |
| [`29574aea`](https://github.com/NixOS/nixpkgs/commit/29574aead822e59e83f7a8ca30143a579453aafe) | `obs-studio-plugins.obs-multi-rtmp: 0.2.6.1 -> 0.2.7.1`                           |
| [`e45dd4bf`](https://github.com/NixOS/nixpkgs/commit/e45dd4bffe1ddd8320c1b0ef59c0d80277348f8d) | `python3Packages.class-registry: enable tests`                                    |
| [`eb35be71`](https://github.com/NixOS/nixpkgs/commit/eb35be717f3f15f6292034b26a56ca9df0f9696f) | `python3Packages.class-registry: 2.1.2 -> 3.0.5`                                  |
| [`ae315a3c`](https://github.com/NixOS/nixpkgs/commit/ae315a3c21ce725aaff049f0695e807f6398251b) | `just: 0.10.1 -> 0.10.2`                                                          |
| [`95140031`](https://github.com/NixOS/nixpkgs/commit/95140031d45cd0ae33ca5249710d741e7978a582) | `ioccheck: init at unstable-2021-09-29`                                           |
| [`7997c744`](https://github.com/NixOS/nixpkgs/commit/7997c7447c7b3974ce168d78037b11c3709cc741) | `alot: 0.9.1 -> 0.10 (#139603)`                                                   |
| [`4600c3e3`](https://github.com/NixOS/nixpkgs/commit/4600c3e3c40ec78cef6dd11e4882bc7c13291087) | `owncast: 0.0.8 -> 0.0.9 (#139862)`                                               |
| [`b7fa38dc`](https://github.com/NixOS/nixpkgs/commit/b7fa38dcf64c6198c8566c0f0dcb88d2ec7555a9) | `qemu: add makeWrapper back to nativeBuildInputs`                                 |
| [`983726e1`](https://github.com/NixOS/nixpkgs/commit/983726e1bf776d96a5708b62793323667770fb4c) | `python38Packages.pytest-console-scripts: 1.2.0 -> 1.2.1`                         |
| [`e0ad11f6`](https://github.com/NixOS/nixpkgs/commit/e0ad11f61b428bb81a33749183c752a96dfa8e7e) | `python3Packages.vt-py: init at 0.7.4`                                            |
| [`d243845a`](https://github.com/NixOS/nixpkgs/commit/d243845a84eadd8e9b95ddd61a33aa69051f70cf) | `roogle: init at 0.1.4`                                                           |
| [`16a4da91`](https://github.com/NixOS/nixpkgs/commit/16a4da9127418cd031a5b43bcf2d3b2ce96aafd6) | `dockerTools: Test pullImage fetcher whenever its implementation changes`         |
| [`8e8b3fa1`](https://github.com/NixOS/nixpkgs/commit/8e8b3fa1bb3aaabae1cf7fabd6e91e4f4300cb6d) | `invalidateFetcherByDrvHash: Add self-check`                                      |
| [`c34905f5`](https://github.com/NixOS/nixpkgs/commit/c34905f516e6c7e1bb817a4cda37fe8a0b305f45) | `nixos/boot: qemu-flags -> qemu-common`                                           |
| [`29fe5daf`](https://github.com/NixOS/nixpkgs/commit/29fe5dafcd76a58e9ae63db79f330da09f884000) | `protoc-gen-doc: 2019-04-22 -> 1.5.0`                                             |
| [`c1e83d73`](https://github.com/NixOS/nixpkgs/commit/c1e83d738d3bf037191566be2d22cb6b19c943b3) | `ocamlPackages: update a bunch of libraries from the mirage universe (#132550)`   |
| [`636a4110`](https://github.com/NixOS/nixpkgs/commit/636a41106963acfb02dfacdf711ab96cd117a89b) | `neofetch: apply patch to fix neofetch returning wrong icon theme`                |
| [`51562752`](https://github.com/NixOS/nixpkgs/commit/5156275264d3f611ece78f860a03cab03944a4d1) | `dasel: 1.20.0 -> 1.21.0`                                                         |
| [`020e88bf`](https://github.com/NixOS/nixpkgs/commit/020e88bf7a46a089b94cc6ae962d5bada7233341) | `nixos/tests/docker-tools: check explicitly for file in exportImage`              |
| [`4f7b14b7`](https://github.com/NixOS/nixpkgs/commit/4f7b14b7cd6da46955687ba4faa236fd39c3cc01) | `python38Packages.mypy-boto3-s3: 1.18.48 -> 1.18.50`                              |
| [`07ebe7ba`](https://github.com/NixOS/nixpkgs/commit/07ebe7baabc66db71f7b1f9e337e561116c1b00b) | `rustcat: init at 1.3.0`                                                          |
| [`0911f3c3`](https://github.com/NixOS/nixpkgs/commit/0911f3c313285efce0dd54df1859dbaca337a134) | `python38Packages.mediafile: 0.8.0 -> 0.8.1`                                      |
| [`733cb4e5`](https://github.com/NixOS/nixpkgs/commit/733cb4e5f02c2072d21132643f5dbd0b8bd30e3e) | `mitmproxy: 7.0.3 -> 7.0.4`                                                       |
| [`1515a906`](https://github.com/NixOS/nixpkgs/commit/1515a90611465a6774ea42d59e7315e8adb16f1e) | `python3Packages.python-socketio: 5.3.0 -> 5.4.0`                                 |
| [`e894641c`](https://github.com/NixOS/nixpkgs/commit/e894641cfe6a91d8167e74e7c73ebc76e57e3f57) | `python3Packages.python-engineio: 4.2.0 -> 4.2.1`                                 |
| [`725ee09d`](https://github.com/NixOS/nixpkgs/commit/725ee09d21a23b5dd3ae765c77ff7188d506bd0c) | `python38Packages.jsonrpclib-pelix: 0.4.2 -> 0.4.3.1`                             |
| [`988da51d`](https://github.com/NixOS/nixpkgs/commit/988da51d9c49a1d43fe28a5f92394f5dbc16eede) | `qemu: 6.0.0 -> 6.1.0`                                                            |
| [`9a2bfdab`](https://github.com/NixOS/nixpkgs/commit/9a2bfdab16351a8dcfbc9dcc2e76c8d7be405f2b) | `dalfox: 2.4.9 -> 2.5.2`                                                          |
| [`83002b9c`](https://github.com/NixOS/nixpkgs/commit/83002b9ca57644d65dd901b062e283da1606e47f) | `python38Packages.gphoto2: 2.2.4 -> 2.3.0`                                        |
| [`a35c28c1`](https://github.com/NixOS/nixpkgs/commit/a35c28c10984a634df4195ebc8ab71bd39ba3c25) | `go365: init at 1.4`                                                              |
| [`38d13a60`](https://github.com/NixOS/nixpkgs/commit/38d13a6015c7faeba09de0c7da1aca886953d2b7) | `blanket: init at 0.5.0`                                                          |
| [`4791e7de`](https://github.com/NixOS/nixpkgs/commit/4791e7de6b94d19ebac398af74052bb6733a877d) | `python3Packages.hijri-converter: 2.2.0 -> 2.2.2`                                 |
| [`949421ef`](https://github.com/NixOS/nixpkgs/commit/949421ef611698faa63ddc619db39e28637bf6bc) | `python3Packages.fritzconnection: 1.6.0 -> 1.7.0`                                 |
| [`84587ece`](https://github.com/NixOS/nixpkgs/commit/84587ecefab25048229e41ba709f98643765482c) | `pict-rs: init at 0.3.0-alpha.37`                                                 |
| [`b56d66f5`](https://github.com/NixOS/nixpkgs/commit/b56d66f50710a548a248e757fb62de764998065a) | `python3Packages.aiounifi: enable tests`                                          |
| [`a4eeeecd`](https://github.com/NixOS/nixpkgs/commit/a4eeeecd8dbace4cc6befb569fd4c558e8770491) | `tree-sitter: add norg grammar`                                                   |
| [`84785c63`](https://github.com/NixOS/nixpkgs/commit/84785c63af4aa454176bbb9990b4e2708ce5e642) | `ocamlPackages.logs: also build the optional `logs.browser` library`              |
| [`11175a4c`](https://github.com/NixOS/nixpkgs/commit/11175a4c8b0ea4a87905445f1fcbf52b8a184bec) | `masscan: enable selftest and minor cleanups`                                     |
| [`49fd2c26`](https://github.com/NixOS/nixpkgs/commit/49fd2c26f6048396f3638cf01a376c56bc86bcff) | `python3Packages.aiounifi: 26 -> 27`                                              |
| [`1a0edf13`](https://github.com/NixOS/nixpkgs/commit/1a0edf135a3000a6af7200d4f2e4e344922f186d) | `dockerTools.exportImage: Make $out a tarball again`                              |
| [`63bf4539`](https://github.com/NixOS/nixpkgs/commit/63bf4539b9eaecee667100197ebf6f2be6522914) | `dockerTools.runWithOverlay: Avoid cluttering $out and copying`                   |
| [`8863a519`](https://github.com/NixOS/nixpkgs/commit/8863a5199db598b4a0d23c9997a525a9457cbcb7) | `vmTools.createEmptyImage: Add destination parameter`                             |
| [`c4fc3602`](https://github.com/NixOS/nixpkgs/commit/c4fc3602a0bedc1b333d68b25f76517aae938216) | `exploitdb: 2021-09-25 -> 2021-09-29`                                             |
| [`d9015f09`](https://github.com/NixOS/nixpkgs/commit/d9015f0986b0a840a2793920b81f6dfa98f26d30) | `fluxbox: fix build on gcc-11 (c++17 compat)`                                     |
| [`3a0437d2`](https://github.com/NixOS/nixpkgs/commit/3a0437d2b01d56702d06bb3e787f0d0f6bd0ae92) | `nixos/release-notes: document wpa_supplicant changes`                            |
| [`62126f8c`](https://github.com/NixOS/nixpkgs/commit/62126f8c155d58f7836b2c3873a40e4ad00cf46e) | `nixos/tests/wpa_supplicant: init`                                                |
| [`52b9dd7b`](https://github.com/NixOS/nixpkgs/commit/52b9dd7bf69f2b333bfd1a1e6cbb7d187471054b) | `nixos/wpa_supplicant: add safe secret handling`                                  |
| [`29672350`](https://github.com/NixOS/nixpkgs/commit/296723509fd432d13280a7978c962eb4793ec471) | `python38Packages.ipyvue: 1.5.0 -> 1.6.0`                                         |
| [`f3af592b`](https://github.com/NixOS/nixpkgs/commit/f3af592bea66cd0db326a471dd3df42e0c8458c0) | `brave: 1.29.79 -> 1.30.86`                                                       |
| [`fa0cc611`](https://github.com/NixOS/nixpkgs/commit/fa0cc611ff8ae49efd76e2ed7700a2cdef5707c4) | `dockerTools: fix export`                                                         |
| [`0319228a`](https://github.com/NixOS/nixpkgs/commit/0319228a458f471c017c326ac39fdb6925156271) | `docker-tools: add example for exportImage functionality and test`                |
| [`971b6d4b`](https://github.com/NixOS/nixpkgs/commit/971b6d4b4549010c63bd86943e611d057fd4071f) | `python38Packages.azure-mgmt-extendedlocation: 1.0.0b2 -> 1.0.0`                  |
| [`0ebf9332`](https://github.com/NixOS/nixpkgs/commit/0ebf933264303b3b58498514f3b8cafa9a57604f) | `desmume: 0.9.11 -> 0.9.11+unstable=2021-09-22`                                   |
| [`7917d052`](https://github.com/NixOS/nixpkgs/commit/7917d052705ba260a5e24251059ee9a4e1a3dd06) | `python38Packages.holidays: 0.11.2 -> 0.11.3`                                     |
| [`b38e1eec`](https://github.com/NixOS/nixpkgs/commit/b38e1eecbcb292229b7ab618102d4c7b4f1279a2) | `python38Packages.mediafile: 0.8.0 -> 0.8.1`                                      |
| [`be6947f0`](https://github.com/NixOS/nixpkgs/commit/be6947f03d8966512b1d0817d59fc646024530f1) | `python38Packages.gphoto2: 2.2.4 -> 2.3.0`                                        |
| [`bb2522a4`](https://github.com/NixOS/nixpkgs/commit/bb2522a475ec0a3b3ea08312c4678d191798e9d5) | `pantheon.wingpanel-applications-menu: 2.8.2 -> 2.9.0`                            |
| [`594c066d`](https://github.com/NixOS/nixpkgs/commit/594c066d8d8dac73f6ba6a8a4d1f10a003c6aa5b) | `python38Packages.azure-mgmt-netapp: 5.0.0 -> 5.1.0`                              |
| [`99fd7cdb`](https://github.com/NixOS/nixpkgs/commit/99fd7cdb72cd9f56d6f4ff14b220d8fba2ac28c6) | `python38Packages.casbin: 1.9.0 -> 1.9.1`                                         |
| [`3158087c`](https://github.com/NixOS/nixpkgs/commit/3158087c78c183651dffcce2ed56ff63e8348742) | `tarsnap: always ping ipv4 address in preStart`                                   |
| [`01d12be5`](https://github.com/NixOS/nixpkgs/commit/01d12be5e9fccbff5336954690efa604471d6fd3) | `deno: 1.14.1 -> 1.14.2`                                                          |
| [`4a0e843a`](https://github.com/NixOS/nixpkgs/commit/4a0e843a5b9179f6840f8cf7a4d49feae02a293b) | `pantheon.switchboard-plug-applications: 6.0.0 -> 6.0.1`                          |
| [`fdd55cfc`](https://github.com/NixOS/nixpkgs/commit/fdd55cfc60fec49ac16219da4207bb9907d4fe82) | `pantheon.wingpanel: 3.0.0 -> 3.0.1`                                              |
| [`79dd408c`](https://github.com/NixOS/nixpkgs/commit/79dd408ce6f8c25876678544bb228855c504b901) | `pantheon.elementary-tasks: 6.0.3 -> 6.0.4`                                       |
| [`d109418b`](https://github.com/NixOS/nixpkgs/commit/d109418be8961cf78236b1b7f9fe84b2b87106d1) | `pantheon.wingpanel-indicator-notifications: 6.0.0 -> 6.0.1`                      |
| [`88c7c97a`](https://github.com/NixOS/nixpkgs/commit/88c7c97ab9dbb5311bac1cfc9efa92f7a22593d5) | `pantheon.elementary-mail: 6.1.1 -> 6.2.0`                                        |
| [`bf03507d`](https://github.com/NixOS/nixpkgs/commit/bf03507d6d6b139ce235b0d3c382c5e5e73bf8bf) | `pantheon.elementary-files: 6.0.2 -> 6.0.3`                                       |
| [`1a642483`](https://github.com/NixOS/nixpkgs/commit/1a6424832c6572f37d4735343da89cc031d8e65c) | `pantheon.switchboard-plug-onlineaccounts: 6.2.0 -> 6.2.1`                        |
| [`7951c9b0`](https://github.com/NixOS/nixpkgs/commit/7951c9b0a1b61877fe69cff5b2ce8e334eefdf29) | `pantheon.elementary-code: 6.0.0 -> 6.0.1`                                        |
| [`95ea33d4`](https://github.com/NixOS/nixpkgs/commit/95ea33d41d016fbafa534fad174e1dcbfb924dc7) | `boundary: 0.6.1 -> 0.6.2`                                                        |
| [`c246461a`](https://github.com/NixOS/nixpkgs/commit/c246461a1b73be67bde00a2f2369c27d6467f331) | `bisq-desktop: 1.7.3 -> 1.7.4`                                                    |
| [`41a997c8`](https://github.com/NixOS/nixpkgs/commit/41a997c8b2cb191bd588d991cc11803c5e0eb24b) | `ccache: 4.4.1 → 4.4.2`                                                           |
| [`60dcbe98`](https://github.com/NixOS/nixpkgs/commit/60dcbe9837101489af5f6db6171de3c3826224a2) | `melonDS: add libpcap to library path (#139787)`                                  |
| [`c3c2cf65`](https://github.com/NixOS/nixpkgs/commit/c3c2cf65cfd023c094ddbc2450486bd8d3c36aa6) | `python38Packages.thrift: 0.13.0 -> 0.15.0`                                       |
| [`56cf4e1d`](https://github.com/NixOS/nixpkgs/commit/56cf4e1d0759ed2164128e4ba1b3acb32ce7c40d) | `chromedriver: add dbus to libraries, correct LD_LIBRARY_PATH wrapping (#139723)` |
| [`0a3d9773`](https://github.com/NixOS/nixpkgs/commit/0a3d9773b43e6ef71dea6266d890a07b5219765c) | `python38Packages.scikit-hep-testdata: 0.4.8 -> 0.4.9`                            |
| [`87fe4dad`](https://github.com/NixOS/nixpkgs/commit/87fe4dad31522d1130505267a32251eddfcaa051) | `taplo-lsp: 0.2.5 -> 0.2.6`                                                       |
| [`681758d4`](https://github.com/NixOS/nixpkgs/commit/681758d41588c27aaa6f3c3a72184dcc4d0aeba8) | `lib/generators: fix error message`                                               |
| [`be884abb`](https://github.com/NixOS/nixpkgs/commit/be884abbd8f9ed86d5b599db7110e9ef8e1bd5dd) | `python3Packages.angrop: 9.0.10010 -> 9.0.10055`                                  |
| [`566b883e`](https://github.com/NixOS/nixpkgs/commit/566b883e5024e704e9963ee3b17eaa63cd6f330a) | `python3Packages.angr: 9.0.10010 -> 9.0.10055`                                    |
| [`ec38eaaf`](https://github.com/NixOS/nixpkgs/commit/ec38eaafdc1f0094a3adefd9bb81a77a1b7dd04f) | `python3Packages.cle: 9.0.10010 -> 9.0.10055`                                     |
| [`1ead258b`](https://github.com/NixOS/nixpkgs/commit/1ead258bfce4b90a0914882b8bf92583c74c4249) | `python3Packages.claripy: 9.0.10010 -> 9.0.10055`                                 |
| [`55cf91a5`](https://github.com/NixOS/nixpkgs/commit/55cf91a57b9db8b8422a3b2a6e75864bd65d704f) | `python3Packages.pyvex: 9.0.10010 -> 9.0.10055`                                   |
| [`3c0a8953`](https://github.com/NixOS/nixpkgs/commit/3c0a895362a00c297beee8525ac321f125b79ada) | `python3Packages.ailment: 9.0.10010 -> 9.0.10055`                                 |
| [`12e92858`](https://github.com/NixOS/nixpkgs/commit/12e9285814cf588bcb6f6c0328ea9e1cb151049c) | `python3Packages.archinfo: 9.0.10010 -> 9.0.10055`                                |
| [`b0815e98`](https://github.com/NixOS/nixpkgs/commit/b0815e9825ded6cccabe0a93c95b8ec646ddf155) | `privoxy: switch to openssl`                                                      |
| [`c6c2dd37`](https://github.com/NixOS/nixpkgs/commit/c6c2dd3727e1c2d5b173653b4792f4ab4bd21d89) | `powershell: patchelf replace liblttng-ust.so.0 to so.1`                          |
| [`1ac46a05`](https://github.com/NixOS/nixpkgs/commit/1ac46a05a8672ed63097d7c929c3a677cab61922) | `roon-server: correctly set platforms`                                            |
| [`affef156`](https://github.com/NixOS/nixpkgs/commit/affef156d169d87cec1c80f5e52bbaa4fe1bd059) | `roon-bridge: correctly set platforms`                                            |
| [`c75c37de`](https://github.com/NixOS/nixpkgs/commit/c75c37de7ef775bd9eb2fb4402d0ebb31e378668) | `onlyoffice: wrap correctly and force xcb since onlyoffice doesn't`               |
| [`a5a7c33e`](https://github.com/NixOS/nixpkgs/commit/a5a7c33e772353cb0c8faf3c5904be55d2538c77) | `threejs-sage: install in expected location`                                      |
| [`406221cd`](https://github.com/NixOS/nixpkgs/commit/406221cda300402d843bcd3dd91cfebf7e57afea) | `element-desktop: 1.8.5 -> 1.9.0`                                                 |
| [`4484be0a`](https://github.com/NixOS/nixpkgs/commit/4484be0a520dccc0ecca7678c1e7473acf1f2108) | `element-web: 1.8.5 -> 1.9.0`                                                     |
| [`cfa8af7f`](https://github.com/NixOS/nixpkgs/commit/cfa8af7f1b02b88611b593ddd91cd4ac935ef87e) | `roon-bridge: use upstream stable URL for src`                                    |
| [`dc7bcb2c`](https://github.com/NixOS/nixpkgs/commit/dc7bcb2c85ca2ffe1bb51a2c88b45b9a1a57cd5e) | `roon-server: use upstream stable URL for src`                                    |
| [`66e47d8f`](https://github.com/NixOS/nixpkgs/commit/66e47d8f35a4074d2d85d7ae597365dc13fab7be) | `python39Packages.python-swiftclient: install shell completion`                   |
| [`d433cd1f`](https://github.com/NixOS/nixpkgs/commit/d433cd1ff9a1507d3dcd0dd8f11085bb825ddafb) | `git-extras: move bash completion under share, patch less files`                  |
| [`8110ef59`](https://github.com/NixOS/nixpkgs/commit/8110ef5933637dffcdd72cecca559f25126efee2) | `python3Packages.renault-api: 0.1.4 -> 0.1.5`                                     |
| [`6b740f44`](https://github.com/NixOS/nixpkgs/commit/6b740f441f205f4b5e8695e4809fabee9afd8a8b) | `lm_sensors: fix for cross compilation (#139577)`                                 |
| [`62eff259`](https://github.com/NixOS/nixpkgs/commit/62eff2592ca6324546ed8745f440f4959307dc27) | `python38Packages.pulp: 2.5.0 -> 2.5.1 (#139760)`                                 |
| [`feafe817`](https://github.com/NixOS/nixpkgs/commit/feafe817eb19b272fc2b7dcc6ad9f5f79f4ed1da) | `monitor: 0.9.5 -> 0.10.0`                                                        |
| [`bbd54564`](https://github.com/NixOS/nixpkgs/commit/bbd545646b762f09b2d986074c796c3e7de97801) | `polkadot: 0.9.9-1 -> 0.9.10 (#139660)`                                           |
| [`2cbdd8d8`](https://github.com/NixOS/nixpkgs/commit/2cbdd8d88670e8cba97d4b07e7af1b581c19162c) | `aminal: remove (#139747)`                                                        |
| [`5282622c`](https://github.com/NixOS/nixpkgs/commit/5282622cf542bf05e7892f256410402847f75276) | `home-assistant: relax voluptuous constraint`                                     |
| [`53a45348`](https://github.com/NixOS/nixpkgs/commit/53a45348429c59633ec06ad22e3a903b096b6c3c) | `venta: 0.6 -> 0.7`                                                               |
| [`b1a7f33b`](https://github.com/NixOS/nixpkgs/commit/b1a7f33b3927eede727144d1761c0afe61676706) | `firefox-bin: fix license`                                                        |
| [`b1adc893`](https://github.com/NixOS/nixpkgs/commit/b1adc89386998dae3c7ee05126ec881709e82d02) | `spot: 0.1.14 -> 0.2.0 (#137435)`                                                 |
| [`fd7d5824`](https://github.com/NixOS/nixpkgs/commit/fd7d5824556ec20ddc2a42da05cb14dadb09508c) | `vimPlugins.nvim-code-action-menu: init at 2021-09-28`                            |
| [`daa817d2`](https://github.com/NixOS/nixpkgs/commit/daa817d23ab35e4b5e3f3e9841d462f051ce51d3) | `vimPlugins: update`                                                              |
| [`be499cf8`](https://github.com/NixOS/nixpkgs/commit/be499cf85eec9a067141cd7e64cdaa979cf7fcfc) | `vimPlugins.crates-nvim: fix branch name`                                         |