### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6d7a5212c5c2cb8a873477927078ed53a028307b",
-        "sha256": "0xcd9527qcak0g06n4xnaz76gzj9m6x5gfnqmsq9rapjvmxinnhv",
+        "rev": "94d91a448b87a70204485bd768977c07575911e8",
+        "sha256": "01vrv51amr4hapwbjv97vbvcpgk5ijpi27ww62xr6pxf7zl0ihqk",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/6d7a5212c5c2cb8a873477927078ed53a028307b.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/94d91a448b87a70204485bd768977c07575911e8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`aeebe4de`](https://github.com/NixOS/nixpkgs/commit/aeebe4de10ab27887db6f500827a2d1f17059f90) | `ksnip: fix qt wrapping`                                                                      |
| [`cb3a0f55`](https://github.com/NixOS/nixpkgs/commit/cb3a0f55e8e37c4f7db239ce27491fd66c9503cc) | `stage2: use atomic bind mounts`                                                              |
| [`3572d2f0`](https://github.com/NixOS/nixpkgs/commit/3572d2f04fb2afe789fd853aeb29c5fa0424e25b) | `plasma-workspace: fix systemd unit detection`                                                |
| [`0f57c4b9`](https://github.com/NixOS/nixpkgs/commit/0f57c4b9529b840d8d3a1e2349513535f3b7adc7) | `nixosTest/plasma5-systemd-start: init`                                                       |
| [`1380230a`](https://github.com/NixOS/nixpkgs/commit/1380230a378043ecd55c3d50a0bfa1f401d80efc) | `python38Packages.jupyter_server: 1.11.1 -> 1.11.2`                                           |
| [`9a790f06`](https://github.com/NixOS/nixpkgs/commit/9a790f06b0e32882a1370be080621cee7212efa2) | `python38Packages.sqlmap: 1.5.10 -> 1.5.11`                                                   |
| [`50029ed8`](https://github.com/NixOS/nixpkgs/commit/50029ed89ce5e38f0b893689762c7ead26c2f678) | `nixos/dokuwiki: add missing option enable`                                                   |
| [`550dab22`](https://github.com/NixOS/nixpkgs/commit/550dab224a26ec25e20e82c0c8bfc764e01b772e) | `bash-preexec: fix build with Bats 1.5.0`                                                     |
| [`7bc749e0`](https://github.com/NixOS/nixpkgs/commit/7bc749e0640d5a3d8b4b7122ace4a3e4980af7a0) | `maintainers: add ayazhafiz to entry-points-txt, headerparser, wheel-filename, wheel-inspect` |
| [`c6e744c9`](https://github.com/NixOS/nixpkgs/commit/c6e744c9f2dc2dc6f181235bb1286dfae11e8759) | `maintainers: add ayazhafiz`                                                                  |
| [`5ce67c6a`](https://github.com/NixOS/nixpkgs/commit/5ce67c6a9b63cc64a048789453b44e6c57501ddd) | `wheel-inspect: init at 1.7.0`                                                                |
| [`a5fbf148`](https://github.com/NixOS/nixpkgs/commit/a5fbf1487adcd2c1171bb4d0da17898381d01234) | `entry-points-txt: init at 0.1.0`                                                             |
| [`97452c28`](https://github.com/NixOS/nixpkgs/commit/97452c285cb2b36455ca37dd101cc33d12f24b4e) | `headerparser: init at 0.4.0`                                                                 |
| [`f5014e47`](https://github.com/NixOS/nixpkgs/commit/f5014e47feea55c2b15af3570c5e9df54e3c8263) | `wheel-filename: init at 1.3.0`                                                               |
| [`670af1fb`](https://github.com/NixOS/nixpkgs/commit/670af1fba859ae2834325b4e764fb3c3d08b662a) | `hd-idle: package rewrite`                                                                    |
| [`bf873fbb`](https://github.com/NixOS/nixpkgs/commit/bf873fbb2f461f1897335debcffbde67e3e83f44) | `fclones: 0.17.0 -> 0.17.1 (#144150)`                                                         |
| [`86c83e8c`](https://github.com/NixOS/nixpkgs/commit/86c83e8cf6258288b4cb2d2ee2e62c4604d1f341) | `tabnine: 3.6.8 -> 3.7.25`                                                                    |
| [`29f4f711`](https://github.com/NixOS/nixpkgs/commit/29f4f7110c7d454eddf11199f750fc99bc03cc83) | `nixos/smokeping: Add nh2 to maintainers`                                                     |
| [`4aeabbee`](https://github.com/NixOS/nixpkgs/commit/4aeabbee61d9a445d90f8510629f0ce947b63873) | `nixos/rl-2111: Document smokeping service updates`                                           |
| [`c7ed7466`](https://github.com/NixOS/nixpkgs/commit/c7ed7466c317249953948ec7221d7b9fabc7d6e7) | `nixos/smokeping: Don't listen on all interfaces by default.`                                 |
| [`bb2a6ec7`](https://github.com/NixOS/nixpkgs/commit/bb2a6ec751dfb2810ef86be0fb44b93379b7de11) | `nixos/smokeping: Use requiredBy instead of wantedBy.`                                        |
| [`123171b5`](https://github.com/NixOS/nixpkgs/commit/123171b557eb9a8ea6a4d7910ffe785f8d280d24) | `nixos/smokeping: Remove partOf to ensure restarts work.`                                     |
| [`17e4387b`](https://github.com/NixOS/nixpkgs/commit/17e4387b38ad35e2ba4fb8101d3cf36ccc14232f) | `nixos/smokeping: Make default imgUrl relative.`                                              |
| [`2760695d`](https://github.com/NixOS/nixpkgs/commit/2760695df0bae341cc7f345593628d9c19af9007) | `nixos/smokeping: Add host option.`                                                           |
| [`0a210354`](https://github.com/NixOS/nixpkgs/commit/0a2103547f1c27ed79a81e3c3b735bf1bdf3d2a7) | `nixos/smokeping: Remove bash wrapper, refactor.`                                             |
| [`e884e284`](https://github.com/NixOS/nixpkgs/commit/e884e2840e9a6e3b3bffb332514b944e13b85f5d) | `tdesktop: fix build`                                                                         |
| [`76079c14`](https://github.com/NixOS/nixpkgs/commit/76079c145bdce2aef8642eb49190272df279b0c7) | `fcitx5-mozc: fix build`                                                                      |
| [`65590d54`](https://github.com/NixOS/nixpkgs/commit/65590d546c32fcef75149eb9d56a225787ba71ce) | `river: 2021-09-30 -> 2021-11-01`                                                             |
| [`6204fa6c`](https://github.com/NixOS/nixpkgs/commit/6204fa6c7a71ad915dd603ff522c3a8280028105) | `spike: move test to installCheck phase (#143832)`                                            |
| [`121dfb7a`](https://github.com/NixOS/nixpkgs/commit/121dfb7a5aa0a31cb96b02d232a6080ccd617340) | `kodi.packages.jellyfin: 0.7.4 -> 0.7.7`                                                      |
| [`bf2f82a4`](https://github.com/NixOS/nixpkgs/commit/bf2f82a43757e9b9c56bba45bceb009395e61966) | `python38Packages.azure-mgmt-eventhub: 9.1.0 -> 10.0.0`                                       |
| [`6751e742`](https://github.com/NixOS/nixpkgs/commit/6751e7428f20328fed076acfcbb340d0f4aa0c07) | `whalebird: init at 4.4.5 (#142885)`                                                          |
| [`78dd8567`](https://github.com/NixOS/nixpkgs/commit/78dd8567c113a2d23736c7c6c064b55ddeb9d5ad) | `threema-desktop: init at 1.0.3 (#143194)`                                                    |
| [`f538c07f`](https://github.com/NixOS/nixpkgs/commit/f538c07f2ebae64cc05526be65914a8212ab20b2) | `datefudge: work correctly even if GNU date is not in PATH (#94045)`                          |
| [`f048f4a3`](https://github.com/NixOS/nixpkgs/commit/f048f4a329900a2494f732d893fdff32eafa5626) | `python38Packages.pex: 2.1.53 -> 2.1.54`                                                      |
| [`b3ce132a`](https://github.com/NixOS/nixpkgs/commit/b3ce132ad24968d7e002a2e573d6b46afa499940) | `sierra-breeze-enhanced: init at 1.0.3 (#143696)`                                             |
| [`f727a6ae`](https://github.com/NixOS/nixpkgs/commit/f727a6aebe68a66e5d9d4291fd0b61e69aca77de) | `why3: remove spurious camlp5 dependency`                                                     |
| [`2628350c`](https://github.com/NixOS/nixpkgs/commit/2628350c274d6290cfb000e2970ad46168d86742) | `protoc-gen-twirp_php: 0.7.5 -> 0.8.0`                                                        |
| [`d68cb2ac`](https://github.com/NixOS/nixpkgs/commit/d68cb2ac457f31462af65c34308c4797db4f4965) | `python3Packages.uncompyle6: 3.7.4 -> 3.8.0`                                                  |
| [`a45bb60e`](https://github.com/NixOS/nixpkgs/commit/a45bb60ece9107def5e054eb7cbb3fcd38e49860) | `python3Packages.xdis: 5.0.11 -> 6.0.2`                                                       |
| [`9b51266f`](https://github.com/NixOS/nixpkgs/commit/9b51266f85a7da4ae727eef0877b8ff3c766d520) | `slides: 0.6.2 -> 0.7.2`                                                                      |
| [`3a912b2c`](https://github.com/NixOS/nixpkgs/commit/3a912b2cac2c934bca903f3c995e57ef514230ed) | `nxpmicro-mfgtools: 1.4.72 -> 1.4.165`                                                        |
| [`5d70e696`](https://github.com/NixOS/nixpkgs/commit/5d70e696220d12ca4c99c1b776a337f806935620) | `python3Packages.pyclip: init at 0.5.4`                                                       |
| [`89d7336c`](https://github.com/NixOS/nixpkgs/commit/89d7336c20d2321e3d5657bb825680c18a1deebb) | `lean: 3.34.0 -> 3.35.0`                                                                      |
| [`c707a468`](https://github.com/NixOS/nixpkgs/commit/c707a468a47286deb290956de5a91d25686fbe6b) | `lean: 3.33.0 -> 3.34.0`                                                                      |
| [`404254c8`](https://github.com/NixOS/nixpkgs/commit/404254c829ff2e2e87acd5943ce178ec7d753ceb) | `python3Packages.qutip: init at 4.6.2`                                                        |
| [`949c9f67`](https://github.com/NixOS/nixpkgs/commit/949c9f67cd0826c4fe82fe37710acbfce5d00aea) | `makeRustPlatform: allow to easily override stdenv`                                           |
| [`edfa1714`](https://github.com/NixOS/nixpkgs/commit/edfa1714bb21fb672c3325247a44255363408434) | `dbeaver: 21.2.3 -> 21.2.4`                                                                   |
| [`946f55cc`](https://github.com/NixOS/nixpkgs/commit/946f55cc0475c2a0979ba7a751abc84d4d21375d) | `statix: 0.3.4 -> 0.3.5`                                                                      |
| [`eaab54e2`](https://github.com/NixOS/nixpkgs/commit/eaab54e2688ebefcaf2f71248cad22bd4b18a6c5) | `libxc: 5.1.6 -> 5.1.7`                                                                       |
| [`877511d4`](https://github.com/NixOS/nixpkgs/commit/877511d42a6e831bdc3f9a2435917a72484f20df) | `python3Packages.rapidfuzz: 1.8.0 -> 1.8.2`                                                   |
| [`f506ecdc`](https://github.com/NixOS/nixpkgs/commit/f506ecdca92d55c99fc3b8d8c7ef2f03218f9386) | `all-packages: pass cxxStandard to or-tools`                                                  |
| [`1a590c52`](https://github.com/NixOS/nixpkgs/commit/1a590c529c847207e510fc614fb790f6bebb25ad) | `grpc: remove explicit cxx17 requirement coming from abseil-cpp`                              |
| [`f918954e`](https://github.com/NixOS/nixpkgs/commit/f918954e0673c768ff4a3be5f38e3ff555d813bd) | `abseil-cpp: format`                                                                          |
| [`af3444ff`](https://github.com/NixOS/nixpkgs/commit/af3444ffc5ad73d5efc351acae8bd0fa79a8c1df) | `abseil-cpp: add cxxStandard input`                                                           |
| [`0ab65c1d`](https://github.com/NixOS/nixpkgs/commit/0ab65c1d899a154d83abfd3ae5c774f43ccf6ea1) | `python3Packages.isbnlib: 3.10.8 -> 3.10.9`                                                   |
| [`be37b5fa`](https://github.com/NixOS/nixpkgs/commit/be37b5fa919ac0b45df39d7a10161e543c5cd965) | `python3Packages.hstspreload: 2021.10.1 -> 2021.11.1`                                         |
| [`1fe2aba0`](https://github.com/NixOS/nixpkgs/commit/1fe2aba063bd4001308fb2b14f26e7c74dde926e) | `crc32c: 1.1.0 -> 1.1.2 (#143839)`                                                            |
| [`595ecd2c`](https://github.com/NixOS/nixpkgs/commit/595ecd2ceb83387cc0e09c3b807d8b9fa0408fc1) | `sway: inherit tests from unwrapped package`                                                  |
| [`23640799`](https://github.com/NixOS/nixpkgs/commit/23640799a356b9ee333a3481d26f4e4267d401c4) | `home-assistant: pin aiounifi to v28`                                                         |
| [`70e0d12f`](https://github.com/NixOS/nixpkgs/commit/70e0d12fa638abb47d62ba4d8ef96ea744d3956c) | `python38Packages.google-re2: 0.2.20210901 -> 0.2.20211101`                                   |
| [`ffc27bb0`](https://github.com/NixOS/nixpkgs/commit/ffc27bb0db8b3997b3c075504de95fa847866326) | `python3Packages.django-debug-toolbar: init at 3.2.2`                                         |
| [`b8308f14`](https://github.com/NixOS/nixpkgs/commit/b8308f143bab090cbc9a94b246e958274028db63) | `maintainers: add yuu`                                                                        |
| [`85d7132e`](https://github.com/NixOS/nixpkgs/commit/85d7132ea7f25ff033bf4d994384ddab0da62fff) | `bitwise: 0.42 -> 0.43`                                                                       |
| [`80521a98`](https://github.com/NixOS/nixpkgs/commit/80521a98acd2f6c3977b33997348b2390b8e850e) | `electrs: 0.9.1 -> 0.9.2`                                                                     |
| [`6b7aa566`](https://github.com/NixOS/nixpkgs/commit/6b7aa566ef292ef162e9f29dbd059fb74f761df5) | `electrs/update.sh: ensure tag is checked out`                                                |
| [`c166beb8`](https://github.com/NixOS/nixpkgs/commit/c166beb8e5710c51b6a6e638dbdf9a6b54e8edf3) | `python38Packages.github3_py: 2.0.0 -> 3.0.0`                                                 |
| [`f374bc41`](https://github.com/NixOS/nixpkgs/commit/f374bc4113efe3ad4b472a28420cfef6e055e0fe) | `maintainer: sort`                                                                            |
| [`f13aa788`](https://github.com/NixOS/nixpkgs/commit/f13aa788e10846c1e9b5a0cf5c6b09ef9a16f5a6) | `elan: 1.2.0 -> 1.3.0`                                                                        |
| [`e791519f`](https://github.com/NixOS/nixpkgs/commit/e791519f0fb838d2dc95f525d0b58b0f419df445) | `nixos/qemu-vm: use qemu_kvm`                                                                 |
| [`07b54fd9`](https://github.com/NixOS/nixpkgs/commit/07b54fd95d8751a9701b0586ecc8135d4a968373) | `python38Packages.django_3: 3.2.8 -> 3.2.9`                                                   |
| [`7fa90b3e`](https://github.com/NixOS/nixpkgs/commit/7fa90b3e6f6ff7e46f68318d5f77c15ad28bd315) | `home-assistant: pin influxdb-client at 1.21.0`                                               |
| [`a188a744`](https://github.com/NixOS/nixpkgs/commit/a188a7448661876eddbe63ac5a18998298afc385) | `nixos/tests/chromium: Add a workaround to fix the test for M96+`                             |
| [`9989591b`](https://github.com/NixOS/nixpkgs/commit/9989591b3238c3cfe84eff118fac0aa1986dedde) | `monado: fix build failure related to VK_NULL_HANDLE change`                                  |
| [`256a798f`](https://github.com/NixOS/nixpkgs/commit/256a798f826696ba7babda4cd150cb952519ff29) | `nixos/kernel: test all upstream kernels, reference linuxKernel directly`                     |
| [`4fb4b643`](https://github.com/NixOS/nixpkgs/commit/4fb4b64362d0e00d2fb496626279f88b6255d26d) | `linux_latest: 5.14 -> 5.15`                                                                  |
| [`63185299`](https://github.com/NixOS/nixpkgs/commit/63185299f4c8beecac7e204dc20394f38e68a477) | `linux: make sure that `src`/`version` actually refer to the declaring file`                  |
| [`fcd2ff57`](https://github.com/NixOS/nixpkgs/commit/fcd2ff57279e73d94006081c12438aa2dddf128f) | `anki-bin: 2.1.48 -> 2.1.49`                                                                  |
| [`9f69e37c`](https://github.com/NixOS/nixpkgs/commit/9f69e37ccc1ffd671c6a29052a832e2606da0902) | `rPackages: fix builds requiring gsl`                                                         |
| [`9d91ebe1`](https://github.com/NixOS/nixpkgs/commit/9d91ebe17e0b0afafb6b8c04a74f3cf7c9da6405) | `linux: init 5.15`                                                                            |
| [`ed24de47`](https://github.com/NixOS/nixpkgs/commit/ed24de47abce645229cbafbcd8871096d2c7a490) | `rPackages: fix builds requiring home`                                                        |
| [`92ed7e16`](https://github.com/NixOS/nixpkgs/commit/92ed7e16b6673d0087a5dd988c33605a18a8e972) | `rPackages.RoBMA: fix missing dependency`                                                     |
| [`63b7bb7f`](https://github.com/NixOS/nixpkgs/commit/63b7bb7fbe891ab3274d9baff67d9a0e71ac24db) | `shadowsocks-rust: 1.10.7 -> 1.11.2`                                                          |
| [`4f1d4c61`](https://github.com/NixOS/nixpkgs/commit/4f1d4c61e1825e9d360e1b1839b81aa6f9b6f681) | `ryujinx: 1.0.7086 -> 1.0.7094`                                                               |
| [`7d434ce3`](https://github.com/NixOS/nixpkgs/commit/7d434ce31c17aab3b4fa07881d13a02d39da17e0) | `qbe: unstable-2021-10-26 -> unstable-2021-10-28`                                             |
| [`7bee2fb2`](https://github.com/NixOS/nixpkgs/commit/7bee2fb2b706ee7fab1c98c4f2ceff323999007d) | `alttpr-opentracker: run unit tests`                                                          |
| [`af339c5c`](https://github.com/NixOS/nixpkgs/commit/af339c5cf87bdf8e51f2ffc5f1d1337ef9b9223d) | `buildDotnetModule: add support for running unit tests`                                       |
| [`dc4e3b54`](https://github.com/NixOS/nixpkgs/commit/dc4e3b543dd279674a767f222917dd64177f44b1) | `ucg: rewrite tests`                                                                          |
| [`f87e45d1`](https://github.com/NixOS/nixpkgs/commit/f87e45d17e866f522a51b37dcb98f6415243a1aa) | `ucg: mark as broken for ARM64`                                                               |
| [`244ad021`](https://github.com/NixOS/nixpkgs/commit/244ad021020acfadf01bae6787e45e9218cddd97) | `python3Packages.google-cloud-storage: fix build`                                             |
| [`c88d7f42`](https://github.com/NixOS/nixpkgs/commit/c88d7f42cb144fc7e58f663dff4d8e9258691d87) | `nixos/plasma5: fix accounts-daemon can't read profile image from systemsettings5`            |
| [`d1bf81f5`](https://github.com/NixOS/nixpkgs/commit/d1bf81f5e6055558d60b3a3217cde177a8e2b22e) | `accountsservice: fix typo, little format cleanup`                                            |
| [`19142fd0`](https://github.com/NixOS/nixpkgs/commit/19142fd0793ab2768463801b78261a5062c0f6f8) | `nixos/plasma5: enable accounts dbus daemon to beable to modify user settings like Pictures`  |
| [`22987611`](https://github.com/NixOS/nixpkgs/commit/22987611d005455a9663b006fe4353535a036237) | `nixos/plasma5: assorted manually formatting changes and cleanups + statix`                   |
| [`441a141e`](https://github.com/NixOS/nixpkgs/commit/441a141e7278143625c3a01b42ab0cdb0929aae1) | `coreutils: switch to version 9 for darwin`                                                   |
| [`b1a8accc`](https://github.com/NixOS/nixpkgs/commit/b1a8accc14522298bbba4c957f001b84c19cf519) | `librsvg: fix darwin build`                                                                   |
| [`c3825385`](https://github.com/NixOS/nixpkgs/commit/c38253850790ff59b97fb0890061aee5f880ab96) | `python3Packages.jedi: fix tests for darwin`                                                  |
| [`2dac86f1`](https://github.com/NixOS/nixpkgs/commit/2dac86f1405bc7f1b5bdf7dd7126d394132bb654) | `python39Packages.influxdb-client: 1.21.0 -> 1.23.0`                                          |
| [`743c0ec2`](https://github.com/NixOS/nixpkgs/commit/743c0ec2d8dec65cf0a7a67c9d4971a5b3325fbe) | `cni-flannel-plugin: 1.1 -> 1.0.0`                                                            |
| [`55015218`](https://github.com/NixOS/nixpkgs/commit/5501521875aa85f8b4a9a7eae90e1e6cf4bdb9dc) | `zabbix: 5.0.15 -> 5.0.17`                                                                    |
| [`c1ca4ad1`](https://github.com/NixOS/nixpkgs/commit/c1ca4ad12b878b969d351528cc826b0cb5e73cb7) | `zabbix: 4.0.33 -> 4.0.35`                                                                    |
| [`684c175f`](https://github.com/NixOS/nixpkgs/commit/684c175f253db9a64bf7ea55f8204efe1ac57bb8) | `etcher: throw on unsupported systems`                                                        |
| [`0214723a`](https://github.com/NixOS/nixpkgs/commit/0214723ab30f86fad05ad456bf3d7f2779fcfa49) | `etcher: 1.5.122 -> 1.6.0`                                                                    |
| [`ccc720b6`](https://github.com/NixOS/nixpkgs/commit/ccc720b698c1bd5f7533408b112a826df9787e48) | `qjackctl: 0.9.4 -> 0.9.5`                                                                    |
| [`5094ee54`](https://github.com/NixOS/nixpkgs/commit/5094ee54f9cf9fce92d173ae0f43c8bf40248e48) | `qcad: 3.26.4.7 -> 3.26.4.10`                                                                 |
| [`cbca6fc0`](https://github.com/NixOS/nixpkgs/commit/cbca6fc0df005fe20e2256e8c42c0c40c6785e0c) | `vdrPlugins.epgsearch: 20191202 -> 2.4.1`                                                     |
| [`11536f97`](https://github.com/NixOS/nixpkgs/commit/11536f974652a42c2df900a007d1cecf6cffaa05) | `pinentry: 1.1.0 -> 1.2.0`                                                                    |
| [`f8d1de8e`](https://github.com/NixOS/nixpkgs/commit/f8d1de8e18f5446f119ec6913ff1bfb7259e1878) | `mesa: 21.2.4 -> 21.2.5`                                                                      |
| [`5b3e4e54`](https://github.com/NixOS/nixpkgs/commit/5b3e4e5408433feaea2107b00ea3ecd7019b69bd) | `auto-multiple-choice: init at 1.5.1`                                                         |
| [`6c0804f1`](https://github.com/NixOS/nixpkgs/commit/6c0804f1b0fce6831773f042afcab68df793ecb0) | `nixos/neovim: Respect option defaultEditor`                                                  |
| [`3e74257f`](https://github.com/NixOS/nixpkgs/commit/3e74257f86d9a7c1fd9573ace96067a01d9f7b94) | `vdr: 2.4.7 -> 2.5.6`                                                                         |
| [`6021b289`](https://github.com/NixOS/nixpkgs/commit/6021b2895ec3c77fdfa83770816a8707deef074f) | `buttercup-desktop: init at 2.13.0`                                                           |
| [`12eb6252`](https://github.com/NixOS/nixpkgs/commit/12eb625292c052d6e3d3dd2782ee7bc965389751) | `markmind: init at 1.3.1`                                                                     |
| [`924ccbff`](https://github.com/NixOS/nixpkgs/commit/924ccbff80dbfba51b9b893879062fcf2539cd72) | `coreutils: Disable SEEK_HOLE due to corruption`                                              |
| [`d5a1964a`](https://github.com/NixOS/nixpkgs/commit/d5a1964ad6118a9186c9f15a76d7b7f18f80926f) | `maintainers: add thblt`                                                                      |
| [`5156f07c`](https://github.com/NixOS/nixpkgs/commit/5156f07c960c42957c9c179f7b810a8d2fa8f4d8) | `pocket-casts: set electron version on top-level`                                             |
| [`1f0317cd`](https://github.com/NixOS/nixpkgs/commit/1f0317cd5b64510aec2fa2e9e49d3333efdd5227) | `rPackages.BayesXsrc: fix build`                                                              |
| [`d008d01c`](https://github.com/NixOS/nixpkgs/commit/d008d01cce6f55a23c473ce819e64ce62150c578) | `coreutils: use version 8 for darwin`                                                         |
| [`69c284c3`](https://github.com/NixOS/nixpkgs/commit/69c284c3c0af5ece5afbe8f868b8de5b282d9375) | `rPackages: fix compression library dependencies`                                             |
| [`7aa68ac8`](https://github.com/NixOS/nixpkgs/commit/7aa68ac8ae6e6bb9c0d60e8ecf06f4557ec4f15b) | `rPackages: fix packages requiring home during build`                                         |
| [`e3a5f66a`](https://github.com/NixOS/nixpkgs/commit/e3a5f66a778a1ddb38c597daccbe8ea6b63ad32c) | `fix httpgd cairo dependency missing`                                                         |
| [`c1fe3d4c`](https://github.com/NixOS/nixpkgs/commit/c1fe3d4cda342f60eee83f0055be8fa54d33e12a) | `git: disable t5003 on darwin`                                                                |
| [`7f8ec078`](https://github.com/NixOS/nixpkgs/commit/7f8ec0789726f8feab7c0f91bf213d9530a836c6) | `rPackages: update CRAN and BIOC package sets`                                                |
| [`7c0561c5`](https://github.com/NixOS/nixpkgs/commit/7c0561c526d25ecfde3250501018540e2d4ef327) | `python38Packages.google-cloud-appengine-logging: 1.0.0 -> 1.1.0`                             |
| [`016b0a42`](https://github.com/NixOS/nixpkgs/commit/016b0a423aea9a789d1327dff3fd10b908bd1e91) | `python3Packages.afdko: update tests for ufonormalizer-0.6.1`                                 |
| [`49488223`](https://github.com/NixOS/nixpkgs/commit/494882232c8e8c11625747108ad670063face1a8) | `libressl: 3.4.0 -> 3.4.1, libressl_3_2: 3.2.5 -> 3.2.7`                                      |
| [`bb9f3e73`](https://github.com/NixOS/nixpkgs/commit/bb9f3e73ac8589d06020dc0f9bc07db07e2b60f6) | `libressl: fix pkg-config exec_prefix`                                                        |
| [`3bd85fa7`](https://github.com/NixOS/nixpkgs/commit/3bd85fa720ceb2f1f0204e5b0410831f4b9f9254) | `Revert "marble: fix build with gpsd 3.23.1"`                                                 |