### PR TITLE
chore(flake/inputs/sops-nix): `16e94d49` -> `517628cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1636286244,
-        "narHash": "sha256-vrF0KS5+9FTY/W97q3quW3PB83Dl8TOd/c5MkToAeVU=",
+        "lastModified": 1636295684,
+        "narHash": "sha256-vm8GaHZFnBcftqrfpIr27rCNfU9g3ZqByks9dto6D3M=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "16e94d49ea37ba09d62add45a6495e9e19f95208",
+        "rev": "517628cc1defc90191f0e1380f8f83e590dd6b56",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                               |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`8bdf7d09`](https://github.com/Mic92/sops-nix/commit/8bdf7d099372b723e17684fa1dd3161befe0a7b3) | `fix nix flake check on macOS`               |
| [`bac08f69`](https://github.com/Mic92/sops-nix/commit/bac08f691921672be782d3c19ccb7b15cdc46820) | `Allow setting user passwords`               |
| [`79706f67`](https://github.com/Mic92/sops-nix/commit/79706f6748a0a001f3120cc3e3c276d2d83730cd) | `Fix secrets mount point and remove default` |