### PR TITLE
chore(deps): update home-manager

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d5151186aca3d706be73b02f47cff574cb91c641",
-        "sha256": "1hif8r5c8w7f2l4xfhnrxi505ykfc6822s1hzjy0snxj8ld7vxg1",
+        "rev": "0f3dfc94ef9f70cdb800e0cf8e22ec9d3a0a3c70",
+        "sha256": "05sbi64a66p322apmq3p5rrj2fyb0zaavcmc4fqmx19gk57r50ac",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/d5151186aca3d706be73b02f47cff574cb91c641.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/0f3dfc94ef9f70cdb800e0cf8e22ec9d3a0a3c70.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixos-hardware": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                              |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`0f3dfc94`](https://github.com/nix-community/home-manager/commit/0f3dfc94ef9f70cdb800e0cf8e22ec9d3a0a3c70) | `services.emacs: add option `extraOptions`` |