### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "94d91a448b87a70204485bd768977c07575911e8",
-        "sha256": "01vrv51amr4hapwbjv97vbvcpgk5ijpi27ww62xr6pxf7zl0ihqk",
+        "rev": "86373221aeecaa9c398f1ce06e721a8ae0f363e8",
+        "sha256": "1xhlmpxm1dgx89m1swv6fclvd28z2fjdhwrk0di5vsyl1cq4zzq4",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/94d91a448b87a70204485bd768977c07575911e8.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/86373221aeecaa9c398f1ce06e721a8ae0f363e8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                            |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`34dad808`](https://github.com/NixOS/nixpkgs/commit/34dad8081605d57da6d5c6677ed7e3d4fc7da998) | `haxor-news: fix build`                                                                   |
| [`c39e9324`](https://github.com/NixOS/nixpkgs/commit/c39e93249a527597a4008f607c9bdf7505dd284d) | `eww: set meta.broken on darwin`                                                          |
| [`739c51ae`](https://github.com/NixOS/nixpkgs/commit/739c51ae4ef9535b37672d7dc303bce432562922) | `nixosTests: Redirect stdout to stderr when detaching`                                    |
| [`698fb089`](https://github.com/NixOS/nixpkgs/commit/698fb089d8276ac6907ae3a13ee1933a59e12112) | `nixosTest: Document stdout waiting behavior`                                             |
| [`3da7e765`](https://github.com/NixOS/nixpkgs/commit/3da7e765cd449d4e2bb2bb705146e2750f1e6f93) | `crc32c: fix tests on darwin`                                                             |
| [`07e0891d`](https://github.com/NixOS/nixpkgs/commit/07e0891d170e18c35452fcda220db11beafb6ae2) | `sanic: disable failing test on darwin`                                                   |
| [`7d6a79ed`](https://github.com/NixOS/nixpkgs/commit/7d6a79ed57fd5aad3891a42787a53db2fa40bd16) | `README.md: fix link to channels manual`                                                  |
| [`dba18804`](https://github.com/NixOS/nixpkgs/commit/dba1880435bc89da344342fe9a35741eece2d411) | `cargo-deadlinks: fix darwin and aarch64-linux test failures`                             |
| [`88cee8a3`](https://github.com/NixOS/nixpkgs/commit/88cee8a3d84c206a6558f024622732c146d64f1c) | `pytest-sanic: mark as broken`                                                            |
| [`e339edff`](https://github.com/NixOS/nixpkgs/commit/e339edff67c600203e1cf6346ef7c37319f8ad05) | `sanic: 21.3.4 -> 21.9.1`                                                                 |
| [`690c0136`](https://github.com/NixOS/nixpkgs/commit/690c0136ee63690a5dd0a62e7cc4456793c9de2c) | `sanic-routing: 0.6.2 -> 0.7.2`                                                           |
| [`e12f4db5`](https://github.com/NixOS/nixpkgs/commit/e12f4db55640401ff06749231a4f4ffcef9a7269) | `treewide: Fix unsafe concatenation of $LD_LIBRARY_PATH, round 2`                         |
| [`2b1b6105`](https://github.com/NixOS/nixpkgs/commit/2b1b6105830424ce5d4567e9ac95cf3205d588f7) | `hqplayerd: 4.26.2-69 -> 4.27.0-70`                                                       |
| [`8fff75df`](https://github.com/NixOS/nixpkgs/commit/8fff75df4987927a176ac76215444973cecf5fdb) | `mathlibtools: fix build`                                                                 |
| [`98749ffa`](https://github.com/NixOS/nixpkgs/commit/98749ffa5fbfcf733ef1d82f9e75791b644f233a) | `nixos/tests/wine: syntax fix`                                                            |
| [`47d8506f`](https://github.com/NixOS/nixpkgs/commit/47d8506f90c0b9fc9f015bba65fc873139094b69) | `kodi.packages.libretro-genplus: init at 1.7.4.31`                                        |
| [`e0cfb5db`](https://github.com/NixOS/nixpkgs/commit/e0cfb5db6767308dbe3f58122be2507b49782e10) | `lavalauncher: 2.0.0 -> 2.1.1, fix broken build`                                          |
| [`4825cb2c`](https://github.com/NixOS/nixpkgs/commit/4825cb2cb5cf099acd618856a5e46aa614bd3d1a) | `credslayer: remove failing tests, add missing runtime dependency`                        |
| [`beb78c94`](https://github.com/NixOS/nixpkgs/commit/beb78c946893ce5910bfe05e61351ff2dcb32c34) | `telepresence2: 2.4.0 -> 2.4.6`                                                           |
| [`b4fb63fa`](https://github.com/NixOS/nixpkgs/commit/b4fb63fa2bb65d2d07ab2dfafe4f532ec3360859) | `acsccid: Remove myself as maintainer`                                                    |
| [`a163ebf8`](https://github.com/NixOS/nixpkgs/commit/a163ebf80549767f66ff155cb86a77f9f8de974e) | `acsccid: Run nixpkgs-fmt`                                                                |
| [`7bffde6d`](https://github.com/NixOS/nixpkgs/commit/7bffde6dbc8900ac6b50ff653110674bcaad9343) | `docs: fix Rust language typos`                                                           |
| [`15491234`](https://github.com/NixOS/nixpkgs/commit/1549123435034220872ddf8e11edbad56b5cd9b3) | `thefuck: fix build on darwin`                                                            |
| [`80b0bf10`](https://github.com/NixOS/nixpkgs/commit/80b0bf1042e7f75d45f01e611bdf686646851f5c) | `teensyduino: 1.53 -> 1.55`                                                               |
| [`5c6c2600`](https://github.com/NixOS/nixpkgs/commit/5c6c2600baff67d12d34e4bcf9096fe0f97df452) | `arduino: 1.8.13 -> 1.8.16`                                                               |
| [`55f6d818`](https://github.com/NixOS/nixpkgs/commit/55f6d818ddf1490b481594483c23a794df1879d6) | `tox-node: add myself to maintainers`                                                     |
| [`076563eb`](https://github.com/NixOS/nixpkgs/commit/076563ebac229d5070b1148faf5a633bc3071804) | `sage: import sympy 1.9 update patch`                                                     |
| [`e2fe1f3f`](https://github.com/NixOS/nixpkgs/commit/e2fe1f3fd462eada34a18179e08b2cfe32c1c606) | `tox-node: fix build`                                                                     |
| [`23448e8b`](https://github.com/NixOS/nixpkgs/commit/23448e8bf2054a4d9b92e4986952214abc1c7804) | `eztrace: 1-1-7 -> 1.1-11, fix build, switch to fetchFromGitLab, refactor`                |
| [`11a2832d`](https://github.com/NixOS/nixpkgs/commit/11a2832dc5042910ed421f51c2c5f419b407042f) | `python3Packages.nassl: 4.0.0 -> 4.0.1`                                                   |
| [`9f8c7459`](https://github.com/NixOS/nixpkgs/commit/9f8c7459a7fcd2d24da15e6220ef4bd0c7182efa) | `python3Packages.tubeup: fix dependencies`                                                |
| [`d3610834`](https://github.com/NixOS/nixpkgs/commit/d3610834b9b8c92e626aa726dd94a132f46edf48) | `python3Packages.editdistance: fix broken version tag`                                    |
| [`6d892398`](https://github.com/NixOS/nixpkgs/commit/6d8923985704b1996b311fd946b983014ba2bae0) | `linuxKernel.kernels.linux_xanmod: 5.14.15 -> 5.14.16`                                    |
| [`a13bfe7f`](https://github.com/NixOS/nixpkgs/commit/a13bfe7fbc27bacd054ad08d6f840cf1e0acc3c8) | `roon-server: 1.8-831 -> 1.8-846`                                                         |
| [`661f05bc`](https://github.com/NixOS/nixpkgs/commit/661f05bc50bb9568d68a21424d30f50646fda4c7) | `btcpayserver: 1.3.1 -> 1.3.2`                                                            |
| [`73092d11`](https://github.com/NixOS/nixpkgs/commit/73092d11f66184650ca3c5b28c897867fdeabeb8) | `noto-fonts-emoji: fix stale source hash`                                                 |
| [`b4507131`](https://github.com/NixOS/nixpkgs/commit/b4507131ccd7e1e5b5895a3d8ed1b04a4fea4278) | `emacsPackages.sunrise-commander: 0.pre+unstable=2021-07-22 -> 0.pre+unstable=2021-09-27` |
| [`a0e6ae47`](https://github.com/NixOS/nixpkgs/commit/a0e6ae474a8fd54ddf2a5c2697f9393778b2646a) | `nongnu-packages 2021-11-04`                                                              |
| [`b66cd27f`](https://github.com/NixOS/nixpkgs/commit/b66cd27f16756a42b24a899d27b240f557dd7ffc) | `melpa-packages 2021-11-04`                                                               |
| [`ba6d8767`](https://github.com/NixOS/nixpkgs/commit/ba6d8767ac1df47aca7cdfed7a7e6b4306594521) | `manual fixup`                                                                            |
| [`74628ed4`](https://github.com/NixOS/nixpkgs/commit/74628ed4622486b6cb4f0e1b1398f3f396c7b232) | `elpa-packages 2021-11-04`                                                                |
| [`326cfefd`](https://github.com/NixOS/nixpkgs/commit/326cfefd68c6841c762fb77035e94e97d6e68d9d) | `Apply suggestions from code review`                                                      |
| [`b829fe48`](https://github.com/NixOS/nixpkgs/commit/b829fe48e36b326d8bcefda14475c2420a52e537) | `add an example with buildRustPackage`                                                    |
| [`8650a7e6`](https://github.com/NixOS/nixpkgs/commit/8650a7e6e1fdab6fcd3e4886bc6929677311f270) | `docs: improve, clean up Rust language advice`                                            |
| [`e04cc18f`](https://github.com/NixOS/nixpkgs/commit/e04cc18f18011471ffe0e693758bfcc0b4cf5393) | `find-tarballs.nix: Avoid all passthru attrs`                                             |
| [`49193f4a`](https://github.com/NixOS/nixpkgs/commit/49193f4ad3b5b0d25109848045ebd6c215ec7d5e) | `scala-cli: init at 0.0.7`                                                                |
| [`6f7bf9bb`](https://github.com/NixOS/nixpkgs/commit/6f7bf9bb0707f7b2bff0e6696dee0997d1229a57) | `maintainers: add kubukoz`                                                                |
| [`e76aa52b`](https://github.com/NixOS/nixpkgs/commit/e76aa52b2f4293526709b4d9b93fb5f2564d23ed) | `connmanMinimal: fix cross compilation`                                                   |
| [`6126a8de`](https://github.com/NixOS/nixpkgs/commit/6126a8de6704d5b889ad1f2bf5b8dc64909f8167) | `noto-fonts-emoji: 2.028 -> 2.034`                                                        |
| [`cfd196cb`](https://github.com/NixOS/nixpkgs/commit/cfd196cb8b0c2d47038d762e20152971982dff71) | `exploitdb: 2021-11-02 -> 2021-11-04`                                                     |
| [`d96ab39a`](https://github.com/NixOS/nixpkgs/commit/d96ab39a64fc01274022f00a9bcae3c2c195a3d3) | `arrow-cpp: refactor source fetching`                                                     |
| [`f12e976a`](https://github.com/NixOS/nixpkgs/commit/f12e976aded8113cb466efcdc2abc1932d9beb05) | `module/prometheus: optionally support reloading on config changes`                       |
| [`2012a63a`](https://github.com/NixOS/nixpkgs/commit/2012a63a7c14a26b3ddbac8dfdbc1e92dd9babec) | `python3Packages.velbus-aio: 2021.10.7 -> 2021.11.0`                                      |
| [`539431e6`](https://github.com/NixOS/nixpkgs/commit/539431e684e57a4f49ec00776fa58bc439a6ffa6) | `knot-dns: 3.1.3 -> 3.1.4`                                                                |
| [`3756460d`](https://github.com/NixOS/nixpkgs/commit/3756460dd08674db4a72b5f1e7e01cdaa9858f28) | `python3Packages.aiogithubapi: 21.8.1 -> 21.11.0`                                         |
| [`a2da109f`](https://github.com/NixOS/nixpkgs/commit/a2da109fab6c64549508226c2a8b9f8fbafc6d5f) | `slurm: 21.08.2.1 -> 21.08.3.1`                                                           |
| [`33c991cf`](https://github.com/NixOS/nixpkgs/commit/33c991cf656b8b37ee6afd3fde889dd4c86bb0e3) | `google-cloud-cpp: 0.14.0 -> 1.32.1`                                                      |
| [`f45b47d9`](https://github.com/NixOS/nixpkgs/commit/f45b47d972ba02a810a77ae2da5e1412ef7d4f9b) | `erlang: 24.1.3 -> 24.1.4`                                                                |
| [`58776b89`](https://github.com/NixOS/nixpkgs/commit/58776b89143b9e8cc52ae04c5c847ab6705235da) | `asciidoctor: 2.0.15 -> 2.0.16; darwin fix`                                               |
| [`e4214b4a`](https://github.com/NixOS/nixpkgs/commit/e4214b4a2d5373d629dfcb44345a2aee1a8ca49d) | `bitwig-studio: 4.0.1 -> 4.0.7`                                                           |
| [`0fbbb454`](https://github.com/NixOS/nixpkgs/commit/0fbbb454dd7290725a8bf675555abac6c622ef13) | `aws-c-mqtt: don't use ninja generator`                                                   |
| [`77dc8455`](https://github.com/NixOS/nixpkgs/commit/77dc8455c69f95a538edab862cfc3ee6f7be2c59) | `smplayer: 21.1.0 -> 21.10.0`                                                             |
| [`28bb9639`](https://github.com/NixOS/nixpkgs/commit/28bb96399f6fdfd5ca1703a47164f76e7629a34e) | `yggdrasil: 0.4.0 -> 0.4.2`                                                               |
| [`37d85bed`](https://github.com/NixOS/nixpkgs/commit/37d85bed1d030305bd9b9b06e5fa558547146e3c) | `bdf2psf: 1.205 -> 1.207`                                                                 |
| [`438367df`](https://github.com/NixOS/nixpkgs/commit/438367dfbabcd93f3841ebbc6f5ee356711b8385) | `plexamp: 3.7.1 -> 3.8.0`                                                                 |
| [`f64f106f`](https://github.com/NixOS/nixpkgs/commit/f64f106ff2bb07cf738d83b490e51d1499bac329) | `hydrus: 458 -> 460`                                                                      |
| [`1fa223ef`](https://github.com/NixOS/nixpkgs/commit/1fa223efce71fe052b2827cd3bf4104359eaedc3) | `python3Packages.simple-di: bring up to standard (#143306)`                               |
| [`e97b3010`](https://github.com/NixOS/nixpkgs/commit/e97b3010e51603b1c6f1764b7c6b89f9926360e0) | `python3Packages.flake8-length: init at 0.2.0 (#143305)`                                  |
| [`fef0cde6`](https://github.com/NixOS/nixpkgs/commit/fef0cde6c7358d376bb65df6532efab1b7514c07) | `py3c: 1.3.1 -> 1.4`                                                                      |
| [`4f7f702d`](https://github.com/NixOS/nixpkgs/commit/4f7f702d6eef43afb8272553779650222a46a25c) | `pt2-clone: 1.36 -> 1.37`                                                                 |
| [`9ee3139d`](https://github.com/NixOS/nixpkgs/commit/9ee3139d4ec9f6a1a846dbab510c4ff2a30099fa) | `clightning: 0.10.1 -> 0.10.2`                                                            |
| [`fea921d1`](https://github.com/NixOS/nixpkgs/commit/fea921d1b595055f01fff22b36d4c3b70c1032d7) | `python3Packages.mrkd: init at 0.2.0`                                                     |
| [`bbce1d9d`](https://github.com/NixOS/nixpkgs/commit/bbce1d9d60eec70181687745e3990766666bb7af) | `nixosTests.elk.ELK-6: Fix evaluation`                                                    |
| [`04a15518`](https://github.com/NixOS/nixpkgs/commit/04a15518c1a1fe06663e4d18d610ccd983c6fa6a) | `swaglyrics: 1.2.2 -> unstable-2021-06-17 and enable on darwin`                           |
| [`9a64bc2a`](https://github.com/NixOS/nixpkgs/commit/9a64bc2a11c312135d071ffb1f627e4e096e891e) | `python3Packages.swspotify: 1.2.1 -> 1.2.2 and fix build on darwin`                       |
| [`ff0434ec`](https://github.com/NixOS/nixpkgs/commit/ff0434ecfe02220815c694df55875e7e862391d4) | `noto-fonts-emoji-blob-bin: 2019-06-14-Emoji-12 -> 14.0.1`                                |
| [`9ed4634a`](https://github.com/NixOS/nixpkgs/commit/9ed4634a01502c0025edb5f3327c65ad86cb394d) | `pscale: 0.76.0 -> 0.85.0`                                                                |
| [`5876cfbe`](https://github.com/NixOS/nixpkgs/commit/5876cfbee5a698d99bd4af112760110d305d882d) | `home-assistant: 2021.10.7 -> 2021.11.0`                                                  |
| [`976307ad`](https://github.com/NixOS/nixpkgs/commit/976307adc323ee19992b848f3f8e374f1d51a443) | `praat: 6.1.53 -> 6.1.55`                                                                 |
| [`942fe94b`](https://github.com/NixOS/nixpkgs/commit/942fe94bc3c871713977690413aac26c5c42ebe0) | `bitwarden: 1.28.1 -> 1.29.1`                                                             |
| [`10362375`](https://github.com/NixOS/nixpkgs/commit/103623757c2c560d29038fa71b0b9d1e7dee6038) | `polkadot: 0.9.12 -> 0.9.12-1`                                                            |
| [`97372859`](https://github.com/NixOS/nixpkgs/commit/9737285976e8b2a3c5bd6f6e51174cb34ca61635) | `python3Packages.ha-av: init at 8.0.4rc1`                                                 |
| [`fdacbe54`](https://github.com/NixOS/nixpkgs/commit/fdacbe54949a00b61229ed30af3b8de14224e7f7) | `pistol: 0.2.1 -> 0.2.2`                                                                  |
| [`ec5455b7`](https://github.com/NixOS/nixpkgs/commit/ec5455b73e3f51163beabde785ef06cfd16bc952) | `pipes-rs: 1.4.5 -> 1.4.6`                                                                |
| [`34ceb864`](https://github.com/NixOS/nixpkgs/commit/34ceb8643cf376cc11a64c91bc3ea3bb452a1528) | `coreutils: drop upstreamed patch for armv7l`                                             |
| [`64566fdb`](https://github.com/NixOS/nixpkgs/commit/64566fdb7704fd1eff72b5939ad77aaf53c6e37d) | `nix-bundle: refactor`                                                                    |
| [`9199162d`](https://github.com/NixOS/nixpkgs/commit/9199162d63e87d6fcb5b3929e7d7f9d26aa8b4ab) | `plan9port: 2021-04-22 -> 0.pre+date=2021-10-19`                                          |
| [`49466be3`](https://github.com/NixOS/nixpkgs/commit/49466be320a4a791d4c448656965fc139f1fb66f) | `msr: init at 20060208`                                                                   |
| [`509a8c29`](https://github.com/NixOS/nixpkgs/commit/509a8c298f0ade52f558ee1ae185dd360ab3f674) | `picard-tools: 2.26.3 -> 2.26.4`                                                          |
| [`f432442f`](https://github.com/NixOS/nixpkgs/commit/f432442f1b44f973decf9d4c3865a16fac6698b5) | `pdfsam-basic: 4.2.6 -> 4.2.7`                                                            |
| [`37e57c37`](https://github.com/NixOS/nixpkgs/commit/37e57c37f535b495a916f75d706234b760ba8c25) | `python3Packages.awesomeversion: 21.8.1 -> 21.10.1`                                       |
| [`0c14a3a2`](https://github.com/NixOS/nixpkgs/commit/0c14a3a2cafa7daa6f136b060158a99d293e36dd) | `packer: 1.7.6 -> 1.7.8`                                                                  |
| [`bd0b227b`](https://github.com/NixOS/nixpkgs/commit/bd0b227bc91738d7aed435111c78b2ff8b54c5e6) | `go-mk: init at 0.pre+date=2015-03-24`                                                    |
| [`d3357931`](https://github.com/NixOS/nixpkgs/commit/d335793134be0cedf4bd5c4c07e82ae208c94a8d) | `otpauth: 0.3.5 -> 0.4.0`                                                                 |
| [`cd9b6253`](https://github.com/NixOS/nixpkgs/commit/cd9b62534639c7cb1283bab0ef3abc4716f82b2b) | `python3Packages.zha-quirks: 0.0.62 -> 0.0.63`                                            |
| [`14bd7d10`](https://github.com/NixOS/nixpkgs/commit/14bd7d10c1926276d6980e99f3bbd52eac3cb7c5) | `python3Packages.zeroconf: 0.36.9 -> 0.36.11`                                             |
| [`b51891bd`](https://github.com/NixOS/nixpkgs/commit/b51891bd554d60b62b3ea25d15673b2143e0b870) | `osqp: 0.6.0 -> 0.6.2`                                                                    |
| [`baae6b94`](https://github.com/NixOS/nixpkgs/commit/baae6b9448d042f439f2ca96761805cb52199731) | `python3Packages.xknx: 0.18.9 -> 0.18.12`                                                 |
| [`61e02931`](https://github.com/NixOS/nixpkgs/commit/61e029317c31cdaa05f9027035a47287fdcaf16c) | `python3Packages.spiderpy: 1.5.0 -> 1.7.1`                                                |
| [`6770dce6`](https://github.com/NixOS/nixpkgs/commit/6770dce64bc944f94289b71ebd8fded83fc3e18e) | `python3Packages.simplisafe-python: 12.0.2 -> 2021.10.0`                                  |
| [`e2e7970d`](https://github.com/NixOS/nixpkgs/commit/e2e7970d05984080f5ae97149ef3cb678c9d771b) | `python3Packages.pylitterbot: 2021.9.0 -> 2021.10.1`                                      |
| [`5b1f3801`](https://github.com/NixOS/nixpkgs/commit/5b1f3801bae844e416163775c9d97405ce23979a) | `python3Packages.pyefergy: 0.1.0 -> 0.1.3`                                                |
| [`be4ed875`](https://github.com/NixOS/nixpkgs/commit/be4ed875ed65b3c05a822b88efca5e34fe9e4da1) | `python3Packages.greeclimate: 0.12.1 -> 0.12.3`                                           |
| [`9b5a1d10`](https://github.com/NixOS/nixpkgs/commit/9b5a1d10f1d9b984b479a41e845c59cfb11b6b84) | `python3Packages.aioesphomeapi: 10.0.3 -> 10.2.0`                                         |
| [`790c5c3d`](https://github.com/NixOS/nixpkgs/commit/790c5c3dd80650df28c97dfe5e2e9f125e571fe4) | `python3Packages.aioambient: 1.3.0 -> 2021.10.1`                                          |
| [`76041cb7`](https://github.com/NixOS/nixpkgs/commit/76041cb768b0e0a31f91a73a081b6dbf804db732) | `mk: remove`                                                                              |
| [`5ba98dc9`](https://github.com/NixOS/nixpkgs/commit/5ba98dc97c0f102a1929e0083dbfe3d86dc96dff) | `or-tools: 9.0 -> 9.1`                                                                    |
| [`d3443cac`](https://github.com/NixOS/nixpkgs/commit/d3443cac943bb2b6030d096e73d0e7cca6b94b7e) | `openxr-loader: 1.0.19 -> 1.0.20`                                                         |
| [`3fefb905`](https://github.com/NixOS/nixpkgs/commit/3fefb905b2730815a1be80b261c3596ff924756d) | `tfsec: 0.58.14 -> 0.58.15`                                                               |
| [`8fed17e6`](https://github.com/NixOS/nixpkgs/commit/8fed17e682164d83bb3a50372034351b2fb37179) | `opensmt: 2.1.1 -> 2.2.0`                                                                 |
| [`3ceafa06`](https://github.com/NixOS/nixpkgs/commit/3ceafa063e4a5624d81ce964be88011ceb2e07a9) | `open-policy-agent: 0.33.1 -> 0.34.0`                                                     |
| [`8153c49e`](https://github.com/NixOS/nixpkgs/commit/8153c49e285eaf359870a0cc5493b52ab11874d3) | `mpv: 0.33.1 -> 0.34.0`                                                                   |
| [`e3e3c0fc`](https://github.com/NixOS/nixpkgs/commit/e3e3c0fcb807b207dc81a97d0b786dfbac46f239) | `oksh: 6.9 -> 7.0`                                                                        |
| [`c7043de5`](https://github.com/NixOS/nixpkgs/commit/c7043de51d0fa7f450f7cf4793c57600dc0e153d) | `PULL_REQUEST_TEMPLATE.md: ticks to bullets`                                              |
| [`d01a1a6d`](https://github.com/NixOS/nixpkgs/commit/d01a1a6ddbf81e60c53e5960a31ae7f442d00147) | `oapi-codegen: 1.8.2 -> 1.8.3`                                                            |
| [`0535a5b7`](https://github.com/NixOS/nixpkgs/commit/0535a5b7acf63780716a4442eea2875f4ee2b94f) | `kubernetes-helm: 3.7.0 -> 3.7.1`                                                         |
| [`ed7259c3`](https://github.com/NixOS/nixpkgs/commit/ed7259c3095d3abedc4ac76b76537ef33eaf624a) | `nwipe: 0.31 -> 0.32`                                                                     |
| [`60461a59`](https://github.com/NixOS/nixpkgs/commit/60461a594b1117da57d94da7f6eafba6b5d5aede) | `metals: 0.10.8 → 0.10.9`                                                                 |
| [`5fbeb790`](https://github.com/NixOS/nixpkgs/commit/5fbeb7902a53b9488f522454e3f46c19456c6601) | `nushell: 0.38.0 -> 0.39.0`                                                               |
| [`5caf1c3b`](https://github.com/NixOS/nixpkgs/commit/5caf1c3bd3935bcb067c534106182b2469aa96f5) | `kwin: add optional dependency libqaccessibilityclient`                                   |
| [`b7bdb154`](https://github.com/NixOS/nixpkgs/commit/b7bdb154f622f247039ad014f26590d680da7e90) | `libsForQt5.libqaccessibilityclient: init at 0.4.1`                                       |
| [`b525a5bb`](https://github.com/NixOS/nixpkgs/commit/b525a5bb3621a90d168cb2defd7d738016b46715) | `nms: 0.3.3 -> 1.0.1`                                                                     |
| [`c70a27d6`](https://github.com/NixOS/nixpkgs/commit/c70a27d607ed4927c47e39de2801e6ed3a2c5f7c) | `asl: fix the expression`                                                                 |
| [`973e5f8e`](https://github.com/NixOS/nixpkgs/commit/973e5f8e9ef38b96ecaccdca4b6d35aecdce3ffa) | `nfpm: 2.6.0 -> 2.7.1`                                                                    |