### PR TITLE
chore(flake/inputs/nixos-hardware): `518b9c21` -> `fd6f34af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -77,11 +77,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1635449388,
-        "narHash": "sha256-i7hMiAgpRTGsMPTQKuNCDfW/ftQ+g9N6iaMj+RN6yws=",
+        "lastModified": 1636317251,
+        "narHash": "sha256-u1cWvvtGH5mfGkeIKrqw2usk4IL7wDiRcnJkUSiZq3Q=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "518b9c2159e7d4b7696ee18b8828f9086012923b",
+        "rev": "fd6f34afcf062761fb5035230f6297752bfedcba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message               |
| ----------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`b50c73d4`](https://github.com/NixOS/nixos-hardware/commit/b50c73d420405517c9fa35fe3f565782a7562be9) | `Update README and flakes`   |
| [`b2083d1b`](https://github.com/NixOS/nixos-hardware/commit/b2083d1b60565857adbf7f27963362e5b1afc14a) | `Dell latitude 7490 support` |