### PR TITLE
chore(flake/inputs/nixpkgs): `0d5b4445` -> `c6c29d58`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1636171905,
-        "narHash": "sha256-R2P/QDhhTA5uXAGNm6vi39oh24aTYUswGuWsmTWxxH4=",
+        "lastModified": 1636214769,
+        "narHash": "sha256-6CHvmF47Apnw+o8o5J0twIfbCBW4PYrZU7JiF4XtTcw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0d5b4445e33b1cd666b107bbdf5920884bbaeb1a",
+        "rev": "c6c29d5845a0f4691e019471b60033c26a5a6d53",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                       |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`a71576b0`](https://github.com/NixOS/nixpkgs/commit/a71576b07b59a86a27555ab8a3dff901b10d8b6c) | `nixos/mastodon/streaming: add '@memlock' SystemCallFilter`          |
| [`91e510ae`](https://github.com/NixOS/nixpkgs/commit/91e510ae220e3287ccfc868ef63b8e952f76d3ae) | `nixos/mastodon: add '@ipc' SystemCallFilter`                        |
| [`700ea62f`](https://github.com/NixOS/nixpkgs/commit/700ea62f549e00fbe531c387e68b99b08378f172) | `nixos/mastodon: remove duplicates SystemCallFilters`                |
| [`943f15d4`](https://github.com/NixOS/nixpkgs/commit/943f15d4b76e13c19ac08a298bc12f7b6f14b931) | `nixos/mastodon: add new sandboxing options`                         |
| [`1dfe0be7`](https://github.com/NixOS/nixpkgs/commit/1dfe0be750cb81f38381e994885296cf0bfb5be0) | `pipr: 0.0.15 -> 0.0.16; fixes build`                                |
| [`57225d51`](https://github.com/NixOS/nixpkgs/commit/57225d51a6afecc991e761d7614ddfc93f39c035) | `statix: 0.3.6 -> 0.4.0`                                             |
| [`039e3758`](https://github.com/NixOS/nixpkgs/commit/039e37580aa9e64424028d0c943697b343149f9b) | `git-aggregator: 1.8.1 -> 2.10, fixes build`                         |
| [`b688707a`](https://github.com/NixOS/nixpkgs/commit/b688707a06342cbe7a11924cc2df10a3ae7c5370) | `python3Packages.devtools: add missing dependencies`                 |
| [`ecd529b0`](https://github.com/NixOS/nixpkgs/commit/ecd529b078aae11ca3351adb7e7ce40657893d71) | `python3Packages.executing: 0.5.4 -> 0.8.2`                          |
| [`021410c0`](https://github.com/NixOS/nixpkgs/commit/021410c0021749930a91278156057c0b2e8c2b77) | `ljsyscall: fix build`                                               |
| [`68f6d766`](https://github.com/NixOS/nixpkgs/commit/68f6d76684d127f713aced1b6dc0127c1553571a) | `nixosTests.chromium: Avoid blocking on xclip stdout`                |
| [`2a4d433b`](https://github.com/NixOS/nixpkgs/commit/2a4d433b1f194595c819cec88361a1e402ebadb8) | `nixosTest: Add xclip as example of stdout blocker`                  |
| [`615aa79f`](https://github.com/NixOS/nixpkgs/commit/615aa79f5ee4052f678c1c316a5aff8e93e113f8) | `plasma-workspace: remove fetchpatch from inputs`                    |
| [`9538bee9`](https://github.com/NixOS/nixpkgs/commit/9538bee9b734895c5f9c3183e68bb2c188fe559e) | `wlogout: add gtk-layer-shell support`                               |
| [`ab269d98`](https://github.com/NixOS/nixpkgs/commit/ab269d980ef8ceee260de027c3e28b7eda421daa) | `arrow-cpp: glob TestS3FSGeneric tests`                              |
| [`14bec588`](https://github.com/NixOS/nixpkgs/commit/14bec588758712d7cc1c951bb0567a7b6d0e3589) | `arrow-cpp: disable some potentially failing s3fs tests`             |
| [`03f9ced5`](https://github.com/NixOS/nixpkgs/commit/03f9ced5124287c9ed9d434a39a8b68f7f084252) | `picoscope: 6.14.44 -> 7.0.83`                                       |
| [`e8815af1`](https://github.com/NixOS/nixpkgs/commit/e8815af10e6477bfcba9bd3cfc4494bd43090cbf) | `bemenu: fix build against upcoming ncurses-6.3`                     |
| [`9672ef7e`](https://github.com/NixOS/nixpkgs/commit/9672ef7e0a7ddbfef1cf38cb9936848c11042a3d) | `wine{,64,Wow}Packages: add {stable,unstable,staging}Full`           |
| [`f2de5cf2`](https://github.com/NixOS/nixpkgs/commit/f2de5cf279c3cf0c36f564eb4d8a5fe5f122623a) | `home-assistant: enable efergy tests`                                |
| [`ff02ceb9`](https://github.com/NixOS/nixpkgs/commit/ff02ceb9153636d9f6f97e5dc6b0f28350ec2a1c) | `python3Packages.mypy-boto3-s3: 1.19.8 -> 1.19.12`                   |
| [`0f840ef4`](https://github.com/NixOS/nixpkgs/commit/0f840ef488acd32979d243cae98e58cd6ebd69e0) | `python3Packages.starkbank-ecdsa: 2.0.0 -> 2.0.1`                    |
| [`220c819f`](https://github.com/NixOS/nixpkgs/commit/220c819f5306e019b9a12984b5f084694b134e96) | `ecasound: fix build against upcoming ncurses-6.3`                   |
| [`5499f32f`](https://github.com/NixOS/nixpkgs/commit/5499f32f080874af2b88e691c349aad913e8267e) | `tor-browser-bundle-bin: Enable content sandbox and hardened malloc` |
| [`84d5983f`](https://github.com/NixOS/nixpkgs/commit/84d5983fb227d341ff4805924b99b30ef26bf221) | `python3Packages.mailman-hyperkitty: fix build`                      |
| [`1a368537`](https://github.com/NixOS/nixpkgs/commit/1a3685370b1ab651a65d5109e6bf765550dd117f) | `python3Packages.proc: disable tests`                                |
| [`b228c241`](https://github.com/NixOS/nixpkgs/commit/b228c241fb2bebf38819d31c2876f556c58e3b2a) | `pylode: relax rdflib constraint`                                    |
| [`b7fceb1f`](https://github.com/NixOS/nixpkgs/commit/b7fceb1fd9a1989e08bc7e4063f823cb4e279573) | `python3Packages.rdflib: 6.0.1 -> 6.0.2`                             |
| [`8c220df7`](https://github.com/NixOS/nixpkgs/commit/8c220df7947221bfc3d729f9816f5f3ba4ce5297) | `wiki-tui: fix build on darwin`                                      |
| [`3e368b17`](https://github.com/NixOS/nixpkgs/commit/3e368b176a28e0f985d790d72167bc5881b5aff1) | `metasploit: 6.1.12 -> 6.1.13`                                       |
| [`72f5f393`](https://github.com/NixOS/nixpkgs/commit/72f5f39309f7956b541447bdf7fb63a16eb05ca7) | `checkov: 2.0.528 -> 2.0.549`                                        |
| [`458ea7e6`](https://github.com/NixOS/nixpkgs/commit/458ea7e649b0cf0f330780069f26f2848778f0d3) | `wiki-tui: 0.3.4 -> 0.4.1`                                           |
| [`7acc0e05`](https://github.com/NixOS/nixpkgs/commit/7acc0e054c5d64de945e69a17c57e33410d04f03) | `libredirect: workaround dyld env not inherited`                     |
| [`b09fcdb0`](https://github.com/NixOS/nixpkgs/commit/b09fcdb0be40a81718aa8a7d9b26e019eac56864) | `python3Packages.aws-sam-cli: 1.29.0 -> 1.35.0, fix build`           |
| [`ec46532a`](https://github.com/NixOS/nixpkgs/commit/ec46532a47708493337e6658fe6615d34873b389) | `python3Packages.aws-sam-translator: 1.39.0 -> 1.40.0`               |
| [`d9edc790`](https://github.com/NixOS/nixpkgs/commit/d9edc79055867193e436a2a56805b7d4f0341394) | `nvd: 0.1.1 -> 0.1.2`                                                |
| [`56b22af1`](https://github.com/NixOS/nixpkgs/commit/56b22af1ef90bbf65a64e42eac68b9db4307e43c) | `tela-icon-theme: 2021-10-08 -> 2021-11-05`                          |
| [`d1a3b5c4`](https://github.com/NixOS/nixpkgs/commit/d1a3b5c4cc65616d81b0db28c9b288b1558965b4) | `libredirect: use __interpose on darwin`                             |
| [`01e9eb40`](https://github.com/NixOS/nixpkgs/commit/01e9eb40daaf770519b0c7e876c9e6614702cf0d) | `imgbrd-wrapper: 7.3.2 -> 7.5.1`                                     |
| [`f2325f8e`](https://github.com/NixOS/nixpkgs/commit/f2325f8ef044497cde4f251953d048706f8c4ce6) | `aws-sdk-cpp: re-disable flaky test`                                 |
| [`19505621`](https://github.com/NixOS/nixpkgs/commit/1950562186604c818aff6172c9802c1d748d4510) | `python3Packages.smbprotocol: 1.8.1 -> 1.8.2`                        |
| [`e9b9bea2`](https://github.com/NixOS/nixpkgs/commit/e9b9bea26190f6aaaabf01773c982d30aa0d6a66) | `glibc: include ldd and other scripts in cross-builds`               |
| [`fa34b0f0`](https://github.com/NixOS/nixpkgs/commit/fa34b0f03a82f996202a31d89751885adb78658c) | `toxic: fix build against upcoming ncurses-6.3`                      |
| [`bd7499ed`](https://github.com/NixOS/nixpkgs/commit/bd7499ed61717a3936283311147803c07bd06c85) | `Update pkgs/games/bastet/default.nix`                               |
| [`f9a9b5b6`](https://github.com/NixOS/nixpkgs/commit/f9a9b5b61757c984f7576417d814190cdd96481b) | `purple-lurch: 0.6.7 -> 0.7.0`                                       |
| [`ad14fcea`](https://github.com/NixOS/nixpkgs/commit/ad14fceae4f1e7fd17e04fd3f2984a005b124389) | `partclone: 0.3.17 -> 0.3.18`                                        |
| [`6e7900c2`](https://github.com/NixOS/nixpkgs/commit/6e7900c2aca2eed324453ffdc2568e135e52deed) | `owncast: 0.0.9 -> 0.0.10`                                           |
| [`60152c5b`](https://github.com/NixOS/nixpkgs/commit/60152c5bef92543670653aa77ecfdf9ad887fe2d) | `bwm_ng: pull upstream fix for upcoming ncurses-6.3`                 |
| [`1eb84924`](https://github.com/NixOS/nixpkgs/commit/1eb8492488da08698ed7e05cb2ed006f271722d5) | `litestream: 0.3.5 -> 0.3.6`                                         |
| [`72aca77a`](https://github.com/NixOS/nixpkgs/commit/72aca77ae534742ce3fc670f29b3ae10deb0b940) | `mcabber: pull upstream fix for upcoming ncurses-6.3`                |
| [`77c54c90`](https://github.com/NixOS/nixpkgs/commit/77c54c908fc71cd6e60e7d3b5233b2168b3b9722) | `bastet: fix build against upcoming ncurses-6.3`                     |
| [`37d0deb4`](https://github.com/NixOS/nixpkgs/commit/37d0deb4e0387446ecfe46231b8b6d31ba0214bc) | `koreader: 2021.09 -> 2021.10.1`                                     |
| [`18e622a1`](https://github.com/NixOS/nixpkgs/commit/18e622a1f5252de098186609493d518e3cfb6e52) | `plasma-vault: regenerate patches`                                   |
| [`e169ff9d`](https://github.com/NixOS/nixpkgs/commit/e169ff9dfa75efa15ccbd64ae952c84f6571cfb2) | `Revert "plasma-workspace: include patch from 5.23.2"`               |
| [`27013816`](https://github.com/NixOS/nixpkgs/commit/27013816ac44633e08cdb5c660ddbc17d74b3551) | `plasma5: 5.23.1 -> 5.23.2`                                          |
| [`383a7900`](https://github.com/NixOS/nixpkgs/commit/383a7900cb771edeeaf8113be7e41a9eab1a5fbd) | `nixopsUnstable: 2.0.0-pre (2021-11-02)`                             |
| [`57bfc1e6`](https://github.com/NixOS/nixpkgs/commit/57bfc1e6a3b0fff8ba9fc3aabb6bb7baa2fa19d9) | `libvirt: 7.8.0 -> 7.9.0`                                            |
| [`0fa259d1`](https://github.com/NixOS/nixpkgs/commit/0fa259d1f4e6da796cd6e303755ea3946d3c8540) | `flightgear: 2020.3.8 -> 2020.3.11`                                  |
| [`7038b8ad`](https://github.com/NixOS/nixpkgs/commit/7038b8ad9eddb1f126f2dcfdfa5c664a3295a889) | `simgear: fix homepage url`                                          |
| [`ff22dd66`](https://github.com/NixOS/nixpkgs/commit/ff22dd6684ca492fcec69ab04c4f81fb574891f9) | `nixos/libvirtd: use /etc/ethertypes from iptables package`          |
| [`429e07ef`](https://github.com/NixOS/nixpkgs/commit/429e07efe5977f0d2cee0ecc2d4169e24caa3219) | `aewan: fix build against ncurses-6.3`                               |
| [`580951d4`](https://github.com/NixOS/nixpkgs/commit/580951d4e2605ce4e10fa70f676a7ff341e0bf5b) | `gradle: Add update.sh maintenance script`                           |
| [`43750fb9`](https://github.com/NixOS/nixpkgs/commit/43750fb958839d5c1de3b3a388da02c16585883a) | `gradle: add 7.3-rc-3, 6.8 -> 6.9.1`                                 |
| [`ad20e87e`](https://github.com/NixOS/nixpkgs/commit/ad20e87e39749f1b6176f06e8d9bbb653738f020) | `plasma5: set default session to plasma X11`                         |
| [`91812b84`](https://github.com/NixOS/nixpkgs/commit/91812b84b8b2ec4051c23bb11d7eb92eba367780) | `sddm: respect services.xserver.displayManager.defaultSession`       |
| [`7f5ed45b`](https://github.com/NixOS/nixpkgs/commit/7f5ed45b3ac42ded4ac1c6c2598bd3e28d1c975d) | `crabz: fix darwin build`                                            |
| [`6d436e18`](https://github.com/NixOS/nixpkgs/commit/6d436e18bece8b11c2b76aeff829b69db98a4c9e) | `riemann_c_client: 1.10.4 -> 1.10.5`                                 |
| [`0343045a`](https://github.com/NixOS/nixpkgs/commit/0343045a92d2cff88ad861304f7a979f8e7dcd2d) | `nixos/mosquitto: add module documentation`                          |
| [`d09952fe`](https://github.com/NixOS/nixpkgs/commit/d09952fea85538ff72fb25a9fe8e473f853a58ec) | `nixos/mosquitto: restore passwordless system feature`               |
| [`81175b44`](https://github.com/NixOS/nixpkgs/commit/81175b442f4e4e3c9c8aa807b92047f73647458e) | `nixos/mosquitto: refactor test a little`                            |
| [`85fce578`](https://github.com/NixOS/nixpkgs/commit/85fce57861bec51fbf154ebb25b91cccab2f5976) | `picoscope: use nixpkgs mono, generated sources.json`                |
| [`8c9a5a09`](https://github.com/NixOS/nixpkgs/commit/8c9a5a09f92f28e116723ba3d928af868f71474d) | `picoscope: init at 6.14.44-4r5870`                                  |