### PR TITLE
chore(flake/inputs/nixpkgs): `c9acf478` -> `1e6d3c55`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1636300541,
-        "narHash": "sha256-UiaOhzCeJX0EpHl/iVxsqpoS0blSG2yZnR4JrN8GcvM=",
+        "lastModified": 1636343876,
+        "narHash": "sha256-6chye5fw5dpoJ+PGbL2J8yROo7POin3nFCk8yULvHO4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c9acf4782f2a830da29c18b77ec564cb73e22946",
+        "rev": "1e6d3c55f0a11e85cd22d361ce02da351f833d5a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                         |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`372a7456`](https://github.com/NixOS/nixpkgs/commit/372a7456a8d0e7cbceb9ef8ba9a889be7baa895c) | `nix: disable separateDebugInfo for nix_2_4 static`                    |
| [`0d6fec73`](https://github.com/NixOS/nixpkgs/commit/0d6fec737acbac2bc17205938459f5360c2de95f) | `nix_2_4: fix NIX_LDFLAGS`                                             |
| [`c37c7299`](https://github.com/NixOS/nixpkgs/commit/c37c7299aba0269ce25757e9b433dfe42c1a452e) | `nixFlakes: nixUnstable -> nix_2_4`                                    |
| [`971f4a09`](https://github.com/NixOS/nixpkgs/commit/971f4a097caf6be19b1b894f30b4cc7f9abdeec2) | `nix_2_3: init @ 2.3.16`                                               |
| [`93e78204`](https://github.com/NixOS/nixpkgs/commit/93e78204491f38b6a94eb1b4bbed01c2b4cd5bf0) | `nix_2_4: 2.4pre-rc1 -> 2.4`                                           |
| [`772069c2`](https://github.com/NixOS/nixpkgs/commit/772069c287600817e9ec64ab5e459b57a847b2f6) | `handbrake: mark broken on darwin < 10.13`                             |
| [`e24463bc`](https://github.com/NixOS/nixpkgs/commit/e24463bcc92ccd58584fbfda8c2dd661b7858450) | `nvidia-x11: Add update comment`                                       |
| [`ea33beda`](https://github.com/NixOS/nixpkgs/commit/ea33beda928094fc7d5709fdcb110a99773914a0) | `kopia: 0.9.4 -> 0.9.5`                                                |
| [`c39ad5be`](https://github.com/NixOS/nixpkgs/commit/c39ad5be5eb81c4cc0edf7fbb756d4f2d5a7f095) | `numberstation: 0.5.0 -> 1.0.0`                                        |
| [`b06550ed`](https://github.com/NixOS/nixpkgs/commit/b06550ed1feaf4f538b44001645052e0de87286e) | `phpmd: Fix meta.broken`                                               |
| [`fbdf7823`](https://github.com/NixOS/nixpkgs/commit/fbdf78236a346f57f716fb66ed62e1993260c9e5) | `pkgs/applications: rename name to pname&version part 1 (#144949)`     |
| [`b4fab0a9`](https://github.com/NixOS/nixpkgs/commit/b4fab0a98b28ee09102aeac511a967be6253572e) | `treewide: remove fmt from buildInputs where spdlog is used`           |
| [`f06cec95`](https://github.com/NixOS/nixpkgs/commit/f06cec9564a2fc6b85d92398551a0c059fc4db86) | `spdlog: 1.8.5 -> 1.9.2`                                               |
| [`8f499b97`](https://github.com/NixOS/nixpkgs/commit/8f499b97ad9c9d7fad6423fa4d334db11a860494) | `firefox: 94.0 -> 94.0.1`                                              |
| [`18ed048c`](https://github.com/NixOS/nixpkgs/commit/18ed048c7b27e288a6c9ba894790a7e67ed5080d) | `build-support/rust: Organize`                                         |
| [`b142bd35`](https://github.com/NixOS/nixpkgs/commit/b142bd35d508ce0cfb0abc9814ebb1cc07704d4f) | `nixos/neovim: fix withRuby, add with{Python3,NodeJs}`                 |
| [`155c4ad5`](https://github.com/NixOS/nixpkgs/commit/155c4ad5ab5c5ef7f1da4fe012fae21bb97a25a8) | `vimPlugins.stabilize-nvim: init at 2021-11-07`                        |
| [`de696e21`](https://github.com/NixOS/nixpkgs/commit/de696e213f12a995e4ed6fe11291a6793db73781) | `vimPlugins: update`                                                   |
| [`b0088eb8`](https://github.com/NixOS/nixpkgs/commit/b0088eb87347b6f1799d25355a657c586c3eb24b) | `python3Packages.pyemby: 1.7 -> 1.8`                                   |
| [`6d6fe244`](https://github.com/NixOS/nixpkgs/commit/6d6fe2447e8766c3e6efbdedf32a54446809b888) | `zydis: fix upgrade`                                                   |
| [`ea5437f8`](https://github.com/NixOS/nixpkgs/commit/ea5437f80c60bb7a8c5ca258dd443aa96c5e763f) | `arrow-cpp: add GCS feature flag (#144610)`                            |
| [`cfb91f81`](https://github.com/NixOS/nixpkgs/commit/cfb91f812b79cdf923f63e2cbb6dd5f09c03122c) | `python3Packages.commoncode: disable test_searchable_paths on darwin`  |
| [`eca55443`](https://github.com/NixOS/nixpkgs/commit/eca554435e6acdc412825f2fb0683ccd423ea6bb) | `cloog: enable parallel building, explicitly disable parallel testing` |
| [`a2149a2e`](https://github.com/NixOS/nixpkgs/commit/a2149a2ee2134efcbc398e6129f65903dd466f9b) | `lima: 0.7.2 -> 0.7.3`                                                 |
| [`7d64d4b1`](https://github.com/NixOS/nixpkgs/commit/7d64d4b197ec74e66532cce8dbf6a440e9a22ebc) | `factorio{,demo,headless}: 1.1.42 -> 1.1.46`                           |
| [`b52ab3b7`](https://github.com/NixOS/nixpkgs/commit/b52ab3b712cc44b5eb88557ad2ca206dcd10af20) | `pkgs/applications: rename name to pname&version part 2`               |
| [`5c72b636`](https://github.com/NixOS/nixpkgs/commit/5c72b63690eaed2f5aa10f8cad3df0b43cd267a4) | `fscryptctl: Fix meta.changelog`                                       |
| [`afdd9ddb`](https://github.com/NixOS/nixpkgs/commit/afdd9ddbfa130f93d5861c2ca4635f735cf0c9db) | `fscryptctl-experimental: remove the package`                          |
| [`056d880f`](https://github.com/NixOS/nixpkgs/commit/056d880f90dc1e1a89ea5f349b6408337397650d) | `helmfile: Stop prefixing PATH with kubernetes-helm`                   |
| [`dc5e6713`](https://github.com/NixOS/nixpkgs/commit/dc5e6713e4f63fdf69174e99725498ca8fc247d1) | `rspamd: add lewo as maintainer`                                       |
| [`db20747d`](https://github.com/NixOS/nixpkgs/commit/db20747d364aad0f3e474873152155295ec3aa4a) | `rpsamd: 3.0 -> 3.1`                                                   |
| [`6661cb08`](https://github.com/NixOS/nixpkgs/commit/6661cb0887876cc2d3a96adf832ce20a114fbc96) | `kakoune: 2021.10.28 -> 2021.11.08`                                    |
| [`f3e1b319`](https://github.com/NixOS/nixpkgs/commit/f3e1b3194b09e604abba94c811e90321020263d9) | `python3Packages.slackclient: disable broken tests on darwin`          |
| [`f55376e8`](https://github.com/NixOS/nixpkgs/commit/f55376e8753e36ce1bb629273743fdfa349c0972) | `tiny: 0.9.0 -> 0.10.0`                                                |
| [`2ef3df9e`](https://github.com/NixOS/nixpkgs/commit/2ef3df9e93621b672c274cd739f6e6c251616fc4) | `notmuch: 0.34 -> 0.34.1`                                              |
| [`ba3bf3b9`](https://github.com/NixOS/nixpkgs/commit/ba3bf3b9f69eb3a3e0281bb40b45532b74822f1e) | `racket: 8.2 -> 8.3`                                                   |
| [`ff0d921b`](https://github.com/NixOS/nixpkgs/commit/ff0d921b21da7e7e210874bbb18a007428d2571d) | `kde-gear: 21.08.2 -> 21.08.3`                                         |
| [`f3ee1060`](https://github.com/NixOS/nixpkgs/commit/f3ee1060747b49902533568bf1ba2ecd4127fc76) | `kubebuilder: 3.1.0 -> 3.2.0`                                          |
| [`9dc25578`](https://github.com/NixOS/nixpkgs/commit/9dc255786375a0c0cd82e483efe6fa58c6dd2b9f) | `ayu-theme-gtk: init @ unstable-2017-05-12`                            |
| [`06919741`](https://github.com/NixOS/nixpkgs/commit/0691974106f9f6c725e96d75852a48042f1471b0) | `python3Packages.pyspnego: 0.3.0 -> 0.3.1`                             |
| [`b1d97b20`](https://github.com/NixOS/nixpkgs/commit/b1d97b202c8e0f6b70fcb37769108efa16666733) | `py-spy: 0.3.9 -> 0.3.10`                                              |
| [`ab9ecf61`](https://github.com/NixOS/nixpkgs/commit/ab9ecf61c70d445fdcfdf47ae6a8629767304cde) | `vpnc: remove unnecessary patch`                                       |
| [`fdc681b8`](https://github.com/NixOS/nixpkgs/commit/fdc681b8b9aa5332171a1c7fced919ac954488fc) | `autorestic: 1.2.0 -> 1.3.0`                                           |