### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7c8883cf2d4570c525ad495995241850171a72a7",
-        "sha256": "1g7j9rz2gncykp46ap5cvx6v10ydvfs6xda8c0vgl0fwicikiv4m",
+        "rev": "0d5b4445e33b1cd666b107bbdf5920884bbaeb1a",
+        "sha256": "0zn4n4srkb7538q4nqckhvdj3nnzwamrp381bip0wk31710gyqs7",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/7c8883cf2d4570c525ad495995241850171a72a7.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/0d5b4445e33b1cd666b107bbdf5920884bbaeb1a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixus": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                               |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`4d821295`](https://github.com/NixOS/nixpkgs/commit/4d821295f132630956e9def11fcb7bb843f4da69) | `dhall-grafana: init at 0.1. (#144826)`                                      |
| [`f3decfa7`](https://github.com/NixOS/nixpkgs/commit/f3decfa7da519290e61c06fb029bfc8ff0ce4147) | `octofetch: init at 0.3.1`                                                   |
| [`3f9f6c91`](https://github.com/NixOS/nixpkgs/commit/3f9f6c91bd3ef6b7bd5d4105b0d4bc93fb30fdc2) | `maintainers: add jyooru`                                                    |
| [`02dfbde6`](https://github.com/NixOS/nixpkgs/commit/02dfbde63938f077e21d7880781132ea141b0b21) | `treewide: use mirror URLs where available`                                  |
| [`4419e8ee`](https://github.com/NixOS/nixpkgs/commit/4419e8ee8eb76bc11b629069e2a5215503d7b1c9) | `mirrors: prioritize HTTPS`                                                  |
| [`1b78d372`](https://github.com/NixOS/nixpkgs/commit/1b78d3720cc7f05c230741795e1ddee99c016b98) | `mirrors: use HTTPS where available`                                         |
| [`246d34d5`](https://github.com/NixOS/nixpkgs/commit/246d34d57ad3c1842705ec371609da3ebc21e728) | `mirrors: remove inactive mirrors`                                           |
| [`9c705966`](https://github.com/NixOS/nixpkgs/commit/9c70596689599cfbe28602db26b346e9092024c6) | `mirrors: update sunet base URLs`                                            |
| [`88e646ef`](https://github.com/NixOS/nixpkgs/commit/88e646ef28ae1fdc29351b0b172858620edb0d24) | `python3Packages.pyppeteer: relax websockets constrain`                      |
| [`2f5a4daf`](https://github.com/NixOS/nixpkgs/commit/2f5a4daf0c830380a54d9d35da4f79f20b5f9794) | `python3Packages.parfive: disable on older Python releases`                  |
| [`2f121361`](https://github.com/NixOS/nixpkgs/commit/2f121361da67d677f6f3f5dcc7e61ee8be4e2e5e) | `geopandas: 0.9.0 -> 0.10.2; fix check`                                      |
| [`3ffe9fed`](https://github.com/NixOS/nixpkgs/commit/3ffe9fed00db98160e74960593a16e863b36626b) | `libsForQt5.applet-window-buttons: 0.9.0 -> 0.10.1`                          |
| [`678cf220`](https://github.com/NixOS/nixpkgs/commit/678cf220a78fd3beb3a8725293812c9f3f81a76e) | `python3Packages.radio_beam: fix version detection by adding setuptools-scm` |
| [`d6598567`](https://github.com/NixOS/nixpkgs/commit/d65985674794acc54dce4052239686cf8784d496) | `nixosTests.service-runner: Redirect stdout to avoid blocking`               |
| [`1927b719`](https://github.com/NixOS/nixpkgs/commit/1927b71928f8f9420c2df48222a1b6808251b4e1) | `nixosTests.xfce: Redirect stdout to avoid blocking`                         |
| [`0fb80630`](https://github.com/NixOS/nixpkgs/commit/0fb806301dd627c7eb342658796da1a8c9ba586e) | `nixosTests.pantheon: Redirect stdout to avoid blocking`                     |
| [`edc67d38`](https://github.com/NixOS/nixpkgs/commit/edc67d3862c242b254e3eff0b61bd5cef989e4d1) | `nixosTests.chromium: Redirect stdout to avoid blocking`                     |
| [`d747e78e`](https://github.com/NixOS/nixpkgs/commit/d747e78e5210824dae78e158b67f2f61f9b43cd4) | `python38Packages.subprocess-tee: test_molecule disabled`                    |
| [`5fc42890`](https://github.com/NixOS/nixpkgs/commit/5fc42890c93405cc7ea98e8d6cd514b970a492ed) | `python3Packages.aioguardian: 2021.10.0 -> 2021.11.0`                        |
| [`19de3a7c`](https://github.com/NixOS/nixpkgs/commit/19de3a7c5bbc6e12edcebc6d27d46be8a41c561d) | `thonny: add desktop item`                                                   |
| [`cf0dfe4c`](https://github.com/NixOS/nixpkgs/commit/cf0dfe4c7e6ac3ed585fed0f12bd50a3dbea7549) | `dduper: update btrfs-progs patch`                                           |
| [`571c4e73`](https://github.com/NixOS/nixpkgs/commit/571c4e73e1211579a029d9b06dac164eff274dea) | `OVMF: disable LTO on i686`                                                  |
| [`b9bf35b0`](https://github.com/NixOS/nixpkgs/commit/b9bf35b065a29d06c73b8354c230e38c92b76f51) | `sshfs: add 'meta.mainProgram'`                                              |
| [`a123ab3a`](https://github.com/NixOS/nixpkgs/commit/a123ab3a7229bdf05a456e663a6d5469ecff04eb) | `tonelib-zoom: fix meta.platforms`                                           |
| [`d78a7264`](https://github.com/NixOS/nixpkgs/commit/d78a7264c6b4892062f4561d7e9881a60eafdff9) | `tonelib-jam: fix meta.platforms`                                            |
| [`39ce7a8a`](https://github.com/NixOS/nixpkgs/commit/39ce7a8afc6f81cafcf832896399dcdd21b4dbd6) | `unpfs: unstable-2019-05-17 -> unstable-2021-05-23`                          |
| [`e747e23a`](https://github.com/NixOS/nixpkgs/commit/e747e23ab5362cbf5bf09982db09a38320cba0d4) | `lxqt.screengrab: 2.2.0 -> 2.3.0`                                            |
| [`5330d479`](https://github.com/NixOS/nixpkgs/commit/5330d479fb11029b29996f08a46d3ecfbed0fcb7) | `lxqt.qtermwidget: 0.17.0 -> 1.0.0`                                          |
| [`d567162b`](https://github.com/NixOS/nixpkgs/commit/d567162b83f8535efa5a3a48dc18f1b308ccbbe2) | `lxqt.qterminal: 0.17.0 -> 1.0.0`                                            |
| [`0cdf5e76`](https://github.com/NixOS/nixpkgs/commit/0cdf5e76efa025676926da80d87380d6aad60a47) | `lxqt.qps: 2.3.0 -> 2.4.0`                                                   |
| [`2978c38b`](https://github.com/NixOS/nixpkgs/commit/2978c38b76229c66bd18d645e6fb0fa568bd6ed3) | `lxqt.pcmanfm-qt: 0.17.0 -> 1.0.0`                                           |
| [`3594a560`](https://github.com/NixOS/nixpkgs/commit/3594a5609e8921490006fca4012249b8ebace29d) | `lxqt.pavucontrol-qt: 0.17.0 -> 1.0.0`                                       |
| [`f9b30c8e`](https://github.com/NixOS/nixpkgs/commit/f9b30c8ec17285004790f300407c5244f6a93f9b) | `lxqt.lxqt-themes: 0.17.0 -> 1.0.0`                                          |
| [`6c663b5d`](https://github.com/NixOS/nixpkgs/commit/6c663b5ded4942f3fe0196dcb7c3ed28e986fd18) | `lxqt.lxqt-sudo: 0.17.0 -> 1.0.0`                                            |
| [`a2d0e6f2`](https://github.com/NixOS/nixpkgs/commit/a2d0e6f21df56237e5a9459f0fdbcf8cca2cda8f) | `lxqt.lxqt-session: 0.17.1 -> 1.0.0`                                         |
| [`c25eecbc`](https://github.com/NixOS/nixpkgs/commit/c25eecbc7fc9b8a2bc9da8eb999ec04c173705d2) | `lxqt.lxqt-runner: 0.17.0 -> 1.0.0`                                          |
| [`7dffac8c`](https://github.com/NixOS/nixpkgs/commit/7dffac8c319566103eca275173aedfb81ee34c53) | `lxqt.lxqt-qtplugin: 0.17.0 -> 1.0.0`                                        |
| [`6d259c6f`](https://github.com/NixOS/nixpkgs/commit/6d259c6f9b01b16d98da3a19b53322cc51204036) | `lxqt.lxqt-powermanagement: 0.17.1 -> 1.0.0`                                 |
| [`ae441e02`](https://github.com/NixOS/nixpkgs/commit/ae441e02c968500af84e105a515682811f115f06) | `lxqt.lxqt-policykit: 0.17.0 -> 1.0.0`                                       |
| [`5355df22`](https://github.com/NixOS/nixpkgs/commit/5355df22fc88a06499a0080cbb6dc4c747fc7ab1) | `lxqt.lxqt-panel: 0.17.1 -> 1.0.0`                                           |
| [`50d4a94f`](https://github.com/NixOS/nixpkgs/commit/50d4a94f5b21db5066c2da063b8b0b133bfc74bb) | `lxqt.lxqt-openssh-askpass: 0.17.0 -> 1.0.0`                                 |
| [`b90a227f`](https://github.com/NixOS/nixpkgs/commit/b90a227fa08bc20fca607ea243088753eee8ad4c) | `lxqt.lxqt-notificationd: 0.17.0 -> 1.0.0`                                   |
| [`0704a1b7`](https://github.com/NixOS/nixpkgs/commit/0704a1b7dd4e0bc564f5798ad32b3dfb5eeaeca9) | `lxqt.lxqt-globalkeys: 0.17.0 -> 1.0.0`                                      |
| [`a3691418`](https://github.com/NixOS/nixpkgs/commit/a36914185c22f75023ede7495cda50cf7c427cd6) | `lxqt.lxqt-config: 0.17.1 -> 1.0.0`                                          |
| [`ee351ee2`](https://github.com/NixOS/nixpkgs/commit/ee351ee2b6d42436e882cebb1856b49bfccfddfd) | `lxqt.lxqt-build-tools: 0.9.0 -> 0.10.0`                                     |
| [`36fa8922`](https://github.com/NixOS/nixpkgs/commit/36fa89224b4a73cf1f340c771df82906c6cc1776) | `lxqt.lxqt-archiver: 0.4.0 -> 0.5.0`                                         |
| [`55e3c0b8`](https://github.com/NixOS/nixpkgs/commit/55e3c0b805b5cc40051e8c74e2111d9e5d65941e) | `lxqt.lxqt-admin: 0.17.0 -> 1.0.0`                                           |
| [`bea015ce`](https://github.com/NixOS/nixpkgs/commit/bea015ce3371ef81ead983ae99fcb41a0d5c088d) | `lxqt.lxqt-about: 0.17.0 -> 1.0.0`                                           |
| [`46e51d7c`](https://github.com/NixOS/nixpkgs/commit/46e51d7c9f3f367f4ce1f1b6598549b94aed7325) | `lxqt.lximage-qt: 0.17.0 -> 1.0.0`                                           |
| [`4f2caec0`](https://github.com/NixOS/nixpkgs/commit/4f2caec03d2653352a9dbb7bf26a082df82c2eb6) | `lxqt.libsysstat: 0.4.5 -> 0.4.6`                                            |
| [`60e363a6`](https://github.com/NixOS/nixpkgs/commit/60e363a600ecae1a39f6f4799eb028a90da17ca4) | `lxqt.libfm-qt: 0.17.1 -> 1.0.0`                                             |
| [`37f82f74`](https://github.com/NixOS/nixpkgs/commit/37f82f743c296c88ddb3047026b82ea228e37eaa) | `lxqt.libqtxdg: 3.7.1 -> 3.8.0`                                              |
| [`71666d92`](https://github.com/NixOS/nixpkgs/commit/71666d92dcf8763c4a99ee2966975f627ddb4c8c) | `lxqt.liblxqt: 0.17.0 -> 1.0.0`                                              |
| [`5564761e`](https://github.com/NixOS/nixpkgs/commit/5564761e1e12083b88e60d0f034337a5ed0ee719) | `linux/hardened/patches/5.4: 5.4.155-hardened1 -> 5.4.157-hardened1`         |
| [`ac295866`](https://github.com/NixOS/nixpkgs/commit/ac2958663880515705c7384c71c35a2e1668108a) | `linux/hardened/patches/5.14: 5.14.14-hardened1 -> 5.14.16-hardened1`        |
| [`0b37e93d`](https://github.com/NixOS/nixpkgs/commit/0b37e93d6be273b3cef6021af1a893e0e08d218e) | `linux/hardened/patches/5.10: 5.10.75-hardened1 -> 5.10.77-hardened1`        |
| [`d4efdd46`](https://github.com/NixOS/nixpkgs/commit/d4efdd46c7b95fefb687c3f30d130e184cacc203) | `linux/hardened/patches/4.19: 4.19.213-hardened1 -> 4.19.215-hardened1`      |
| [`6cbce224`](https://github.com/NixOS/nixpkgs/commit/6cbce224796caabc7762d703f8ae2a6e995c7d11) | `linux/hardened/patches/4.14: 4.14.252-hardened1 -> 4.14.254-hardened1`      |
| [`962be21e`](https://github.com/NixOS/nixpkgs/commit/962be21e1db369e6c6c7e4731df6d095dbc216d6) | `linux_latest-libre: 18413 -> 18452`                                         |
| [`a2dd7acd`](https://github.com/NixOS/nixpkgs/commit/a2dd7acdd8e50c7632d6a4da821968ee507a7d6e) | `linux: 5.4.156 -> 5.4.157`                                                  |
| [`104950ba`](https://github.com/NixOS/nixpkgs/commit/104950bafddf4da4c6c6afd6d95ca96ffafe065b) | `linux: 5.14.15 -> 5.14.16`                                                  |
| [`4deb3cf7`](https://github.com/NixOS/nixpkgs/commit/4deb3cf76a6b754ab624f4ab989230c02dfd5328) | `linux: 5.10.76 -> 5.10.77`                                                  |
| [`5cab1474`](https://github.com/NixOS/nixpkgs/commit/5cab1474d9be130cc83a5cb3c1f0eaa54fac30ff) | `linux: 4.9.288 -> 4.9.289`                                                  |
| [`6292af0d`](https://github.com/NixOS/nixpkgs/commit/6292af0d46c92b1ce236217e32c1e7d5368d13c8) | `linux: 4.4.290 -> 4.4.291`                                                  |
| [`c1f9eef4`](https://github.com/NixOS/nixpkgs/commit/c1f9eef4bc264828fb80cd04e9cd38e86a66d529) | `linux: 4.19.214 -> 4.19.215`                                                |
| [`6ad7cc43`](https://github.com/NixOS/nixpkgs/commit/6ad7cc432340d1ec34d20a8c19ef6ff3a85a9ad4) | `linux: 4.14.253 -> 4.14.254`                                                |
| [`caeab83b`](https://github.com/NixOS/nixpkgs/commit/caeab83ba452364c88f3940f2a3828fa8f13e0fe) | `perlPackages.DateTimeFormatRFC3339: init at 1.2.0`                          |
| [`46b83564`](https://github.com/NixOS/nixpkgs/commit/46b83564550c18ef139a56281687e8cb533d3329) | `rustracer: 2.1.46 -> 2.1.48, mark as broken`                                |
| [`67d07273`](https://github.com/NixOS/nixpkgs/commit/67d0727336181c82907a2f3a22ea97bf56e8b456) | `arrow-cpp: add S3 feature flag`                                             |
| [`81797521`](https://github.com/NixOS/nixpkgs/commit/81797521afa774fb934c15ebdf31fb3cf3e3c47e) | `ocamlPackages.merlin: fix tests on darwin`                                  |
| [`ebaa823a`](https://github.com/NixOS/nixpkgs/commit/ebaa823afd14dca1cb3f6a3a2f0eacf62dd9ac00) | `jami-daemon.ffmpeg: mark as broken for aarch64`                             |
| [`a26830f3`](https://github.com/NixOS/nixpkgs/commit/a26830f3aa56208d8146776065761358eb7c245a) | `cargo-modules: 0.5.0 -> 0.5.6, fix darwin build`                            |
| [`61ef4e45`](https://github.com/NixOS/nixpkgs/commit/61ef4e45994d28f1b2cba50cbfd43a082818869b) | `exploitdb: 2021-11-04 -> 2021-11-05`                                        |
| [`933f117a`](https://github.com/NixOS/nixpkgs/commit/933f117a78af47116a64f3faa71c2264f602c8d7) | `docs: Rust language section consistency`                                    |
| [`25ea2449`](https://github.com/NixOS/nixpkgs/commit/25ea24497b629b7335cb7844e925d196e9d76474) | `jami-client-gnome: unset CLUTTER_BACKEND`                                   |
| [`ffa6cb97`](https://github.com/NixOS/nixpkgs/commit/ffa6cb97ff76a25489e83ba409e4a0c7dbbfd93c) | `nginxMainline: use openssl_3_0`                                             |
| [`16873acd`](https://github.com/NixOS/nixpkgs/commit/16873acde8b421eda63a529333753071d7c17b31) | `nginxMainline: 1.21.3 -> 1.21.4`                                            |
| [`6220ede0`](https://github.com/NixOS/nixpkgs/commit/6220ede0457ef353b10d8f0183ebc5c914e3682d) | `HDF5Array: fix build`                                                       |
| [`fcba9f70`](https://github.com/NixOS/nixpkgs/commit/fcba9f709653bf7a71f9543a999990e730325de7) | `sumneko-lua-language-server: 2.4.5 -> 2.4.7`                                |
| [`1889cedd`](https://github.com/NixOS/nixpkgs/commit/1889cedd0af3439c249bd049c5e772be02fe7e76) | `crun: 1.2 -> 1.3`                                                           |
| [`1f6a7796`](https://github.com/NixOS/nixpkgs/commit/1f6a7796fa2cc6c2821bcea928a4410a78f84597) | `skopeo: 1.5.0 -> 1.5.1`                                                     |
| [`609c79f5`](https://github.com/NixOS/nixpkgs/commit/609c79f5861472cbd1aefce5d34136fe9cc7f361) | `cargo-spellcheck: fix build on darwin`                                      |
| [`68a8b278`](https://github.com/NixOS/nixpkgs/commit/68a8b278c16b9359a71faa45d3ba583e20957474) | `anup: fix build on darwin`                                                  |
| [`1b5d156f`](https://github.com/NixOS/nixpkgs/commit/1b5d156f833a9ad61492efa6d4713219e73da103) | `python3Packages.identify: 2.3.1 -> 2.3.3`                                   |
| [`eba0510e`](https://github.com/NixOS/nixpkgs/commit/eba0510e180cfc885dac3b211dc14ba5ab5e3de5) | `netcoredbg: init at 1.2.0-825`                                              |
| [`e9c11edd`](https://github.com/NixOS/nixpkgs/commit/e9c11eddbe86a59293e438e45127fa91b71454a4) | `zabbix.agent2: update vendorSha256`                                         |
| [`d2229386`](https://github.com/NixOS/nixpkgs/commit/d222938650f24f8f34145b87ed8b61a49f4211df) | `qemu: add upstream patches for qemu-6.1.0 regressions`                      |
| [`8b9d12e3`](https://github.com/NixOS/nixpkgs/commit/8b9d12e3fa2bc75d57d9275ca83ad192794b7d50) | `glog: Simpler approach to fix tests.`                                       |
| [`197b5f2e`](https://github.com/NixOS/nixpkgs/commit/197b5f2ec37c50b213b4729f0bc993d85974e934) | `glog: 0.4.0 -> 0.5.0, also enable tests`                                    |
| [`bdc92788`](https://github.com/NixOS/nixpkgs/commit/bdc92788abb950da7cf47ae85ca2e1c7054dea31) | `glog: Add nh2 and r-burns as maintainers`                                   |
| [`f709048c`](https://github.com/NixOS/nixpkgs/commit/f709048c36c52cdbe8b777a8e819fb4e8044f671) | `pwncat: 0.1.1 -> 0.1.2`                                                     |
| [`ddac912c`](https://github.com/NixOS/nixpkgs/commit/ddac912cf72f2aa18f298547ad92a9dccd6b9144) | `python3Packages.vcver: 0.2.10 -> 0.2.12`                                    |
| [`d776647e`](https://github.com/NixOS/nixpkgs/commit/d776647e22bd82b94f1ddebff65a86a4acaf96f1) | `python3Packages.millheater: 0.8.0 -> 0.8.1`                                 |
| [`7c6bf233`](https://github.com/NixOS/nixpkgs/commit/7c6bf2334f1d7e9c0e2ddf7aa42b9730632fea9e) | `python3Packages.sunpy: 3.0.2 -> 3.1.0`                                      |
| [`e1f76eeb`](https://github.com/NixOS/nixpkgs/commit/e1f76eeb6464a21731f05ec2681dd561c5f67efb) | `python3Packages.pytest-astropy: fix build`                                  |
| [`703aa3a9`](https://github.com/NixOS/nixpkgs/commit/703aa3a94f21a90d0d354940e16a27cb1d9e15df) | `python3Packages.parfive: fix tests, add imports check`                      |
| [`f386939c`](https://github.com/NixOS/nixpkgs/commit/f386939ca1f6b1a5f13f77b6ec06f9b20ae01726) | `python3Packages.astropy: 4.2 -> 4.3.1`                                      |
| [`8dd4d7ee`](https://github.com/NixOS/nixpkgs/commit/8dd4d7eedd584edb8bf3d6b7f32d0345820c84c0) | `python3Packages.pyerfa: 1.7.1.1 -> 2.0.0`                                   |
| [`242a5a62`](https://github.com/NixOS/nixpkgs/commit/242a5a62f8de51539d46c5f82356cb48780a08a1) | `python3Packages.threadpoolctl: disable test test_architecture`              |
| [`5e1324e4`](https://github.com/NixOS/nixpkgs/commit/5e1324e48a7a05e150f7d05489dfb7507a29d87e) | `code-server: 3.9.0 -> 3.12.0`                                               |
| [`03857732`](https://github.com/NixOS/nixpkgs/commit/03857732e941eeb040792ba49a0f30025115c567) | `nixos/tests/matrix-appservice-irc: Refactor test`                           |
| [`4bf7da57`](https://github.com/NixOS/nixpkgs/commit/4bf7da5720c6de80251f2dbef13eac79a0fe4959) | `nixos/tests/matrix-appservice-irc: Fix test`                                |
| [`f34e8105`](https://github.com/NixOS/nixpkgs/commit/f34e8105cb8f5f26e009a1ab4154112467d99672) | `matrix-appservice-irc 0.26.1 -> 0.30.0`                                     |