### PR TITLE
chore(flake/inputs/home-manager): `f6f013f7` -> `2917ef23`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -62,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1636215015,
-        "narHash": "sha256-OZYgfAmVh/1VqSsKa13ZKTB/gg0E+zufO792OLvawRs=",
+        "lastModified": 1636274622,
+        "narHash": "sha256-tZYuGhqcfH7piCsrUrIYM0P3oPJcoBxGkuxeFNVxkCc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f6f013f7642437b0b613aec17f331fe5700fcb35",
+        "rev": "2917ef23b398a22ee33fb34b5766b28728228ab1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`2917ef23`](https://github.com/nix-community/home-manager/commit/2917ef23b398a22ee33fb34b5766b28728228ab1) | `kakoune: clean up tests`                         |
| [`c678162e`](https://github.com/nix-community/home-manager/commit/c678162e208bf3342471accf8024d67fe563ea79) | `ci: error out if code contains `literalExample`` |
| [`7f416c9e`](https://github.com/nix-community/home-manager/commit/7f416c9e2f3b72b514ff8f39f7ef789de442fb80) | `home: use literalExpression`                     |