### PR TITLE
chore(deps): update home-manager

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bb72555852c0dc397ca65ba21c6317cada7e3058",
-        "sha256": "1fc8v9jivx54hnphq0z6r5z7qqz4ggknvcas1dm4zhngfhvim0dj",
+        "rev": "71902bc913ccc36baa9ac18dd9b84117a34a36b0",
+        "sha256": "1vpb75fdy87hmcv2qw2gki6wd2f0hyqc754vgg0syxn4b1axy7mg",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/bb72555852c0dc397ca65ba21c6317cada7e3058.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/71902bc913ccc36baa9ac18dd9b84117a34a36b0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixos-hardware": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                        |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`71902bc9`](https://github.com/nix-community/home-manager/commit/71902bc913ccc36baa9ac18dd9b84117a34a36b0) | `home-manager: fix command line option for nix build` |
| [`134c5ccd`](https://github.com/nix-community/home-manager/commit/134c5ccdd356607da86f8b422fddf5e585793d93) | `mbsync: stub test dependency`                        |
| [`e28a720c`](https://github.com/nix-community/home-manager/commit/e28a720ce942bbb87240885e20408a3f32218556) | `irssi: fix test directory name`                      |
| [`78afc2fa`](https://github.com/nix-community/home-manager/commit/78afc2fa741a93df3c73cedd26f09ee77465dc71) | `git: stub test dependency on msmtp`                  |
| [`0f724418`](https://github.com/nix-community/home-manager/commit/0f7244182114ce4f131ffc9ed2f23aebf290cf15) | `bspwm: stub test dependency`                         |
| [`7e30aec2`](https://github.com/nix-community/home-manager/commit/7e30aec28236cbfeddd932c94b801adcc718e6c6) | `hexchat: simplify theme example`                     |