### PR TITLE
chore(flake/inputs/sops-nix): `8318a036` -> `16e94d49`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1636061735,
-        "narHash": "sha256-QiY9mA5cnGnNHD7PpJltR8hiCr2py8VMvuEmi1EmIcQ=",
+        "lastModified": 1636286244,
+        "narHash": "sha256-vrF0KS5+9FTY/W97q3quW3PB83Dl8TOd/c5MkToAeVU=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "8318a036fee9492068e44fdee202863766763c1a",
+        "rev": "16e94d49ea37ba09d62add45a6495e9e19f95208",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                                  |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`9683d128`](https://github.com/Mic92/sops-nix/commit/9683d128bde88ab3800c1ce1c1a83ea53878fcc7) | `Add support for restarting/reloading units`    |
| [`da426dcd`](https://github.com/Mic92/sops-nix/commit/da426dcdd623e0b8c919879032af9d26b7c40c89) | `update flakes`                                 |
| [`c9cdb0ca`](https://github.com/Mic92/sops-nix/commit/c9cdb0cabee8e91635355fca8b75588af03c196d) | `update drone channel`                          |
| [`bd818c21`](https://github.com/Mic92/sops-nix/commit/bd818c21e4b383a945ecd52c64080e28ba249cc6) | `change drone pipeline type`                    |
| [`17c4771b`](https://github.com/Mic92/sops-nix/commit/17c4771b216e670fa57d02c5654af8c3c51497c2) | `remove nixos tests from test set`              |
| [`73ca7935`](https://github.com/Mic92/sops-nix/commit/73ca793539ae73f2c58921bc859879557996e57c) | `Revert "remove drone (replaced by github ci)"` |