### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "86373221aeecaa9c398f1ce06e721a8ae0f363e8",
-        "sha256": "1xhlmpxm1dgx89m1swv6fclvd28z2fjdhwrk0di5vsyl1cq4zzq4",
+        "rev": "7c8883cf2d4570c525ad495995241850171a72a7",
+        "sha256": "1g7j9rz2gncykp46ap5cvx6v10ydvfs6xda8c0vgl0fwicikiv4m",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/86373221aeecaa9c398f1ce06e721a8ae0f363e8.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/7c8883cf2d4570c525ad495995241850171a72a7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                  |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`02a01828`](https://github.com/NixOS/nixpkgs/commit/02a01828c58cec2e2f0e66116abc330b94a26ed4) | `pkgsMusl.connmanMinimal: fix build with Alpine patch`                          |
| [`3097a434`](https://github.com/NixOS/nixpkgs/commit/3097a43496206a1364f3e61740990115e81a76ae) | `xmedcon: 0.21.0 -> 0.21.2`                                                     |
| [`0886f51b`](https://github.com/NixOS/nixpkgs/commit/0886f51b37faa7abdb71292c232f117b67f44e8b) | `xmedcon: fix meta.platforms`                                                   |
| [`7f2b8a3b`](https://github.com/NixOS/nixpkgs/commit/7f2b8a3beba0743485bffefffe517962009b28bc) | `azuredatastudio: 1.17.1 -> 1.33.0 (#143078)`                                   |
| [`aeb8fae6`](https://github.com/NixOS/nixpkgs/commit/aeb8fae646cc1ea725d4498fd7e0808470a19a7f) | `coqPackages.coqeal: 1.0.6 -> 1.1.0`                                            |
| [`ac4188fe`](https://github.com/NixOS/nixpkgs/commit/ac4188fe579f0c1f2121848771a372cc13200c8c) | `arrow-cpp: add flight feature flag (#144609)`                                  |
| [`0bbc0244`](https://github.com/NixOS/nixpkgs/commit/0bbc02446218acd49e65204b96636356e51b1e81) | `zerobin: fix build`                                                            |
| [`f3ff3fe3`](https://github.com/NixOS/nixpkgs/commit/f3ff3fe3dbb281d7bc9990b8501b7e98e344a780) | `eclipses.plugins: Add Apache ivyde, iyvderv, ivyant and ivy plugins (#142407)` |
| [`2f4214e7`](https://github.com/NixOS/nixpkgs/commit/2f4214e7dab1d40d04093f45e32774c4ed0bc8c5) | `prowlarr: 0.1.1.978 -> 0.1.1.1030`                                             |
| [`c0cc06c2`](https://github.com/NixOS/nixpkgs/commit/c0cc06c245fb150bdc87cd26dde3ba098742acb7) | `cargo-deny: don't vendor openssl, fix license`                                 |
| [`9876a8bc`](https://github.com/NixOS/nixpkgs/commit/9876a8bc4b23e2fbb8fe11707f7de56ac0a39829) | `selene: 0.14.0 -> 0.15.0`                                                      |
| [`d21e8452`](https://github.com/NixOS/nixpkgs/commit/d21e84526b9eef48c1e64be4db64bf3ccaa11afd) | `python3Packages.tern: add packageurl dependency`                               |
| [`c22dad59`](https://github.com/NixOS/nixpkgs/commit/c22dad59dcb74a9861ab29aea54c7aef8fa4688a) | `statix: 0.3.5 -> 0.3.6`                                                        |
| [`0f60c45e`](https://github.com/NixOS/nixpkgs/commit/0f60c45e9c577124dc371e442bdf5d91fc52d9dd) | `nixos/unifi: refactor mountpoints`                                             |
| [`c9ca5290`](https://github.com/NixOS/nixpkgs/commit/c9ca52906639a31e446750e44eacbf99c1e23dac) | `google-cloud-cpp: add comment about doInstallCheck and dependencies`           |
| [`2db4ece3`](https://github.com/NixOS/nixpkgs/commit/2db4ece355770e3b1305ba99bc2459cf9b35034f) | `google-cloud-cpp: add unit tests`                                              |
| [`34913fa4`](https://github.com/NixOS/nixpkgs/commit/34913fa4e80198f4d3465379514431e77589db12) | `btcpayserver: 1.3.2 -> 1.3.3`                                                  |
| [`59225eba`](https://github.com/NixOS/nixpkgs/commit/59225ebaf1f52988964cae3e8a6db1a85cec8158) | `deluge: fix test (#144718)`                                                    |
| [`274df1ce`](https://github.com/NixOS/nixpkgs/commit/274df1ce2871370ce52506e37ec4d240a82b1101) | `nudoku: pull upstream fix for upcoming ncurses-6.3`                            |
| [`b680de77`](https://github.com/NixOS/nixpkgs/commit/b680de7700279a06546eec0df52ae2e193cf911f) | `dovecot_fts_xapian: 1.4.11 -> 1.4.14`                                          |
| [`5f1860b5`](https://github.com/NixOS/nixpkgs/commit/5f1860b53a2075e6dc3b698df62bb4093af9136d) | `python3Packages.pymazda: 0.2.2 -> 0.3.0`                                       |
| [`0278e1e2`](https://github.com/NixOS/nixpkgs/commit/0278e1e297b9862919a66aab312cb1567a1e863d) | `ngrep: Make available on darwin`                                               |
| [`11ba3c1b`](https://github.com/NixOS/nixpkgs/commit/11ba3c1b87f555793fd038a12636461a7cbb11b6) | `python3Packages.qcs-api-client: 0.14.0 -> 0.15.0`                              |
| [`65b34026`](https://github.com/NixOS/nixpkgs/commit/65b34026ba3076e19e19ddb1f66534d442bb8a1e) | `awscli2: 2.2.40 -> 2.3.4`                                                      |
| [`6879dc1e`](https://github.com/NixOS/nixpkgs/commit/6879dc1ece6fdae31edb5467b3a73a9c7b237d2c) | `python3Packages.flux-led: 0.24.12 -> 0.24.14`                                  |
| [`10d8fd24`](https://github.com/NixOS/nixpkgs/commit/10d8fd24c5d72991480c5c09a8d357c07d395755) | `python3Packages.aiopvpc: 2.2.1 -> 2.2.2`                                       |
| [`6cc0ebae`](https://github.com/NixOS/nixpkgs/commit/6cc0ebae3a93a5c8555e22da03860d6d4c313821) | `python3Packages.holidays: 0.11.1 -> 0.11.3.1`                                  |
| [`316dee01`](https://github.com/NixOS/nixpkgs/commit/316dee019773144e26dcf333cfe67638bca28577) | `hyper-haskell: mark broken`                                                    |
| [`9bd3a51b`](https://github.com/NixOS/nixpkgs/commit/9bd3a51bbacf7e612324750c500aee3df29fd165) | `nixos/tests/owncast: rewrite test`                                             |
| [`f92b0841`](https://github.com/NixOS/nixpkgs/commit/f92b08416d2fce4e61c5c32412962957537d720b) | `haskellPackages: mark builds failing on hydra as broken`                       |
| [`d9f35415`](https://github.com/NixOS/nixpkgs/commit/d9f354156967a434980795b6f1a58bb8253908de) | `picom-next: add GKasparov to maintainer-list`                                  |
| [`a3aaebc3`](https://github.com/NixOS/nixpkgs/commit/a3aaebc3006d838bbb51b24541fa12ed82576d65) | `picom-next: init at unstable-2021-10-31`                                       |
| [`03daab72`](https://github.com/NixOS/nixpkgs/commit/03daab729e9c694131ad8d3effa1b80b462b04ef) | `perlPackages.XMLLibXML: fix build on darwin`                                   |
| [`72ab5cbf`](https://github.com/NixOS/nixpkgs/commit/72ab5cbf6963be0dd20aefbe42a7bd025f7b2cb2) | `tree-sitter: fix eval`                                                         |
| [`57225575`](https://github.com/NixOS/nixpkgs/commit/57225575dfa9f3630ba495a9fa9c57b576a23dff) | `nixos/hadoop: fix errors in HTTPFS`                                            |
| [`8331b567`](https://github.com/NixOS/nixpkgs/commit/8331b56701d6df0140345e17a8ae4ac8240f33f9) | `nixos/hadoop: correct openFirewall options`                                    |
| [`c8df915e`](https://github.com/NixOS/nixpkgs/commit/c8df915e0e4b19364038a03d2a5203bf4805c9ff) | `nixos/hadoop: add links for config files`                                      |
| [`74551fd1`](https://github.com/NixOS/nixpkgs/commit/74551fd199c46c0662aafb61e8f32e125302fd86) | `snapmaker-luban: init at 4.0.3`                                                |
| [`0bd4b60a`](https://github.com/NixOS/nixpkgs/commit/0bd4b60a42a84dab321ee6ca61ff3bcf2d27e9fd) | `nixos/hadoop: release notes`                                                   |
| [`42e14ff6`](https://github.com/NixOS/nixpkgs/commit/42e14ff69ff52c74f5ccbb37b7954ef4dea7bf5a) | `nixos/hadoop: replace enable = mkoption bools with mkEnableOption`             |
| [`c3d147f5`](https://github.com/NixOS/nixpkgs/commit/c3d147f507e81455ae467f8aa589972af3449f77) | `nixos/hadoop: replace "enabled" options with "enable" options`                 |
| [`9ca43631`](https://github.com/NixOS/nixpkgs/commit/9ca4363191f05147d0bd23ffb61838d9c1ee890e) | `nixos/hadoop: add HTTPFS`                                                      |
| [`39c007ce`](https://github.com/NixOS/nixpkgs/commit/39c007ce9cc3f46db70bde794323b6cbfccfe62a) | `nixos/hadoop: Add HA capabilities`                                             |
| [`aefde7c0`](https://github.com/NixOS/nixpkgs/commit/aefde7c02ad52936ddea6bdfe66537625fd859ad) | `v2ray-domain-list-community: init at 20211103073737`                           |
| [`cec5b71b`](https://github.com/NixOS/nixpkgs/commit/cec5b71b7ee828f89bf39f25be44c75e1187e3fc) | `kora-icon-theme: 1.4.5 -> 1.4.7`                                               |
| [`e4691108`](https://github.com/NixOS/nixpkgs/commit/e4691108473e526d37aaada5ee66446692fcd01d) | `haskell.packages.ghc921.tf-random: work around aarch64 decoding bug`           |
| [`1d4787f1`](https://github.com/NixOS/nixpkgs/commit/1d4787f14d264da8d18bc247facaf89d3511a56e) | `haskell.compiler.ghc921: 9.2.0.20210821 -> 9.2.1`                              |
| [`66529c5f`](https://github.com/NixOS/nixpkgs/commit/66529c5f40fd5eef86dd33f6583acaaeda896cf5) | `sparse: 0.6.3 -> 0.6.4`                                                        |
| [`a8d21813`](https://github.com/NixOS/nixpkgs/commit/a8d21813179e32d8e8f3880c6d311de5573ed5fb) | `haskellPackages: update diagrams-related packages to latest hackage`           |
| [`f7ce5752`](https://github.com/NixOS/nixpkgs/commit/f7ce5752d7dd8272050590c1d3d6594ae30f45d7) | `haskellPackages.Chart-tests: fix override`                                     |
| [`5d53087f`](https://github.com/NixOS/nixpkgs/commit/5d53087f9b96919eb2175bf44d5669575e24e2f6) | `haskellPackages.callCabal2nixWithOptions: don't guess cabal filename`          |
| [`cc0ac2c9`](https://github.com/NixOS/nixpkgs/commit/cc0ac2c9d43886a16ef637e9b4811f961e0186d7) | `cisco-packet-tracer: init at 7.3.1 and 8.0.1`                                  |
| [`a561e73b`](https://github.com/NixOS/nixpkgs/commit/a561e73b9e64752f87c328a561f3ba08540494ac) | `haskellPackages.matterhorn: provide up to date brick`                          |
| [`e3bca385`](https://github.com/NixOS/nixpkgs/commit/e3bca38518f3a962f94ed7caa6af8d77801cbf0e) | `haskellPackages.tasty-checklist: unbreak`                                      |
| [`a0029f0b`](https://github.com/NixOS/nixpkgs/commit/a0029f0b02ddb1ae97924563eebf9040fe48003c) | `haskellPackages.idris: remove patches included in new release`                 |
| [`742d75c5`](https://github.com/NixOS/nixpkgs/commit/742d75c5bcd587ba0ac2a4c01e16b0872b743b89) | `ghcjs: remove duplicate vector patch`                                          |
| [`46a23e81`](https://github.com/NixOS/nixpkgs/commit/46a23e81f3d2cc95f32c2527739d063eb218a595) | `haskellPackages.hw-prim-bits: unbreak`                                         |
| [`595b25ed`](https://github.com/NixOS/nixpkgs/commit/595b25ed53a824633a0159da98e4b0137baec705) | `haskellPackages.diagrams-canvas: unbreak`                                      |
| [`4b7c62ff`](https://github.com/NixOS/nixpkgs/commit/4b7c62ffc328fc683b31963a97ceaf9c462c2307) | `haskellPackages.aeson-via: unbreak`                                            |
| [`3478ac5c`](https://github.com/NixOS/nixpkgs/commit/3478ac5c5ba30b841cb8096d314c01fa553b19a3) | `haskellPackages.lua: fix install phase`                                        |
| [`30e8984d`](https://github.com/NixOS/nixpkgs/commit/30e8984d31b9311ca226a16ed757f43dd0177fcd) | `haskellPackages: regenerate package set based on current config`               |
| [`b65bb811`](https://github.com/NixOS/nixpkgs/commit/b65bb811cf7777d7c64491f2bf2611c1e6e6efc4) | `all-cabal-hashes: 2021-10-18T14:27:09Z -> 2021-10-23T04:57:02Z`                |
| [`1da3fa5b`](https://github.com/NixOS/nixpkgs/commit/1da3fa5b78e3d574a1754d84f21cc418648c75b2) | `haskellPackages.cabal2nix-unstable: 2021-09-28 -> 2021-10-23`                  |
| [`bd0e2e52`](https://github.com/NixOS/nixpkgs/commit/bd0e2e52e44ae07a3f470d0fda72476c0adc5613) | `haskellPackages.bytestring-trie: unbreak`                                      |
| [`59a7fb27`](https://github.com/NixOS/nixpkgs/commit/59a7fb27a166717d2765411fc04c7deedfe18882) | `nvidia: install egl wayland gbm support`                                       |
| [`7761e237`](https://github.com/NixOS/nixpkgs/commit/7761e2378570a2f4c9ddc0b75b6cca052667b7b5) | `nvidia: add wayland to nvidia-egl-wayland libpath`                             |
| [`216dd5b7`](https://github.com/NixOS/nixpkgs/commit/216dd5b740f91f4250e33256e3c11e4e342895ce) | `nvidia: fix egl-wayland loading`                                               |
| [`60369bb3`](https://github.com/NixOS/nixpkgs/commit/60369bb333534d0cfcfe7bd34958b5a95739a60a) | `nixos/vmware-guest: fix headless option`                                       |
| [`613a0bff`](https://github.com/NixOS/nixpkgs/commit/613a0bffcdc5189ef53ef2c4ed5550d9ac362f48) | `openssl: openssl3 is published under Apache License v2.0`                      |
| [`0db4ebbf`](https://github.com/NixOS/nixpkgs/commit/0db4ebbf1f3187b12c44f78a363dff79ca344aad) | `openssl3: disable build-time feature detection`                                |
| [`7f25b31f`](https://github.com/NixOS/nixpkgs/commit/7f25b31f07c3b4cbbefad89377318f014611a2e8) | `openssl3: init at 3.0.0`                                                       |