### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b256715457b6078d729c64bf91596f808a67e28e",
-        "sha256": "1likp7yfr1fdl5yf5qiq3bzcpm378dbn5bbzrng73h81sbjqdy6j",
+        "rev": "01bd5f8e0dc866e28808bd6acc6e1fe65e08cf34",
+        "sha256": "0nr05vhb95svka442hrkiqyfcqqc1nbivshb0hxr4bbbcyfclvas",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/b256715457b6078d729c64bf91596f808a67e28e.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/01bd5f8e0dc866e28808bd6acc6e1fe65e08cf34.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                             |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`8a233582`](https://github.com/NixOS/nixpkgs/commit/8a2335829c2718cef61967a79bd142c634d4ec67) | `ktrip: init at 21.05`                                                     |
| [`25a433d2`](https://github.com/NixOS/nixpkgs/commit/25a433d286078c90e59fb5dcba9b91dc627708cc) | `koko: init at 21.05`                                                      |
| [`ea73dda9`](https://github.com/NixOS/nixpkgs/commit/ea73dda9217b1c3ef4d58a9efc3e728568c0b593) | `spacebar: init at 21.05`                                                  |
| [`907976ea`](https://github.com/NixOS/nixpkgs/commit/907976ea4ee4720c907f275395824029b3c4cc2a) | `plasma-phonebook: init at 21.05`                                          |
| [`211cba43`](https://github.com/NixOS/nixpkgs/commit/211cba432ae2ab1db0e2ddb85fdc0d353e015707) | `plasma-dialer: init at 21.05`                                             |
| [`0acc8547`](https://github.com/NixOS/nixpkgs/commit/0acc8547bc10e63cc2950f79473af5dd509def8f) | `krecorder: init at 21.05`                                                 |
| [`d07a0aed`](https://github.com/NixOS/nixpkgs/commit/d07a0aed114f683f761a503b0859fc4aa838280f) | `calindori: init at 21.05`                                                 |
| [`7d8cb832`](https://github.com/NixOS/nixpkgs/commit/7d8cb8321cd63cc05e02115169c4279c44f6c372) | `alligator: init at 21.05`                                                 |
| [`dcbe5b8d`](https://github.com/NixOS/nixpkgs/commit/dcbe5b8d126e9c34aa15f032efecc6c6379e9f5f) | `kclock: init at 21.05`                                                    |
| [`094eb89b`](https://github.com/NixOS/nixpkgs/commit/094eb89b7eaa513284c4aa33512a42dd49890399) | `kalk: init at 21.05`                                                      |
| [`546b930b`](https://github.com/NixOS/nixpkgs/commit/546b930bd8dfdc69502e42c4615a83e75f629be7) | `qt5-packages.nix: Add plasmaMobileGear`                                   |
| [`3f7fa2ec`](https://github.com/NixOS/nixpkgs/commit/3f7fa2eca8cf7e1f807f66bf0bb5ac45fe7c7f80) | `applications/plasma-mobile: Add empty plasma-mobile package set`          |
| [`f974dc30`](https://github.com/NixOS/nixpkgs/commit/f974dc304bc6bf598f4f6a63197048950ac31403) | `applications/plasma-mobile: Init srcs.nix`                                |
| [`b77fcd30`](https://github.com/NixOS/nixpkgs/commit/b77fcd30a9c2c51fbd6c18817461e049a3d8cd27) | `applications/plasma-mobile: Add fetch script`                             |
| [`3e9044f4`](https://github.com/NixOS/nixpkgs/commit/3e9044f4caa0898fd4c5cb576cbb98aaf9031ab7) | `libqofono: init at 0.103`                                                 |
| [`b5651798`](https://github.com/NixOS/nixpkgs/commit/b5651798b25f5d4ba8fab012a9007241391e53e4) | `kpublictransport: init at 21.04.0`                                        |
| [`af47c471`](https://github.com/NixOS/nixpkgs/commit/af47c4717e2ea01496d0e5f90bf0ccb283bfe103) | `kirigami-addons: init at 21.05`                                           |
| [`5dc009c1`](https://github.com/NixOS/nixpkgs/commit/5dc009c131f46f590f39df180df386837372e784) | `aliases: Drop kalk (kalker)`                                              |
| [`45be4792`](https://github.com/NixOS/nixpkgs/commit/45be479255d805afa0dd7d8b0aefce6736c2e9ad) | `llvmPackages_rocm.compiler-rt: replace dead patch with clone`             |
| [`22eff159`](https://github.com/NixOS/nixpkgs/commit/22eff15993176cbdfd6f306c479d4c847030c658) | `dt-schema: 2021.7 -> 2021.10`                                             |
| [`9b2a54f7`](https://github.com/NixOS/nixpkgs/commit/9b2a54f7d6084c202a23e0f5e4f49a1bb99f09fb) | `treewide: change 0.0.0 to 0.pre in version attrs`                         |
| [`15349e69`](https://github.com/NixOS/nixpkgs/commit/15349e69e4c8eb946af6e97edaec2da6562eb592) | `beam-modules: webdriver: rename version`                                  |
| [`f289d93a`](https://github.com/NixOS/nixpkgs/commit/f289d93a41cf9888f0ade3357b0d8df9104505dd) | `doc/contributing: add lib.optional (#121251)`                             |
| [`0d7ed306`](https://github.com/NixOS/nixpkgs/commit/0d7ed306f13c002e87ee82e9df3646117cc83579) | `elastix: update homepage`                                                 |
| [`9b132de1`](https://github.com/NixOS/nixpkgs/commit/9b132de195c15f8e4b0db8a017f56d378c3a707c) | `font-config-info: init at 1.0.0`                                          |
| [`fe36d93c`](https://github.com/NixOS/nixpkgs/commit/fe36d93cea36dc74ea112994527c10134eb1b7a2) | `siesta: 4.1-b3 -> 4.1.5`                                                  |
| [`ad67f862`](https://github.com/NixOS/nixpkgs/commit/ad67f8629ec6d7902fd4e87f7b3ae0ac52bf9f5c) | `catgirl: fix path to openssl utility after configuring`                   |
| [`e0028948`](https://github.com/NixOS/nixpkgs/commit/e0028948c2e8ed41e3e6b7a84ba0f8caf07764ba) | `emacs2nix: Bump version`                                                  |
| [`a0627a25`](https://github.com/NixOS/nixpkgs/commit/a0627a25647f00416a396b226ca0cfb7c4834c06) | `python3Packages.angrop: 9.0.10055 -> 9.0.10072`                           |
| [`9b60125d`](https://github.com/NixOS/nixpkgs/commit/9b60125d5dd2b335ef0356f5564da8a33894760d) | `cozy-drive: Add Cozy Drive package. (#138730)`                            |
| [`49b21b75`](https://github.com/NixOS/nixpkgs/commit/49b21b756ccc1e09efba02c8916226f49031d824) | `python3Packages.angr: 9.0.10055 -> 9.0.10072`                             |
| [`c773f0a0`](https://github.com/NixOS/nixpkgs/commit/c773f0a0e579d697d0f3b65e3288862dce4dc4d4) | `python3Packages.cle: 9.0.10055 -> 9.0.10072`                              |
| [`d933d6c0`](https://github.com/NixOS/nixpkgs/commit/d933d6c004771ba1d5685b296957a7c084e50015) | `python3Packages.claripy: 9.0.10055 -> 9.0.10072`                          |
| [`b1fbbf7a`](https://github.com/NixOS/nixpkgs/commit/b1fbbf7a9a89e500cadea0f8da8896621e32775e) | `python3Packages.pyvex: 9.0.10055 -> 9.0.10072`                            |
| [`beed9a88`](https://github.com/NixOS/nixpkgs/commit/beed9a88d2ce8b445ee39d51e7cc1eb3175a82f8) | `python3Packages.ailment: 9.0.10055 -> 9.0.10072`                          |
| [`facc0f71`](https://github.com/NixOS/nixpkgs/commit/facc0f714088ff3ee269987f7d1cd0383f32af6a) | `python3Packages.archinfo: 9.0.10055 -> 9.0.10072`                         |
| [`a9c44270`](https://github.com/NixOS/nixpkgs/commit/a9c442702d38939cb42d39909e4b2f1b92bdd283) | `sqlfluff: 0.6.6 -> 0.6.8`                                                 |
| [`cc380d53`](https://github.com/NixOS/nixpkgs/commit/cc380d53893efd01615af60662746921d81fa960) | `liquidctl: 1.7.1 -> 1.7.2`                                                |
| [`51e1f152`](https://github.com/NixOS/nixpkgs/commit/51e1f1525149efbcc0f4f9cf6ffd8004cf8e4523) | `onionshare: disable test_receive_mode_webhook on darwin`                  |
| [`04f95964`](https://github.com/NixOS/nixpkgs/commit/04f959640594d7770369ab4c7a135dd4674ac945) | `bpfmon: init at 2.50`                                                     |
| [`bf8e9d00`](https://github.com/NixOS/nixpkgs/commit/bf8e9d00040b8cef113c6d036a5a8779bf2884f1) | `spyre: init at 1.2.1`                                                     |
| [`18a1ce05`](https://github.com/NixOS/nixpkgs/commit/18a1ce0580bbc03a879635f41dbe156088e258cb) | `vmware-horizon-client: 2103 -> 2106.1`                                    |
| [`654d462e`](https://github.com/NixOS/nixpkgs/commit/654d462e127ffd239b695cceba4936fba36117eb) | `python39Packages.thinc: 8.0.3 -> 8.0.1`                                   |
| [`27835c2e`](https://github.com/NixOS/nixpkgs/commit/27835c2ee0b55f8865534ef764f20678f436c867) | `python39Packages.spacy: 3.0.6 -> 3.1.3`                                   |
| [`bd4a2fc8`](https://github.com/NixOS/nixpkgs/commit/bd4a2fc8d28adb283807ab7ed945a12c94a854ec) | `python39Packages.spacy-transformers: 1.0.2 -> 1.0.6`                      |
| [`d98ed052`](https://github.com/NixOS/nixpkgs/commit/d98ed0520bbc858398e6385a22e3e1591ffebf62) | `signal-desktop: 5.18.0 -> 5.18.1`                                         |
| [`cfd7037d`](https://github.com/NixOS/nixpkgs/commit/cfd7037d2a0145ac5e2c33ffa57df1d62716acfb) | `starsector: init at 0.95a-RC15`                                           |
| [`d04d7c0d`](https://github.com/NixOS/nixpkgs/commit/d04d7c0dc4d2b07ed1f0cae0f36504e234548049) | `prisma: 3.1.1 -> 3.2.0`                                                   |
| [`881ba67f`](https://github.com/NixOS/nixpkgs/commit/881ba67f837a1939dba3c35a526346c7a12aa004) | `pkgsStatic.perl: fix build`                                               |
| [`c5d08ebe`](https://github.com/NixOS/nixpkgs/commit/c5d08ebee1805668b2a3945f0f5b2e06a1e03412) | `nixos/nextcloud: Fix ambiguity in `objectstoreConfig` string`             |
| [`1ef6c4bf`](https://github.com/NixOS/nixpkgs/commit/1ef6c4bf378a262946c4770ceda6a9ac467eb9f6) | `ubootQemuRiscv64Smode: init`                                              |
| [`b0f99ad5`](https://github.com/NixOS/nixpkgs/commit/b0f99ad5270605d9f0da072048c2723ab62f9780) | `ubootRaspberryPi4: provide fix for C0 revisions`                          |
| [`32a9c0ad`](https://github.com/NixOS/nixpkgs/commit/32a9c0adc30d334aee1984f48749b61e2c79ab0e) | `uboot: 2021.04 -> 2021.10`                                                |
| [`e11b3afd`](https://github.com/NixOS/nixpkgs/commit/e11b3afd8bff1a2e1f381a2fe2b17287cbc3698c) | `python39Packages.graphene: 3.0.0b7 -> 3.0.0b8`                            |
| [`ba0377ff`](https://github.com/NixOS/nixpkgs/commit/ba0377ff1aae448e3748ebf610ba472bc1f49248) | `duckstation: unstable-2020-12-29 -> unstable-2021-10-01`                  |
| [`d1bc31b2`](https://github.com/NixOS/nixpkgs/commit/d1bc31b26b6334c65b7c4551d67d9dbbf5e2dc81) | `usbrip: init at unstable-2021-07-02`                                      |
| [`1f4b6127`](https://github.com/NixOS/nixpkgs/commit/1f4b61279f4a721b0c223c398bce35b461cb11b5) | `eclipses: 2021-06 -> 2021-09`                                             |
| [`8ea44034`](https://github.com/NixOS/nixpkgs/commit/8ea44034837b46f026a253ff435c8d1d71fed08e) | `plasma5Packages.kdeGear: update doc for KDE Gear`                         |
| [`a8df3e77`](https://github.com/NixOS/nixpkgs/commit/a8df3e773e35f62efdde98df2aa93028164409d2) | `kde/fetch.sh: use https for getting checksums`                            |
| [`61f69f02`](https://github.com/NixOS/nixpkgs/commit/61f69f025f03b64b036a003f811da300b4b3040f) | `lego: 4.4.0 -> 4.5.2`                                                     |
| [`3a242c05`](https://github.com/NixOS/nixpkgs/commit/3a242c0594fa70feca9993c5e0b5d446450d2a5e) | `restinio: init 0.6.13`                                                    |
| [`8dc03d06`](https://github.com/NixOS/nixpkgs/commit/8dc03d0606feb616b9b01e8c2cfc74c7096d8fd8) | `linux_lqx: 5.14.6 -> 5.14.9`                                              |
| [`a9b3548f`](https://github.com/NixOS/nixpkgs/commit/a9b3548fb6a4d72c07eec73e0f3071f2dd21c3b8) | `postgresqlPackages.pgvector: 0.1.8 -> 0.2.0`                              |
| [`e793481a`](https://github.com/NixOS/nixpkgs/commit/e793481afd200c8d00ec730e82e2d31973fb8304) | `postgresqlPackages.pgroonga: 2.3.1 -> 2.3.2`                              |
| [`c1783f6a`](https://github.com/NixOS/nixpkgs/commit/c1783f6a3a77a03ccabf0da45311db5898dab1e4) | `ocamlPackages.uuseg: 11.0.0 → 14.0.0`                                     |
| [`a539a827`](https://github.com/NixOS/nixpkgs/commit/a539a82707bad3c644fe5537300808e040540ae5) | `nixos/nextcloud: Account for nix_read_secret refactor in exception msg`   |
| [`fbffadde`](https://github.com/NixOS/nixpkgs/commit/fbffaddefe1db5b7ba0a86b302902311d8c06411) | `nixos/nextcloud: Make `objectstore.s3.useSsl` explicitly true by default` |
| [`b23d6a41`](https://github.com/NixOS/nixpkgs/commit/b23d6a4113bb087357d66e5073c1ee6883eb1744) | `nixos/nextcloud: Simplify `objectstore.s3` options, remove submodule`     |
| [`03171ae3`](https://github.com/NixOS/nixpkgs/commit/03171ae31abf0427467fea968c3fa465338535f3) | `nixos/nextcloud: Remove `objectstore.s3.secret` option`                   |
| [`1ed93ac4`](https://github.com/NixOS/nixpkgs/commit/1ed93ac4a17b68ebfb5c7284299a24808021293f) | `nixos/nextcloud: Add option for using object storage as primary storage`  |
| [`d513da88`](https://github.com/NixOS/nixpkgs/commit/d513da881c6a94454fc2a604655c1b5bcc109621) | `texstudio: 3.1.2 -> 4.0.0`                                                |
| [`31f0e8fb`](https://github.com/NixOS/nixpkgs/commit/31f0e8fb2eed323ad2027d27f2c6ffad448a633c) | `go-containerregistry: 0.4.1 -> 0.6.0`                                     |
| [`d7ae51d4`](https://github.com/NixOS/nixpkgs/commit/d7ae51d4f6dc6c8ee9495f79b8c5b4112d9876c0) | `regclient: init 0.3.8`                                                    |
| [`7f9fabb6`](https://github.com/NixOS/nixpkgs/commit/7f9fabb6eb528cc4de54d09e273af807013790c5) | `sunxi-tools: 2018-11-13 -> 2021-08-29`                                    |