### PR TITLE
chore(flake/inputs/nixpkgs): `c6c29d58` -> `81d15682`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1636214769,
-        "narHash": "sha256-6CHvmF47Apnw+o8o5J0twIfbCBW4PYrZU7JiF4XtTcw=",
+        "lastModified": 1636254356,
+        "narHash": "sha256-eBujs6+KrAa0WqYwo/zUmzRohKFBqP52x2EcNw5arwE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c6c29d5845a0f4691e019471b60033c26a5a6d53",
+        "rev": "81d15682625635d93ba66def75fd13fd16c0515b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`06a3d5fe`](https://github.com/NixOS/nixpkgs/commit/06a3d5fe54aaa98752105717aecf6af3cc7aa64e) | `wiki-tui: 0.4.1 -> 0.4.2`                                                           |
| [`81e952e8`](https://github.com/NixOS/nixpkgs/commit/81e952e8a49d936f0612e98e0234eaf4dd192f02) | `cspell: init at 5.12.6 (#144954)`                                                   |
| [`c207be65`](https://github.com/NixOS/nixpkgs/commit/c207be6591e45e844f193f147c1f3447af054eba) | `handbrake: 1.3.3 -> 1.4.2 (#143654)`                                                |
| [`84b960ca`](https://github.com/NixOS/nixpkgs/commit/84b960ca01dfbf6e40148698f8cdc999d6615804) | `metal-cli: Fix build`                                                               |
| [`7be1b371`](https://github.com/NixOS/nixpkgs/commit/7be1b371026529af5fe16f5ea5ab3c50eb2f0b06) | `python3Packages.aioshelly: 1.0.3 -> 1.0.4`                                          |
| [`8f6392ce`](https://github.com/NixOS/nixpkgs/commit/8f6392cec9ab0392a2c959796e6c18b8823cbc33) | `dhall-grafana: Fix Prelude dependency. (#144915)`                                   |
| [`6b83b457`](https://github.com/NixOS/nixpkgs/commit/6b83b457d25cf670f83df84b2e3c9244a61eda68) | `entangle: Add missing zstd dependency`                                              |
| [`ef89ee9b`](https://github.com/NixOS/nixpkgs/commit/ef89ee9b71aaa8597198e5dd4b90b46051569459) | `fheroes2: 0.9.8 -> 0.9.9`                                                           |
| [`065281ad`](https://github.com/NixOS/nixpkgs/commit/065281add0016f2c1e6fa340ae78823fba9124c7) | `cemu: mark as broken on darwin`                                                     |
| [`27717439`](https://github.com/NixOS/nixpkgs/commit/277174396634aff9e48fb254f38fba86a77f4206) | `cemu: add link-time-compile-gen, build with gcc9stdenv`                             |
| [`d64f7a76`](https://github.com/NixOS/nixpkgs/commit/d64f7a76fb53a98f9f699f9d1c6b36053c486b6f) | `nixos/tests.plasma5: Fix after #142747`                                             |
| [`c0814cef`](https://github.com/NixOS/nixpkgs/commit/c0814cef0bcdc20c082ff90f031f46611c0abd99) | `python3.pkgs.dropbox: use source from git, since it contains documentation`         |
| [`c756d168`](https://github.com/NixOS/nixpkgs/commit/c756d168dc6883244358ccf7b09404c29d69ed8c) | `pgcli: disable failing tests`                                                       |
| [`bf3aff8e`](https://github.com/NixOS/nixpkgs/commit/bf3aff8eb0b9db1ff43139dc7e08cbc1d539eea6) | `newsflash: 1.4.3 -> 1.5.1`                                                          |
| [`4b5e873e`](https://github.com/NixOS/nixpkgs/commit/4b5e873e6ea165c751c8103f1f03040360c60f3b) | `linuxPackages.rtl88x2bu: 2021-05-18 -> 2021-11-04`                                  |
| [`525c565b`](https://github.com/NixOS/nixpkgs/commit/525c565baeec06bbd200fd7cb555f7c6f15a13b4) | `linuxPackages.rtl8192eu: 4.4.1.20210403 -> 4.4.1.20211023`                          |
| [`44729a30`](https://github.com/NixOS/nixpkgs/commit/44729a305e55ddbf66c6bbdc670cc8b1cd01b513) | `linuxPackages.rtl8821cu: 2021-05-19 -> 2021-10-21`                                  |
| [`8cc3c4ff`](https://github.com/NixOS/nixpkgs/commit/8cc3c4ff6e623fab80291e35791c9ce6b2232fef) | `linuxPackages.rtl8821au: 2021-05-18 -> 2021-11-05`                                  |
| [`999d3972`](https://github.com/NixOS/nixpkgs/commit/999d3972591f87515379ff511aead07cd8f7f751) | `linuxPackages.rtl8814au: 2021-05-18 -> 2021-10-25`                                  |
| [`ef0ac43d`](https://github.com/NixOS/nixpkgs/commit/ef0ac43dee7ac5443d8f587f09fdc80f393e5596) | `pythonPackages.watermark: init at 2.2.0`                                            |
| [`787b6127`](https://github.com/NixOS/nixpkgs/commit/787b6127d24e6006feaedc216181a235af993af4) | `pythonPackages.watermark: init at 2.2.0`                                            |
| [`50417ddb`](https://github.com/NixOS/nixpkgs/commit/50417ddb87f8dbe992f08fdd9ad9be26ebad0098) | `opendungeons: 0.7.1 -> unstable-2021-11-06`                                         |
| [`e9d384fd`](https://github.com/NixOS/nixpkgs/commit/e9d384fd6283260a3abac2a4287c37ea70c8f978) | `osu-lazer: 2021.1028.0 -> 2021.1105.0`                                              |
| [`c3cf40e5`](https://github.com/NixOS/nixpkgs/commit/c3cf40e50e78eb570826860d8bf4c17bf948d625) | `linuxPackages.xmm7360-pci: set minimum kernel version`                              |
| [`6ce4879b`](https://github.com/NixOS/nixpkgs/commit/6ce4879bfb702d159e7d886acc1b5bdeb68cf3fd) | `linuxPackages.rtl88xxau-aircrack: mark broken on Linux 5.15`                        |
| [`3683cca6`](https://github.com/NixOS/nixpkgs/commit/3683cca605e147a6ea5b9b654c7a9f0dc4a8fc06) | `linuxPackages.rtl8812au: mark broken on Linux 5.15`                                 |
| [`163e90cd`](https://github.com/NixOS/nixpkgs/commit/163e90cdd75446cbef621598b999fff3e5aa2d88) | `linuxPackages.rtl8188eus-aircrack: mark broken on Linux 5.15`                       |
| [`4e7392e7`](https://github.com/NixOS/nixpkgs/commit/4e7392e76ba23d1bc7ac4f1fac9fe058ff4dfc10) | `linuxPackages.openafs_1_9: mark broken on Linux 5.15`                               |
| [`bb2b3da3`](https://github.com/NixOS/nixpkgs/commit/bb2b3da36d2a39446417fc05aaadbde5fc68fa3e) | `linuxPackages.openafs: mark broken on Linux 5.15`                                   |
| [`a32d9211`](https://github.com/NixOS/nixpkgs/commit/a32d921183c0088c979438dd29b132e9c6245ac5) | `linuxPackages.evdi: mark broken on Linux 5.15`                                      |
| [`768c8ca1`](https://github.com/NixOS/nixpkgs/commit/768c8ca1625a423d926285a83a3ab7a9f1903dc9) | `linuxPackages.ena: mark broken on Linux 5.15`                                       |
| [`b21b1b7c`](https://github.com/NixOS/nixpkgs/commit/b21b1b7c6471fe610e5815e11b4e9d3d0822b778) | `linuxPackages.ddcci: mark broken on Linux 5.15`                                     |
| [`17f391e0`](https://github.com/NixOS/nixpkgs/commit/17f391e05a97c611d2892602a6054917eda89283) | `linuxPackages.kvmfr: set minimum kernel version`                                    |
| [`7aa9186a`](https://github.com/NixOS/nixpkgs/commit/7aa9186ae4cd67983db5d0cc14bd79748d8f216b) | `linuxPackages.rr-zen_workaround: mark x86_64-only`                                  |
| [`541fe07b`](https://github.com/NixOS/nixpkgs/commit/541fe07bb117d8fc9e8c8c8eb6e480c48d1af9bb) | `python3Packages.pip-tools: use pytestCheckHook, disable failing test, cleanup`      |
| [`2fa9bf4b`](https://github.com/NixOS/nixpkgs/commit/2fa9bf4b8b13adcadb9c06529ff46ccff7c255a9) | `yandex-browser: set meta.broken`                                                    |
| [`f7a4abe5`](https://github.com/NixOS/nixpkgs/commit/f7a4abe5c0594cfa60e6dc6bfef446fdbf2c7b17) | `tagutil: fix build`                                                                 |
| [`0390fcfd`](https://github.com/NixOS/nixpkgs/commit/0390fcfd059dd76e2fe2939892888e121c21e65a) | `jconvolver: init at 1.1.0 (#143520)`                                                |
| [`46180e40`](https://github.com/NixOS/nixpkgs/commit/46180e407e520aa1959ad50128e7be2657c610b9) | `nixos/xmrig: init`                                                                  |
| [`ed83ff9b`](https://github.com/NixOS/nixpkgs/commit/ed83ff9bccf795ba9ce5e885b950ee86d39c68af) | `signal-desktop: 5.22.0 -> 5.23.0`                                                   |
| [`65b2b7e0`](https://github.com/NixOS/nixpkgs/commit/65b2b7e02a4edd91c0eebef52d70200765d44e11) | `python3Packages.pygls: 0.11.2 → 0.11.3`                                             |
| [`ff69cda0`](https://github.com/NixOS/nixpkgs/commit/ff69cda0bc2ad2fbe79e0e863439ed7e283b09b5) | `python3Packages.systembridge: 2.2.0 -> 2.2.1`                                       |
| [`32cfea71`](https://github.com/NixOS/nixpkgs/commit/32cfea717df430248c7230c40572dfa9bfd69b0d) | `python3Packages.flower: disable failing tests`                                      |
| [`4d5d3449`](https://github.com/NixOS/nixpkgs/commit/4d5d34495fd08345f2064c875224b48a684f89e9) | `openshot: refactor`                                                                 |
| [`cdddc286`](https://github.com/NixOS/nixpkgs/commit/cdddc286a269502fef895c4f455b27e33765a738) | `libopenshot-audio: 0.2.0 -> 0.2.2`                                                  |
| [`abe8a309`](https://github.com/NixOS/nixpkgs/commit/abe8a309121a7839f5126d405e5edbf18294e685) | `libopenshot: 0.2.5 -> 0.2.7`                                                        |
| [`00460bd6`](https://github.com/NixOS/nixpkgs/commit/00460bd6e2c89f3b76dcb42032194e6eed0616d2) | `chromiumDev: 97.0.4682.3 -> 97.0.4688.2`                                            |
| [`41dbc0a9`](https://github.com/NixOS/nixpkgs/commit/41dbc0a9954d852ef1d33ec5c79d64fe3cc84b8c) | `chromiumBeta: 96.0.4664.27 -> 96.0.4664.35`                                         |
| [`26e1daaa`](https://github.com/NixOS/nixpkgs/commit/26e1daaa43876c082d64f4ab9941602b99b5c14f) | `treewide: eliminate stdenv.lib usage`                                               |
| [`392a7a3d`](https://github.com/NixOS/nixpkgs/commit/392a7a3d7ebc07fc2950459bbf72a2837caa1157) | `python39Packages.ansible-runner: 2.0.2 -> 2.0.3`                                    |
| [`cdd38551`](https://github.com/NixOS/nixpkgs/commit/cdd385510a69ada4a0c6b3e2348ad6aa4b88344e) | `nixos/ddclient: customizable package option`                                        |
| [`7deb5247`](https://github.com/NixOS/nixpkgs/commit/7deb5247a5da4f468a0abe464275f6c913c5f33f) | `nixos/ddclient: fix privs when loading password`                                    |
| [`90bac670`](https://github.com/NixOS/nixpkgs/commit/90bac670c0ef7b474841c2f929a2e0d63059e8a0) | `nixos/pam: pam_mkhomedir umask to 0077`                                             |
| [`9de65b38`](https://github.com/NixOS/nixpkgs/commit/9de65b383740cd9ed3c2adec66efce414013e072) | `amass: 3.14.2 -> 3.14.3`                                                            |
| [`38d8d66d`](https://github.com/NixOS/nixpkgs/commit/38d8d66d0a004499d525b1286ebd1be986cc5c16) | `python3Packages.restfly: 1.4.3 -> 1.4.4`                                            |
| [`1e4f70fc`](https://github.com/NixOS/nixpkgs/commit/1e4f70fc39142febd8962fb65b81183647bfdceb) | `fzf: 0.27.3 -> 0.28.0`                                                              |
| [`fe175c8e`](https://github.com/NixOS/nixpkgs/commit/fe175c8e9aa0d753f2209fb2f7215e0bb6c03efb) | `vagrant: 2.2.18 -> 2.2.19`                                                          |
| [`53ea17e1`](https://github.com/NixOS/nixpkgs/commit/53ea17e1a691a40af83eab95954f98d7c6c6cda3) | `diffoscope: 188 -> 190`                                                             |
| [`963b1971`](https://github.com/NixOS/nixpkgs/commit/963b1971df77544b8fc0af4c5276e97af2658c61) | `i3status-rust: 0.20.4 -> 0.20.5`                                                    |
| [`013a1d5c`](https://github.com/NixOS/nixpkgs/commit/013a1d5c24d480e6cd01cb6964f18859e096809e) | `python3Packages.flux-led: 0.24.14 -> 0.24.17`                                       |
| [`469d40a4`](https://github.com/NixOS/nixpkgs/commit/469d40a4b2be6a274ff2fd10f685eca67edd28a4) | `sarasa-gothic: Use TTC format instead of TTF`                                       |
| [`480285a3`](https://github.com/NixOS/nixpkgs/commit/480285a39e1ed10a384c1a9231720312542ed551) | `rstudio: fix desktop icon`                                                          |
| [`7326f67e`](https://github.com/NixOS/nixpkgs/commit/7326f67e4225edc30a4ec9b06ef12eff1707bdf1) | `nerdctl: 0.12.1 -> 0.13.0`                                                          |
| [`a4ec5fa3`](https://github.com/NixOS/nixpkgs/commit/a4ec5fa360d85c8392299f6a6b37762c9a9cff88) | `auditwheel: set meta.platforms`                                                     |
| [`e1fad6fc`](https://github.com/NixOS/nixpkgs/commit/e1fad6fc50df6e8840a30f047a244413ec46f393) | `go_1_17: enable on x86_64-darwin`                                                   |
| [`63a08302`](https://github.com/NixOS/nixpkgs/commit/63a08302443e4758f9a6d58f36f80736ed7ba474) | `mullvad-vpn: fix the .desktop file`                                                 |
| [`30e8835d`](https://github.com/NixOS/nixpkgs/commit/30e8835d5c42cb19e32c8fec0ee4113a4fb6426e) | `rPackages.{HierO,tiledb,x13binary,switchr}: mark broken`                            |
| [`95233574`](https://github.com/NixOS/nixpkgs/commit/952335745326653bb1ed39d8a69ab42b84ae7ebe) | `rPackages.systemPipeShiny: requires home`                                           |
| [`23b57f2e`](https://github.com/NixOS/nixpkgs/commit/23b57f2e6a3b68fb4801a34ef5c22de1f44e21d0) | `rPackages.flowWorkspace: fix missing zlib dependency`                               |
| [`40ff9b26`](https://github.com/NixOS/nixpkgs/commit/40ff9b267f6ae809456bca4612f251c58bde183c) | `rPackages.PoissonBionomial: fix missing dependency`                                 |
| [`a71c0e16`](https://github.com/NixOS/nixpkgs/commit/a71c0e16154a2c849df7f7e9eaa21f66afe74d17) | `rPackages.RmecabKo: fix missing dependency`                                         |
| [`6611a558`](https://github.com/NixOS/nixpkgs/commit/6611a558d31bab546e174e6308d5ee0a28f99c4f) | `rPackages.{trackViewer,themetagenomics,NanoMethViz}: fix missing zlib dependencies` |
| [`71723e1f`](https://github.com/NixOS/nixpkgs/commit/71723e1f68625f95a8a9cbabd8f66b02a77190c1) | `rPackages.rrd: fix build`                                                           |
| [`7264b569`](https://github.com/NixOS/nixpkgs/commit/7264b569ac35e776d57da1711c4ff8e1d8cb4f33) | `rPackages.RcppCWB: fix build`                                                       |
| [`ab946b51`](https://github.com/NixOS/nixpkgs/commit/ab946b511356c129ee6af3796448637e1a6757a4) | `rPackages.{scModels,multibridge}: add mpfr dependency`                              |
| [`c9ce16ee`](https://github.com/NixOS/nixpkgs/commit/c9ce16ee6937c9803e33ecf0e896b1ac6265c497) | `rPackages.valse: mark broken`                                                       |
| [`cad71004`](https://github.com/NixOS/nixpkgs/commit/cad71004f72e8d8fe9c6a44f85ca2a8a96c75ee1) | `rPackages: fix builds requiring gsl`                                                |
| [`8920d6bc`](https://github.com/NixOS/nixpkgs/commit/8920d6bce7bfcd951f24bf811758d63672d25c53) | `rPackages.nullrangesData: mark as broken`                                           |
| [`2b786e82`](https://github.com/NixOS/nixpkgs/commit/2b786e821cc24c2c7482853256d68c43bb29d099) | `rPackages.proj4: fix build`                                                         |
| [`74aa5fc7`](https://github.com/NixOS/nixpkgs/commit/74aa5fc758cc1d07069d7e3b302a54c60c139ece) | `rPackages.{HDF5Array,FLAMES,ncdfFlow}: fix missing zlib dependency`                 |
| [`93168abf`](https://github.com/NixOS/nixpkgs/commit/93168abf30fd60f9e3529a2255a4e0d7059453c0) | `rPackages.rawrr: fix missing mono dependency`                                       |
| [`a451b344`](https://github.com/NixOS/nixpkgs/commit/a451b3441fb44c2fb151adcc4c1a08fd7f0c8b36) | `rPackages.arrow: fix build`                                                         |
| [`803ae4b5`](https://github.com/NixOS/nixpkgs/commit/803ae4b5f317d8a47648fc81d0135ab5e6103d32) | `rPackages.{fixest,paxtoolsr}: fix new builds requiring home`                        |
| [`212cdd5c`](https://github.com/NixOS/nixpkgs/commit/212cdd5c3903982a34af898274e71b5c378a6fea) | `vpnc: remove unnecessary substitution`                                              |
| [`ddda0d42`](https://github.com/NixOS/nixpkgs/commit/ddda0d423843969c5f38f9fb8a67d2540c501752) | `passff-host: 1.2.1 -> 1.2.2`                                                        |
| [`b97a25a3`](https://github.com/NixOS/nixpkgs/commit/b97a25a3c1936c95cf68a2df6adb7560e9a813aa) | `nextdns: 1.37.2 -> 1.37.3`                                                          |
| [`5c7e0b2e`](https://github.com/NixOS/nixpkgs/commit/5c7e0b2e70a72f6cbf05e32ab0acb8756808cfd7) | `mixxx: 2.3.0 -> 2.3.1`                                                              |
| [`bdc35a61`](https://github.com/NixOS/nixpkgs/commit/bdc35a61074c10e7f59f8d028da263e64940cd3b) | `minitube: 3.8.1 -> 3.9.1`                                                           |
| [`3c6769b9`](https://github.com/NixOS/nixpkgs/commit/3c6769b9758c97f8f1a374cbc5e2f06e789d1cbc) | `rPackages: CRAN and BioC update`                                                    |
| [`257a939c`](https://github.com/NixOS/nixpkgs/commit/257a939cfc516662ec01dd117d0bb45a5338f6a5) | `R: 4.1.1 -> 4.1.2`                                                                  |
| [`f7add182`](https://github.com/NixOS/nixpkgs/commit/f7add18261df368ee871f608700ec1437d7fe660) | `top-level/release-r.nix: disable x86_64-darwin`                                     |
| [`19725aa5`](https://github.com/NixOS/nixpkgs/commit/19725aa59ac0cf1ede551113984f604382bc0426) | `tdesktop: 3.1.9 -> 3.1.11`                                                          |
| [`2f8b77a7`](https://github.com/NixOS/nixpkgs/commit/2f8b77a74d763a42698dc56f5a6d87386d21b398) | `python3Packages.aioshelly: 1.0.2 -> 1.0.3`                                          |
| [`281d57c9`](https://github.com/NixOS/nixpkgs/commit/281d57c93874f49d35c7f2f011cd84ea4929ae09) | `sympa: 6.2.64 -> 6.2.66`                                                            |
| [`1bd71f3e`](https://github.com/NixOS/nixpkgs/commit/1bd71f3e96ddf91a89217521cf329d74a7631298) | `terraform-providers.lxd: 1.5.0 -> 1.6.0`                                            |
| [`41c7806d`](https://github.com/NixOS/nixpkgs/commit/41c7806df50a88b723667969c3d3078bf298226f) | `zsh: fix `git stash drop` completions`                                              |
| [`2923a0fb`](https://github.com/NixOS/nixpkgs/commit/2923a0fbab77b7bbb25de96bfe5b332595305d08) | `cudatoolkit: 11.4.1 -> 11.4.2`                                                      |
| [`8316ec9e`](https://github.com/NixOS/nixpkgs/commit/8316ec9e4ed3743517f6ddb6323b1a5588f9cdb5) | `cudatoolkit: add 11.5.0`                                                            |
| [`fd49494b`](https://github.com/NixOS/nixpkgs/commit/fd49494b61bc6bc97330317da21385a48e3b143c) | `precice: 2.2.1 -> 2.3.0`                                                            |
| [`a6448ad3`](https://github.com/NixOS/nixpkgs/commit/a6448ad36e050066daae5897a66598a1ade2299a) | `cutensor: make 11_4 as default 11`                                                  |
| [`20d65c58`](https://github.com/NixOS/nixpkgs/commit/20d65c583861362bc630123c49da42efe109ed78) | `cudnn: make 11_4 as default 11`                                                     |
| [`7f98fe1e`](https://github.com/NixOS/nixpkgs/commit/7f98fe1ebdd7f551fe698ec704c648d7aec8a2a7) | `cudatoolkit: make 11_4 as default 11`                                               |
| [`9650d42a`](https://github.com/NixOS/nixpkgs/commit/9650d42a4c3e12e0df3a0b8e9c0209b8ceb438f5) | `cutensor: 1.2.2.5 -> 1.3.1.3`                                                       |
| [`e6da69e8`](https://github.com/NixOS/nixpkgs/commit/e6da69e878f956fa179169024c1458708635f1d9) | `cudatolkit: fix documentation into $doc output`                                     |
| [`659354f0`](https://github.com/NixOS/nixpkgs/commit/659354f0b75929c84ab53c57787e26fbb8d6e506) | `cudnn_cudatoolkit: init 11_3 and 11_4`                                              |