### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6fa4e75f7622ccedee8cb58a8d2ecaa658667a10",
-        "sha256": "1f4i71z30i9rfrvaapahwbhwj8zwl20yh1dgzpmbfh4x4zgxdnsd",
+        "rev": "ee084c02040e864eeeb4cf4f8538d92f7c675671",
+        "sha256": "1x8amcixdaw3ryyia32pb706vzhvn5whq9n8jin0qcha5qnm1fnh",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/6fa4e75f7622ccedee8cb58a8d2ecaa658667a10.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/ee084c02040e864eeeb4cf4f8538d92f7c675671.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                 |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`d8e6e07a`](https://github.com/NixOS/nixpkgs/commit/d8e6e07af0a28f5b7564076dfed977dd31ce2d02) | `r-httpuv: add missing zlib.dev dependency to fix the build`                   |
| [`dd74170c`](https://github.com/NixOS/nixpkgs/commit/dd74170ce49788447f34fbe9a63972735ecb7d4b) | `flex-ndax: init at 0.1-20210714.0`                                            |
| [`849f091e`](https://github.com/NixOS/nixpkgs/commit/849f091e68efd6d0e29e0b93decad57732911782) | `flex-ncat: init at 0.0-20210420.0`                                            |
| [`396e421c`](https://github.com/NixOS/nixpkgs/commit/396e421c8967175b476a79e727c6c607999ff62c) | `rancher: init at 2.4.13`                                                      |
| [`1c0a20ef`](https://github.com/NixOS/nixpkgs/commit/1c0a20efcfdb40d7a08078e436baade866f83b0f) | `create-amis.sh: fix typo`                                                     |
| [`2d67b946`](https://github.com/NixOS/nixpkgs/commit/2d67b946b7a065dfae76f77e6da810ac022f99bd) | `create-amis.sh: use status message`                                           |
| [`407998d1`](https://github.com/NixOS/nixpkgs/commit/407998d15a06a733c330b0a73e1897032c4e6041) | `create-amis.sh: add support for the ZFS AMIs`                                 |
| [`1ff82fec`](https://github.com/NixOS/nixpkgs/commit/1ff82fec9a0f48ce29b73113b24d43b83e023813) | `create-amis.sh: allow uploading private AMIs`                                 |
| [`0543f2d2`](https://github.com/NixOS/nixpkgs/commit/0543f2d2f62dcc3d5e917f34d3c0526d0548473f) | `create-amis.sh: make vars overridable from env`                               |
| [`417487b4`](https://github.com/NixOS/nixpkgs/commit/417487b45764cedd6474c7990219b795a42117be) | `cbqn: 0.0.0+unstable=2021-09-29 -> 0.0.0+unstable=2021-10-01`                 |
| [`fc88ec5d`](https://github.com/NixOS/nixpkgs/commit/fc88ec5d9d0ad91a091645655e78f46ac642fb0e) | `dbqn: init at 0.0.0+unstable=2021-10-02`                                      |
| [`e6bdd969`](https://github.com/NixOS/nixpkgs/commit/e6bdd9690ced527fffa7a432ec80135e932907c4) | `wgpu: init at 0.10.0`                                                         |
| [`9e6a39be`](https://github.com/NixOS/nixpkgs/commit/9e6a39be4d465892d32bee6944626415fbd77933) | `perlPackages.LaTeXML: 0.8.5 -> 0.8.6 (#140173)`                               |
| [`f1f64068`](https://github.com/NixOS/nixpkgs/commit/f1f640684c2e926d187e75f9910bbe04518b35b7) | `rewritefs: add `unstable` prefix`                                             |
| [`3f025a3b`](https://github.com/NixOS/nixpkgs/commit/3f025a3bffb07495f8b7e3f2dd357088f789231e) | `git-extras: 6.2.0 -> 6.3.0`                                                   |
| [`c80fae5b`](https://github.com/NixOS/nixpkgs/commit/c80fae5bbeb9f4bcc0c48a1acd3bc8b4a12d7438) | `gitlab: 14.2.4 -> 14.3.1`                                                     |
| [`7d88d0b0`](https://github.com/NixOS/nixpkgs/commit/7d88d0b040c23684815b2b0e7eb742bcfc3cd88b) | `clair: 4.2.0 -> 4.3.0`                                                        |
| [`966763c5`](https://github.com/NixOS/nixpkgs/commit/966763c5b17e46bc1128bd9c4c1a8bde9a762dd2) | `btop: 1.0.10 -> 1.0.13`                                                       |
| [`236d58ae`](https://github.com/NixOS/nixpkgs/commit/236d58aeefd5ad0b80b86ae996906f6dfaaee766) | `vimPlugins.neuron-nvim: init at 2021-03-20`                                   |
| [`9336af2d`](https://github.com/NixOS/nixpkgs/commit/9336af2d1aa19247c9309227699ba1867b65e38b) | `fnlfmt: 0.2.1 -> 0.2.2 (#140381)`                                             |
| [`be01e0f3`](https://github.com/NixOS/nixpkgs/commit/be01e0f3bc8f11fffb4394caeab806350a2536ca) | `black: Disable failing tests on Darwin (#130785)`                             |
| [`c4115245`](https://github.com/NixOS/nixpkgs/commit/c41152455777f877d5488236616890980fe7457c) | `vimPlugins: update`                                                           |
| [`752336b6`](https://github.com/NixOS/nixpkgs/commit/752336b6e82349db3cf8a9a497101d12fc9ec2f8) | `home-assistant: update component-packages`                                    |
| [`921142e8`](https://github.com/NixOS/nixpkgs/commit/921142e8897b8db93f751149dccc2a577764cacb) | `python3Packages.pycarwings2: init at 2.11`                                    |
| [`f887d5b3`](https://github.com/NixOS/nixpkgs/commit/f887d5b363b75456d787e2a7e4ca71d2371b22d8) | `maintainers/maintainers-list: add Matrix IDs`                                 |
| [`0d7d78f8`](https://github.com/NixOS/nixpkgs/commit/0d7d78f8ff9539fbaf54ef8fc972eb4336893b87) | `python3Packages.async-upnp-client: 0.22.4 -> 0.22.5`                          |
| [`97fe835b`](https://github.com/NixOS/nixpkgs/commit/97fe835b44f6f3fe020db6e9a372a904750cc29f) | `coqPackages.gappalib: 1.4.5 → 1.5.0`                                          |
| [`f8333515`](https://github.com/NixOS/nixpkgs/commit/f83335157c800af78709ad6b13925572d15accb7) | `electron_15: init at 15.1.0`                                                  |
| [`6749fd84`](https://github.com/NixOS/nixpkgs/commit/6749fd84fa6c888ce7618368b1782b666b608e5c) | `cawbird: add own API key to not run into rate limits`                         |
| [`a21f4b7a`](https://github.com/NixOS/nixpkgs/commit/a21f4b7a76d1984d10cce20ef02076710155a0d4) | `iosevka: 10.0.0 → 10.3.1`                                                     |
| [`27c05093`](https://github.com/NixOS/nixpkgs/commit/27c05093234894f3eb98e05f41ea37073a5cdfe9) | `webcat: init at unstable-2021-09-06`                                          |
| [`d5735ae1`](https://github.com/NixOS/nixpkgs/commit/d5735ae18defec17313b82d8002b99ca40dd314e) | `erigon: 2021.09.02 -> 2021.09.04 (#139646)`                                   |
| [`52be208f`](https://github.com/NixOS/nixpkgs/commit/52be208f205b3e4ae40f1ce912c29d9db1273c65) | `python3Packages.toposort: 1.6 -> 1.7`                                         |
| [`6d8cab0b`](https://github.com/NixOS/nixpkgs/commit/6d8cab0b537bf768d044f1789a868261f45803fe) | `waydroid: Init at 1.1.1`                                                      |
| [`7f9f26f9`](https://github.com/NixOS/nixpkgs/commit/7f9f26f942f651111cc3472b1fe35a8e3ec1a174) | `python3Packages.gbinder-python: Init at 1.0.0`                                |
| [`0aeb28e5`](https://github.com/NixOS/nixpkgs/commit/0aeb28e566eddfca126f19cec70eb12bca4771d1) | `libgbinder: Init at 1.1.12`                                                   |
| [`5667c1fc`](https://github.com/NixOS/nixpkgs/commit/5667c1fc3f1235e4a55a283d76cfed0ee3cfb04f) | `libglibutil: Init at 1.0.55`                                                  |
| [`6c07b4a3`](https://github.com/NixOS/nixpkgs/commit/6c07b4a3f8d803f78d76d19126f5d0340205327a) | `python3Packages.rapidfuzz: 1.7.0 -> 1.7.1`                                    |
| [`0cb3c776`](https://github.com/NixOS/nixpkgs/commit/0cb3c776cf796c27d535a28b7e0592a05b101e48) | `pulumi-bin: 3.12.0 -> 3.13.2`                                                 |
| [`fecc5d7b`](https://github.com/NixOS/nixpkgs/commit/fecc5d7bfff23a211278cb1e1fc2a9c2dbfb43ea) | `treewide: pkgs/**.nix: remove trailing whitespaces`                           |
| [`b7cec1d2`](https://github.com/NixOS/nixpkgs/commit/b7cec1d27d7aee0a22d7a8a52a7f0b72b50f832e) | `selene: init at 0.14.0`                                                       |
| [`a0f20138`](https://github.com/NixOS/nixpkgs/commit/a0f20138a4323764ead04e7ffda25dbc15dd81c6) | `gnomeExtensions.unite: remove manually packaging and use extension overrides` |
| [`ebebfb4b`](https://github.com/NixOS/nixpkgs/commit/ebebfb4bf0ec3ef0590021cdf598cb0c110b74d9) | `gobang: fix darwin build`                                                     |
| [`785d49fb`](https://github.com/NixOS/nixpkgs/commit/785d49fb982cc2e9d579f8fffa4f848ea5336679) | `rewritefs: 2020-02-21 -> 2021-10-03`                                          |
| [`8067021e`](https://github.com/NixOS/nixpkgs/commit/8067021ee7c637cae2d7597f64e7436e803b0b04) | `chezmoi: 2.1.6 -> 2.3.0`                                                      |
| [`5d572155`](https://github.com/NixOS/nixpkgs/commit/5d572155d472aa2129736ddd4cba29f8bd2b083d) | `python3Packages.gios: 2.0.0 -> 2.1.0`                                         |
| [`d7442dc6`](https://github.com/NixOS/nixpkgs/commit/d7442dc613f8ba6d105b46b845dddbb2fc350b19) | `ocamlPackages.merlin: 4.1 → 4.3.1`                                            |
| [`ba1029a8`](https://github.com/NixOS/nixpkgs/commit/ba1029a81a9e3e56909fb660c721a7357b4905c8) | `Submit/fix vega lite (#139876)`                                               |
| [`9a8c64a2`](https://github.com/NixOS/nixpkgs/commit/9a8c64a2f608c305b38137f793afc1e7865a00c3) | `rslint: init at 0.3.0`                                                        |
| [`404ece99`](https://github.com/NixOS/nixpkgs/commit/404ece99f21859dd973c4e2693d25c9fa339d836) | `asciinema: 2.0.2 -> 2.1.0`                                                    |
| [`32fb71f2`](https://github.com/NixOS/nixpkgs/commit/32fb71f2d9464452038354ee637ebed6017b8225) | `python38Packages.sagemaker: 2.59.4 -> 2.59.6`                                 |
| [`a446cbaa`](https://github.com/NixOS/nixpkgs/commit/a446cbaaaa4b7888558a88910cec70a722e8e97c) | `lscolors: 0.7.1 -> 0.8.0`                                                     |
| [`5313fd63`](https://github.com/NixOS/nixpkgs/commit/5313fd63d3ceeadf3afefbe74a193943025400d8) | `lwan: 0.3 -> 0.4`                                                             |
| [`c7fc01cd`](https://github.com/NixOS/nixpkgs/commit/c7fc01cd77b4b45ae469f3aac25496384c527861) | `aerospike: drop blanket -Werror (#140306)`                                    |
| [`a573c35b`](https://github.com/NixOS/nixpkgs/commit/a573c35b3adc639bddf701ec80cd6d3d9284baff) | `ocrmypdf: 12.5.0 -> 12.6.0`                                                   |
| [`5895ece3`](https://github.com/NixOS/nixpkgs/commit/5895ece3b943092ce2a73b396bf607a0af39e8ee) | `mopidy-youtube: 3.2 -> 3.4`                                                   |
| [`770cdc38`](https://github.com/NixOS/nixpkgs/commit/770cdc3897da0f2f183d431d4286dcf6f193ab5b) | `python38Packages.python-osc: 1.7.7 -> 1.8.0`                                  |
| [`0d1421c5`](https://github.com/NixOS/nixpkgs/commit/0d1421c5c5fc0c51ec5033c8e8303d4b04e65d5c) | `exploitdb: 2021-09-30 -> 2021-10-02`                                          |
| [`7ef5416a`](https://github.com/NixOS/nixpkgs/commit/7ef5416aea91f09cb3ab29bae327f62f035ae4e2) | `taskwarrior: 2.5.3 -> 2.6.0`                                                  |
| [`e4f15f27`](https://github.com/NixOS/nixpkgs/commit/e4f15f27fd51c07843d5027537a474abf1b4687c) | `mpdevil: add missing libnotify dependency`                                    |
| [`5daa5d3b`](https://github.com/NixOS/nixpkgs/commit/5daa5d3b23590c6a7f5a32e413128b91b9153bd6) | `python38Packages.pyhomematic: 0.1.74 -> 0.1.75`                               |
| [`bc56346b`](https://github.com/NixOS/nixpkgs/commit/bc56346bcdeec61a13c0b44310b3236a2ef0e440) | `openssh_hpn/openssh_gssapi: Add CVE-2021-41617`                               |
| [`15567f5a`](https://github.com/NixOS/nixpkgs/commit/15567f5a16fd512af0eb954451433bef04cec03a) | `testssl: 3.0.5 -> 3.0.6`                                                      |
| [`729c2419`](https://github.com/NixOS/nixpkgs/commit/729c241932faee3ef9aeeeca1a861a4bc1aaf96a) | `maintainers: Update vanilla keys.`                                            |
| [`0f0ffc5e`](https://github.com/NixOS/nixpkgs/commit/0f0ffc5e867cbd93134c13396174f7cc6ebe10a9) | `v2ray: 4.42.1 -> 4.43.0`                                                      |
| [`f6e06020`](https://github.com/NixOS/nixpkgs/commit/f6e0602096d78336dbd218878b5b98aaca005b20) | `linkerd: add updateScript`                                                    |
| [`2b0a7ef8`](https://github.com/NixOS/nixpkgs/commit/2b0a7ef8f2e234470315e89c43765cb2258b2afe) | `nixos/hqplayerd: do not make manual depend on (unfree) hqplayerd`             |
| [`1b9dbf40`](https://github.com/NixOS/nixpkgs/commit/1b9dbf407cf8ab3502db9d884288de93d53351dc) | `beam: mix-release: do not use substituteInPlace on binaries`                  |
| [`a5fc6faf`](https://github.com/NixOS/nixpkgs/commit/a5fc6faf043a65a3a75a6a3ca40add3af0bbffe6) | `python38Packages.monkeyhex: 1.7.1 -> 1.7.2`                                   |
| [`820feb8e`](https://github.com/NixOS/nixpkgs/commit/820feb8e8c77e3a5481294cdd85aaf337b52006a) | `maestral-gui: 1.4.8 -> 1.5.0`                                                 |
| [`8436c0e3`](https://github.com/NixOS/nixpkgs/commit/8436c0e33a6af1db1153064c0e501d7e14fdf6bf) | `python3Packages.maestral: 1.4.8 -> 1.5.0`                                     |
| [`e75f346a`](https://github.com/NixOS/nixpkgs/commit/e75f346aa309515fa220f6d2124a27f72e245b69) | `lib: add function escapeXML`                                                  |
| [`dfb2073a`](https://github.com/NixOS/nixpkgs/commit/dfb2073a3e550acef418e5c7698f9412bcdc4a22) | `python38Packages.idasen: 0.7.1 -> 0.8.0`                                      |
| [`0e686577`](https://github.com/NixOS/nixpkgs/commit/0e686577c1c26cba2b450e0b267ee419f187c5ea) | `lagrange: 1.6.5 → 1.7.1`                                                      |
| [`f05a7c4a`](https://github.com/NixOS/nixpkgs/commit/f05a7c4a4bd18bf285db853139d27a5f2a66ec78) | `checkmate: 0.4.1 -> 0.4.5`                                                    |
| [`358659d6`](https://github.com/NixOS/nixpkgs/commit/358659d668d5740384b165ff38ff721cfe62aeec) | `yarn: 1.22.11 -> 1.22.15`                                                     |
| [`24f04ee6`](https://github.com/NixOS/nixpkgs/commit/24f04ee6bb3689a7860dfc7130082c1ad7d733a7) | `mbqn: init at 0.0.0+unstable=2021-10-01`                                      |
| [`f022b391`](https://github.com/NixOS/nixpkgs/commit/f022b39125e441c4b17d5034f9369c43b0c5ce52) | `python38Packages.digital-ocean: 1.16.0 -> 1.17.0`                             |
| [`98ae18fa`](https://github.com/NixOS/nixpkgs/commit/98ae18fa62979ac9837629a39fb18234fcc74772) | `linux_testing_bcachefs: upstream tarballs rather patchsets`                   |
| [`5e7aab59`](https://github.com/NixOS/nixpkgs/commit/5e7aab598257d7f0cde7c9fe2617c8801e224b9d) | `lemmy-ui: add static assets folder to out`                                    |
| [`afd261cf`](https://github.com/NixOS/nixpkgs/commit/afd261cf930eed5b597f56dd4ef2e4a87c3c64c5) | `drawterm: unstable-2021-08-02 -> unstable-2021-10-02`                         |
| [`b8cb98d6`](https://github.com/NixOS/nixpkgs/commit/b8cb98d6be52b4178e98ec9d264290d308a1c012) | `nvchecker: 2.4 -> 2.5`                                                        |
| [`bbaa9914`](https://github.com/NixOS/nixpkgs/commit/bbaa9914f86f600f9ac2cdf7709e14aea94c2215) | `python38Packages.awscrt: 0.12.3 -> 0.12.4`                                    |
| [`bf2a7069`](https://github.com/NixOS/nixpkgs/commit/bf2a70691bbe7572caf94b7cf809ed689edac767) | `fluxcd: fix escape on updateScript`                                           |
| [`39f00331`](https://github.com/NixOS/nixpkgs/commit/39f00331dd68f1eca9dfdb68292a94ae03dac1aa) | `k3s: fix escape on updateScript`                                              |
| [`c0cc04d5`](https://github.com/NixOS/nixpkgs/commit/c0cc04d550929696ce4be92d55b7e2b125c37261) | `linode-cli: fix escape on updateScript`                                       |
| [`0e75ba72`](https://github.com/NixOS/nixpkgs/commit/0e75ba72b3df57ecb48155b566325b4b15bf6fb4) | `river, kile-wl: update`                                                       |
| [`4e536276`](https://github.com/NixOS/nixpkgs/commit/4e5362765cad7b9df243f0ef7cee3b2473a996b8) | `polybar: 3.5.6 -> 3.5.7`                                                      |
| [`df4a3239`](https://github.com/NixOS/nixpkgs/commit/df4a3239d18e94ab7662005669d3ebfbef4a2404) | `scientifica: 2.2 -> 2.3`                                                      |
| [`65981224`](https://github.com/NixOS/nixpkgs/commit/6598122426b9703ef4f6963839d1723e71734d20) | `python38Packages.mypy-boto3-s3: 1.18.51 -> 1.18.53`                           |
| [`a6951b22`](https://github.com/NixOS/nixpkgs/commit/a6951b22dd12aa9813dc106121b3a0d9210ce54f) | `chrysalis: 0.8.5 -> 0.8.6`                                                    |
| [`9f883ad3`](https://github.com/NixOS/nixpkgs/commit/9f883ad3b8feaa0da51f48e21894823df207145e) | `matrix-synapse: build with redis by default`                                  |
| [`4acc1749`](https://github.com/NixOS/nixpkgs/commit/4acc1749db2c8a69e0be801018233074957c99b5) | `got: init at 0.60`                                                            |
| [`bc9fe44e`](https://github.com/NixOS/nixpkgs/commit/bc9fe44e7f11f121e193e065fe7d9b5f9b76da20) | `hover: 0.46.3 -> 0.46.6`                                                      |
| [`bef1d643`](https://github.com/NixOS/nixpkgs/commit/bef1d6430bcf2bc03456dd771fa3fd7c9d0d96bb) | `python38Packages.qrcode: 7.3 -> 7.3.1`                                        |
| [`58503e1c`](https://github.com/NixOS/nixpkgs/commit/58503e1cbbd3fccb7c68b46f68b8835fd436422b) | `metasploit: 6.1.7 -> 6.1.8`                                                   |
| [`0e4095c8`](https://github.com/NixOS/nixpkgs/commit/0e4095c8dc3c5175a1e9ebf1e1106b4ea6bd6561) | `mopidy-iris: 3.58.2 -> 3.59.0`                                                |
| [`fff14cf2`](https://github.com/NixOS/nixpkgs/commit/fff14cf2c9d54f75ea713f5817b2e2695f5efdfc) | `python38Packages.pdftotext: 2.2.0 -> 2.2.1`                                   |
| [`0266137e`](https://github.com/NixOS/nixpkgs/commit/0266137e319343aa85bcd2e94b61cc0a3c9bc34f) | `eksctl: 0.66.0 -> 0.68.0`                                                     |
| [`63fcdb7d`](https://github.com/NixOS/nixpkgs/commit/63fcdb7dfc46fccd9a72a37a0c6199f5f07d49a8) | `python38Packages.geoip2: 4.3.0 -> 4.4.0`                                      |
| [`b40932d3`](https://github.com/NixOS/nixpkgs/commit/b40932d3f350569539d9ebc3122c0150ca572b9c) | `python38Packages.enamlx: 0.4.6 -> 0.5.0`                                      |
| [`3df1167d`](https://github.com/NixOS/nixpkgs/commit/3df1167de0500e2ff18f3caad54f0012df3d0096) | `python38Packages.msal: 1.14.0 -> 1.15.0`                                      |
| [`778f67d5`](https://github.com/NixOS/nixpkgs/commit/778f67d5e0becb734057ef155f37a09414bcdd18) | `ultimate-oldschool-pc-font-pack: link to changelog`                           |
| [`b55e71ba`](https://github.com/NixOS/nixpkgs/commit/b55e71ba9a95713d5454b77e9a39f2d086010acd) | `libb64: 1.2 -> 2.0.0.1`                                                       |
| [`3dce389e`](https://github.com/NixOS/nixpkgs/commit/3dce389e9ed29432fd1226e6cdf26c50f1176e4d) | `atom,atom-beta: 1.57.0 -> 1.58.0, 1.58.0-beta0 -> 1.59.0-beta0`               |
| [`0296fc8d`](https://github.com/NixOS/nixpkgs/commit/0296fc8d6389289725a2efac095d28fb174bd775) | `cargo-msrv: 0.9.0 -> 0.10.0`                                                  |
| [`955c9bcf`](https://github.com/NixOS/nixpkgs/commit/955c9bcf5c27d4ad3ab14ab7c86616759e89afc5) | `ipfs: 0.9.1 -> 0.10.0`                                                        |
| [`0c0bb2d6`](https://github.com/NixOS/nixpkgs/commit/0c0bb2d6e37e82ce777030183ab1fc971d5770c3) | `ocl-icd: 2.2.10 -> 2.3.1`                                                     |
| [`2a8eebc8`](https://github.com/NixOS/nixpkgs/commit/2a8eebc8064227a3bfde4eba145b3233e0e13f49) | `ocl-icd: update homepage, switch to github releases`                          |
| [`3e858135`](https://github.com/NixOS/nixpkgs/commit/3e85813580ea9f118d873dd20046a8703614b52a) | `ghidra-bin: wrap launcher instead of the binary`                              |
| [`35841653`](https://github.com/NixOS/nixpkgs/commit/35841653e1f3571bab5f61ec32a7dc0c67c21965) | `lib/tests/maintainers: add matrix option`                                     |
| [`665494e1`](https://github.com/NixOS/nixpkgs/commit/665494e1b13d1870ae8c2093c5cf2812124fcbe5) | `python3Packages.python-kasa: init at 0.4.0`                                   |
| [`7c33486e`](https://github.com/NixOS/nixpkgs/commit/7c33486e9680feba146f1248c05302f970fa6896) | `python3Packages.asyncclick: init at 8.0.1.3`                                  |
| [`100d3243`](https://github.com/NixOS/nixpkgs/commit/100d3243f7c5991759157f9348abd05f59ad56b5) | `python3Packages.awslambdaric: 1.2.2 -> 2.0.0`                                 |
| [`1d828e6a`](https://github.com/NixOS/nixpkgs/commit/1d828e6ae4d0fdf1ec5a42d2d71583807d58e093) | `venta: 0.7 -> 0.7.1`                                                          |
| [`dd1223aa`](https://github.com/NixOS/nixpkgs/commit/dd1223aa4fbd7bf07802fda046d1e8a9530cfa40) | `python38Packages.nltk: 3.6.2 -> 3.6.4`                                        |
| [`fc39a32a`](https://github.com/NixOS/nixpkgs/commit/fc39a32aa1322d8eec8f7224261c005cbf339549) | `python3Packages.phone-modem: init at 0.1.1`                                   |
| [`3d38f81b`](https://github.com/NixOS/nixpkgs/commit/3d38f81b08ba25dd738662f488c39025b4231090) | `python3Packages.aioserial: init at 1.3.0`                                     |
| [`8b089973`](https://github.com/NixOS/nixpkgs/commit/8b08997383edea7a62fbf2f4a441c522fb6ca625) | `python3Packages.aionanoleaf: init at 0.0.2`                                   |
| [`57034eb1`](https://github.com/NixOS/nixpkgs/commit/57034eb14f0caed9aa06e64e8053c58c3f9dc70a) | `sudo-font: 0.55.2 -> 0.60`                                                    |
| [`bb4b8544`](https://github.com/NixOS/nixpkgs/commit/bb4b8544590662af247f9fc19249275714f4897e) | `actionlint: init at 1.6.4`                                                    |
| [`0d8c23b9`](https://github.com/NixOS/nixpkgs/commit/0d8c23b91690e6a342303bccc1a57c9aff4095bb) | `libvterm-neovim: fix nativeBuildInputs`                                       |
| [`e7ad7464`](https://github.com/NixOS/nixpkgs/commit/e7ad7464865a998849594dadf0fb587649f1725e) | `mavproxy: 1.8.42 -> 1.8.43`                                                   |
| [`5449d04a`](https://github.com/NixOS/nixpkgs/commit/5449d04a6b56700e26fb5e4571d9594b0f52e02a) | `oxefmsynth: fix`                                                              |
| [`b095376a`](https://github.com/NixOS/nixpkgs/commit/b095376aab546e95092da6b05a81e8f565e5e791) | `promscale: 0.5.1 -> 0.6.0`                                                    |
| [`5a5c73ca`](https://github.com/NixOS/nixpkgs/commit/5a5c73cae68717ca6a9bc29475264762c847ccca) | `python3Packages.herepy: 3.5.3 -> 3.5.4`                                       |
| [`a39ca1b8`](https://github.com/NixOS/nixpkgs/commit/a39ca1b8ee24f30f08ab37e858c57c3d992e5b88) | `uboot: increase rpi kernel size patch`                                        |
| [`45db7e6b`](https://github.com/NixOS/nixpkgs/commit/45db7e6b541b499f51074765d000264a31a1806b) | `volatility3: init at 1.0.1`                                                   |
| [`fd7f7bd0`](https://github.com/NixOS/nixpkgs/commit/fd7f7bd0ca8dea073dccee53fffc1b6002dda950) | `time-decode: init at 3.2.0`                                                   |
| [`c1ff7da0`](https://github.com/NixOS/nixpkgs/commit/c1ff7da0a91ccb74b78757b93eef57aa1b2203e0) | `py3c: unconditionally drop -Werror (fix gcc-11 build)`                        |
| [`937852df`](https://github.com/NixOS/nixpkgs/commit/937852df5226e3f2ebd7d0455be277fcbf8b87dd) | `mapcache: init at 1.10.0`                                                     |
| [`65cec7a9`](https://github.com/NixOS/nixpkgs/commit/65cec7a97ee26db10c0e302b937a2d47ed827091) | `mapserver: init at 7.6.4`                                                     |
| [`4a8e5e45`](https://github.com/NixOS/nixpkgs/commit/4a8e5e45b0fcbb05cbaf91744f9cfdfdbfe291fa) | `supercollider: 3.12.0 -> 3.12.1`                                              |
| [`8798aaa2`](https://github.com/NixOS/nixpkgs/commit/8798aaa22f54ce8007488cec99e8692bd906f4b1) | `bandwhich: patch dependency to avoid panics`                                  |
| [`8c53e23b`](https://github.com/NixOS/nixpkgs/commit/8c53e23be1e5cc5f7da334c6c0629760b647ac0f) | `circleci-cli: 0.1.15824 -> 0.1.15848`                                         |