### PR TITLE
chore(flake/inputs/nixpkgs): `81d15682` -> `c9acf478`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1636254356,
-        "narHash": "sha256-eBujs6+KrAa0WqYwo/zUmzRohKFBqP52x2EcNw5arwE=",
+        "lastModified": 1636300541,
+        "narHash": "sha256-UiaOhzCeJX0EpHl/iVxsqpoS0blSG2yZnR4JrN8GcvM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "81d15682625635d93ba66def75fd13fd16c0515b",
+        "rev": "c9acf4782f2a830da29c18b77ec564cb73e22946",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                             |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`8fc318ae`](https://github.com/NixOS/nixpkgs/commit/8fc318aebeee655dbf7edf81120d66f79272cf90) | `exploitdb: 2021-11-05 -> 2021-11-06`                                      |
| [`416369dc`](https://github.com/NixOS/nixpkgs/commit/416369dc847fafaffb57758c00eb5ac9cb009705) | `samba: fix ceph library path`                                             |
| [`8d197bff`](https://github.com/NixOS/nixpkgs/commit/8d197bffd80e21f34c3f52379d93a565444ea189) | `nixos/proxmox-image: init (#144013)`                                      |
| [`102fe107`](https://github.com/NixOS/nixpkgs/commit/102fe107456266547063657deb02c11550454cf2) | `devilutionx: include patch to compile with system SDL2_image`             |
| [`565d6329`](https://github.com/NixOS/nixpkgs/commit/565d63295200f44948f384e0523336c511b60fb6) | `devilutionx: 1.2.1 -> 1.3.0`                                              |
| [`573849ce`](https://github.com/NixOS/nixpkgs/commit/573849ce89f5fc5b18a8979d4496f09ac031880c) | `smpq: init at 1.6`                                                        |
| [`beed35c4`](https://github.com/NixOS/nixpkgs/commit/beed35c41747f033f64cc1d7def4220837140271) | `StormLib: init at 9.22`                                                   |
| [`d1a8806e`](https://github.com/NixOS/nixpkgs/commit/d1a8806e3910ed32d1d702c21b9375297292305e) | `nixos/mastodon: allow '@resources' filter to mastodon-web service`        |
| [`024f518e`](https://github.com/NixOS/nixpkgs/commit/024f518e65ffbe64f0f044b194ad15ec2e973788) | `yarn: 1.22.15 -> 1.22.17 (#144974)`                                       |
| [`db34ebb5`](https://github.com/NixOS/nixpkgs/commit/db34ebb557cd299b0389ef999bc670f05727e820) | `loki: 2.3.0 -> 2.4.0`                                                     |
| [`40c83d1e`](https://github.com/NixOS/nixpkgs/commit/40c83d1e0a0708a16c0c917d231082f6352b38fe) | `virtualbox: Add option to build vboxwebsrv tool`                          |
| [`7e0f6ddd`](https://github.com/NixOS/nixpkgs/commit/7e0f6ddda2a4e52effc40306aacb3a7672fa45c4) | `python3Packages.hbmqtt: drop`                                             |
| [`4c6d0451`](https://github.com/NixOS/nixpkgs/commit/4c6d0451b2dd909f1f3f6eab8403cc34b1870670) | `ffmpeg_2{,_8}: remove`                                                    |
| [`1d177d5a`](https://github.com/NixOS/nixpkgs/commit/1d177d5a70ad0f52a70f68196e69369bf73c8256) | `stepmania: build with newer ffmpeg`                                       |
| [`1777da08`](https://github.com/NixOS/nixpkgs/commit/1777da08a3edef2f6afd9f248dab77a71ed0dd6c) | `gnash: build with newer ffmpeg`                                           |
| [`960eb082`](https://github.com/NixOS/nixpkgs/commit/960eb082f1013536268bbb3bf7ff0969dc6c631b) | `pcsxr: build with newer ffmpeg`                                           |
| [`4dcf909d`](https://github.com/NixOS/nixpkgs/commit/4dcf909d0437df6dc606a9117a8c00f30c70270b) | `pngout: 20150319 -> 20200115`                                             |
| [`59b832d5`](https://github.com/NixOS/nixpkgs/commit/59b832d51a016675256f5d828f563d8be9b2ce3f) | `spidermonkey_91: init at 91.3.0`                                          |
| [`5f12f89a`](https://github.com/NixOS/nixpkgs/commit/5f12f89a6ff32543ad7661c788f93cd9ffbd2010) | `spidermonkey_68: 68.10.0 -> 68.12.0`                                      |
| [`182a36bc`](https://github.com/NixOS/nixpkgs/commit/182a36bc33e399a7f3e607cfe6e3d4d990ed1651) | `spidermonkey: drop unused patches`                                        |
| [`68ca39a7`](https://github.com/NixOS/nixpkgs/commit/68ca39a775a637f289c63248b64443ef7342f6ad) | `winetricks: remove wine dependency`                                       |
| [`ef8eb42d`](https://github.com/NixOS/nixpkgs/commit/ef8eb42db58c2bc0d270054ed16567b51ab92c20) | `msmtp: 1.8.18 -> 1.8.19`                                                  |
| [`ca38dd2a`](https://github.com/NixOS/nixpkgs/commit/ca38dd2a47b11a44f9961c90b17e9faaec1a6a98) | `python3Packages.solo-python: 0.0.30 -> 0.0.31`                            |
| [`f1b83980`](https://github.com/NixOS/nixpkgs/commit/f1b83980d37567eeed64dcb5a7a1fd2d4a84e1ba) | `python3Packages.fastecdsa: migrate to disabledTestPaths`                  |
| [`6f9c9425`](https://github.com/NixOS/nixpkgs/commit/6f9c942585613f3dd4e7662ae906d20911d9b49a) | `couchdb3: 3.2.0 -> 3.2.1`                                                 |
| [`9af25ef3`](https://github.com/NixOS/nixpkgs/commit/9af25ef30bb15cca4996943af31909007432f9e7) | `smemstat: pull pending upstream inclusion fix for ncurses-6.3`            |
| [`a5293373`](https://github.com/NixOS/nixpkgs/commit/a529337334ec8b4a5331c9ae8e481582f8c74423) | `dropbox: Fix missing icon from the desktop item`                          |
| [`0be2bcf9`](https://github.com/NixOS/nixpkgs/commit/0be2bcf9288ce0648e03e0dd3ac196cd381b28b8) | `linux: 5.4.157 -> 5.4.158`                                                |
| [`235c88c0`](https://github.com/NixOS/nixpkgs/commit/235c88c09416bc32e97c77766701f25dece0e737) | `linux: 5.15 -> 5.15.1`                                                    |
| [`ded9d6fd`](https://github.com/NixOS/nixpkgs/commit/ded9d6fd05ad4d6f6d890054b5335abe4f976f64) | `linux: 5.14.16 -> 5.14.17`                                                |
| [`154f16fc`](https://github.com/NixOS/nixpkgs/commit/154f16fc533e1cdd732b83ba6f546d3bda47ecfe) | `linux: 5.10.77 -> 5.10.78`                                                |
| [`69d066da`](https://github.com/NixOS/nixpkgs/commit/69d066da7063b8b8b8526daa412f313e94da79e9) | `linux: 4.19.215 -> 4.19.216`                                              |
| [`caeefb8b`](https://github.com/NixOS/nixpkgs/commit/caeefb8bd128c7928fdbd2b66b905776b47112f5) | `ansifilter: fix non-determinism in gzipped manpages with s/gzip/gzip -n/` |
| [`87d250e6`](https://github.com/NixOS/nixpkgs/commit/87d250e6554161db681fef23ff92cbe5879b0092) | `cpuid: 20201006 -> 20211031`                                              |
| [`54ee0fad`](https://github.com/NixOS/nixpkgs/commit/54ee0fad2eff900f417de96686a7ad760c82175d) | `coconut: 1.5.0 → 1.6.0`                                                   |
| [`e978251c`](https://github.com/NixOS/nixpkgs/commit/e978251cfb8dd231851349c1a154fd054fb8bed7) | `cpyparsing: 2.4.5.0.1.2 → 2.4.7.1.0.0`                                    |
| [`08674415`](https://github.com/NixOS/nixpkgs/commit/0867441532e8a80619ebef64c91eb18b6862aa50) | `vscodium: 1.61.2 -> 1.62.0`                                               |
| [`7e76b12d`](https://github.com/NixOS/nixpkgs/commit/7e76b12d57ba7bcb77e178fbfb60b5597f061f52) | `nixos/waydroid: init`                                                     |
| [`d946c455`](https://github.com/NixOS/nixpkgs/commit/d946c455f02586ba62afb145976bbda3e6399ca5) | `lxd: 4.19 -> 4.20`                                                        |
| [`5f6472a1`](https://github.com/NixOS/nixpkgs/commit/5f6472a107128fe6c015f8e47d60d4c4ef64789a) | `eternal-terminal: 6.1.8 -> 6.1.9`                                         |
| [`7d34d32b`](https://github.com/NixOS/nixpkgs/commit/7d34d32b3df0614724d0960cff9baf1837a5996a) | `nixos/prometheus: add remaining service discovery options`                |
| [`6e769832`](https://github.com/NixOS/nixpkgs/commit/6e7698327aebc3f8a1bbb2d344f6675a88fdb08e) | `ultimate-oldschool-pc-font-pack: 2.0 -> 2.2`                              |
| [`3702a818`](https://github.com/NixOS/nixpkgs/commit/3702a81873d891dc5d256ea555562ee52e71389b) | `vscode: 1.61.2 -> 1.62.0`                                                 |
| [`b3d4f6d8`](https://github.com/NixOS/nixpkgs/commit/b3d4f6d8416e66a57d9685ee16fdf2bbb261182c) | `nixos/prometheus: add service discovery options`                          |
| [`904d29e1`](https://github.com/NixOS/nixpkgs/commit/904d29e1c470d559fccf359c95607ab49b35b978) | `nixos/prometheus: add new configuration options`                          |
| [`0cd97657`](https://github.com/NixOS/nixpkgs/commit/0cd976570f8ff2519f04872f822a51ed865ea9c6) | `nosqli: 0.5.2 -> 0.5.4`                                                   |
| [`ed16d218`](https://github.com/NixOS/nixpkgs/commit/ed16d2189797dcc7d50afdf154b5f54fc655d79d) | `clojure-lsp: 2021.09.30-15.28.01 -> 2021.11.02-15.24.47`                  |
| [`fa80fb5c`](https://github.com/NixOS/nixpkgs/commit/fa80fb5cf481b9a458aed3c3fb33198ca2fef2ce) | `kwin: bypass environment variables from ld.so`                            |
| [`ce6dc57d`](https://github.com/NixOS/nixpkgs/commit/ce6dc57db10dfc2f94471c8e08459132a0b9e53a) | `zydis: 3.1.0 -> 3.2.0`                                                    |
| [`831dae0b`](https://github.com/NixOS/nixpkgs/commit/831dae0b8f80801d4014cace886340dc6cb3650f) | `yubikey-manager: 4.0.5 -> 4.0.7`                                          |
| [`4f16e1e4`](https://github.com/NixOS/nixpkgs/commit/4f16e1e400a93acccda9f49d933675831944490d) | `metasploit: Fix python modules`                                           |
| [`c319107a`](https://github.com/NixOS/nixpkgs/commit/c319107a930fc1bbec20751faafab6409ef61c6b) | `prometheus: 2.27.1 -> 2.30.3`                                             |