### PR TITLE
chore(deps): update home-manager

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "275f955db979e069fbe7a1fd7cfcb5ec030a2096",
-        "sha256": "1zjspmxyp4h75z1f51imnzdv54lnjqafdpisinf48bzd1mxlcvar",
+        "rev": "70c5b268e10025c70823767f4fb49e240b40151d",
+        "sha256": "09si7wq89qpyzfxgs1862s7lv8sl0ikwx7cy9vavf1hd5y6m13s4",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/275f955db979e069fbe7a1fd7cfcb5ec030a2096.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/70c5b268e10025c70823767f4fb49e240b40151d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixos-hardware": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                            |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`70c5b268`](https://github.com/nix-community/home-manager/commit/70c5b268e10025c70823767f4fb49e240b40151d) | `xdg: add option 'xdg.stateHome' (#2439)`                 |
| [`288faaa5`](https://github.com/nix-community/home-manager/commit/288faaa5a65e72e37e6027024829b15c8bb69286) | `programs.zsh.zplug: add zplugHome option`                |
| [`21590d40`](https://github.com/nix-community/home-manager/commit/21590d40c1575ff77c96bbb0c7b151cfa788e100) | `home-environment: document escaping of home.sessionPath` |
| [`2e1a5b53`](https://github.com/nix-community/home-manager/commit/2e1a5b53ec2bec28d92db5acb416ad60e6760926) | `xsession: don't reset the inherited keyboard options`    |
| [`7523252f`](https://github.com/nix-community/home-manager/commit/7523252f97bff5d39de47fb2b112f2039d1218a3) | `htop: fix order or header_columns setting (#2435)`       |