### PR TITLE
chore(deps): update sops-nix

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "a3e3dc7710e6dd60a783b9ae54862a89fd35f70e",
-        "sha256": "14iy4qldpk9j1cg3paxf4ryiyg1lgb1f0r0rh6hrwcyilzjlz591",
+        "rev": "095fca05818c7f4c2285387b2eb94e13b683101a",
+        "sha256": "0pzx1b0bvqbh9q8svw6w1alh7pa5rdyrgf7jsrk870q8vkj01wcz",
         "type": "tarball",
-        "url": "https://github.com/Mic92/sops-nix/archive/a3e3dc7710e6dd60a783b9ae54862a89fd35f70e.tar.gz",
+        "url": "https://github.com/Mic92/sops-nix/archive/095fca05818c7f4c2285387b2eb94e13b683101a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                                     |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`64e84118`](https://github.com/Mic92/sops-nix/commit/64e84118313b7fef579a53fbc3785557f3986127) | `workflow: Replace nixpkgs channel with nixos`     |
| [`2b9a0815`](https://github.com/Mic92/sops-nix/commit/2b9a0815caa1fe70b47575f8382211b331bed3a2) | `Implement nested secrets`                         |
| [`e0e57da4`](https://github.com/Mic92/sops-nix/commit/e0e57da4973a37b946ddeb5f6dcbf7f06f56e0e8) | `fix documentation and assertions for age.keyFile` |
| [`c5e0f55d`](https://github.com/Mic92/sops-nix/commit/c5e0f55d8d4270cde86fdbd0a5a3d33927c75e73) | `nixos-tests: fix identations`                     |
| [`4cebc080`](https://github.com/Mic92/sops-nix/commit/4cebc08062a29c451a82f78793fdbcb946304d69) | `Fix age key generation and test it`               |
| [`5db02f29`](https://github.com/Mic92/sops-nix/commit/5db02f29394bf20a0eb934ae97f2acf0bc41ba4a) | `Import age keyfile and ssh keys at the same time` |