### PR TITLE
chore(deps): update home-manager

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e4df31dceaedc4b9abd18f7c8616d58987e790c8",
-        "sha256": "0sr6r10s6rr6wjasyvji2777xzrp6pi9piyawjhg50y56j5v22jh",
+        "rev": "592da767bd46a206a1a8200a48b829a59a06b969",
+        "sha256": "0sanqcr0vpr7cr0pxm4xgih4l7bb8zw2mwxj8b2qgkqh3w742laf",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/e4df31dceaedc4b9abd18f7c8616d58987e790c8.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/592da767bd46a206a1a8200a48b829a59a06b969.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixos-hardware": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                               |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`592da767`](https://github.com/nix-community/home-manager/commit/592da767bd46a206a1a8200a48b829a59a06b969) | `nnn: init (#2368)`                          |
| [`80d23ee0`](https://github.com/nix-community/home-manager/commit/80d23ee06cff0d0bef20b9327566f7de2498f4cb) | `fzf: do shell initialization a bit earlier` |
| [`af2007bb`](https://github.com/nix-community/home-manager/commit/af2007bb7772c6f17f4924639f2eb8a321d74fb4) | `atuin: add module`                          |
| [`1719495b`](https://github.com/nix-community/home-manager/commit/1719495bdfd5dc1e142aacc43e12a8c08584c856) | `screen-locker: make news entry conditional` |