### PR TITLE
chore(flake/inputs/home-manager): 70c5b268e10025c70823767f4fb49e240b40151d -> f6f013f7642437b0b613aec17f331fe5700fcb35

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -62,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1636044164,
-        "narHash": "sha256-RI9QjS8NBrfVTp6dzmcEVKNNjxYGBf26+/7ihDA/USc=",
+        "lastModified": 1636215015,
+        "narHash": "sha256-OZYgfAmVh/1VqSsKa13ZKTB/gg0E+zufO792OLvawRs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "70c5b268e10025c70823767f4fb49e240b40151d",
+        "rev": "f6f013f7642437b0b613aec17f331fe5700fcb35",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                         |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`f6f013f7`](https://github.com/nix-community/home-manager/commit/f6f013f7642437b0b613aec17f331fe5700fcb35) | `home: shell agnostic aliases (#2347)` |