### PR TITLE
chore(flake/inputs/nixpkgs): `1e6d3c55` -> `93c6633d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1636343876,
-        "narHash": "sha256-6chye5fw5dpoJ+PGbL2J8yROo7POin3nFCk8yULvHO4=",
+        "lastModified": 1636387988,
+        "narHash": "sha256-ojyXiWo8ygP8Z07J8V2ZyUu9UzaEMaY/wkSuzXNmOZA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1e6d3c55f0a11e85cd22d361ce02da351f833d5a",
+        "rev": "93c6633d1f830f88be1bfee5717e54dc02538bae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`93c6633d`](https://github.com/NixOS/nixpkgs/commit/93c6633d1f830f88be1bfee5717e54dc02538bae) | `linuxKernel.packages.linux_5_14_hardened.vhba: 20210418 -> 20211023`                         |
| [`199345b4`](https://github.com/NixOS/nixpkgs/commit/199345b4c85920abbf6ba3d55ea2d507ac921f5c) | `nodePackages.@gitbeaker/cli: init at 34.5.0`                                                 |
| [`01cff5cd`](https://github.com/NixOS/nixpkgs/commit/01cff5cd100d1e8e217bdf44c8973470047ad399) | `python3Packages.skytemple-files: 1.3.2 -> 1.3.3`                                             |
| [`56137af9`](https://github.com/NixOS/nixpkgs/commit/56137af9f1b6f89329d55de169e0eefee57e8263) | `qbittorrent: 4.3.8 -> 4.3.9`                                                                 |
| [`39bd3726`](https://github.com/NixOS/nixpkgs/commit/39bd3726a1fa90a3cf8609110ebef42a025b4632) | `stylua: 0.11.0 -> 0.11.1`                                                                    |
| [`dcb453fd`](https://github.com/NixOS/nixpkgs/commit/dcb453fde4585c6567ecc8bbea7862f84527be71) | `srain: init at 1.3.0`                                                                        |
| [`9102043e`](https://github.com/NixOS/nixpkgs/commit/9102043eff76bf470b3180599a84e8f1fd9f1a35) | `nftables: clarify license`                                                                   |
| [`5f725c07`](https://github.com/NixOS/nixpkgs/commit/5f725c075facb718699b26ca3d8d971f701b22c9) | `tdlib: 1.7.8 -> 1.7.9`                                                                       |
| [`c11d08f0`](https://github.com/NixOS/nixpkgs/commit/c11d08f02390aab49e7c22e6d0ea9b176394d961) | `synergy: 1.13.1.41 -> 1.14.1.32`                                                             |
| [`753a895a`](https://github.com/NixOS/nixpkgs/commit/753a895ad2d9576e13f3d6e452480b37b54baced) | `turbogit: fix libgit2 dependency`                                                            |
| [`ae4666c4`](https://github.com/NixOS/nixpkgs/commit/ae4666c41591b40315ff19f41c4d27a349dc4153) | `darwin.rewrite-tbd: only build on darwin`                                                    |
| [`68e45783`](https://github.com/NixOS/nixpkgs/commit/68e457839c61d3027a3f6bb55f90b34068800db9) | `halfempty: fix tests via patch of unreleased commit`                                         |
| [`9d0de091`](https://github.com/NixOS/nixpkgs/commit/9d0de09147681cf160537699fe4f38b9c6f78149) | `tree-sitter: update grammars`                                                                |
| [`dfe107b2`](https://github.com/NixOS/nixpkgs/commit/dfe107b23cbb08e459742b467f04a3b773073335) | `gitaly: fix libgit2 dependency`                                                              |
| [`7635b869`](https://github.com/NixOS/nixpkgs/commit/7635b869ce14b96f1d755b7058a93dd48f5bb2a9) | `genymotion: 2.8.0 -> 3.2.1`                                                                  |
| [`9e1e3f53`](https://github.com/NixOS/nixpkgs/commit/9e1e3f53655656787e644fef758c7099e8fe4110) | `postgresql: add myself to maintainers`                                                       |
| [`7a12cae1`](https://github.com/NixOS/nixpkgs/commit/7a12cae1b10f86276a93a5f1d06c9ab4c0f6d7e2) | `postgresql_14: build with support for lz4 compression`                                       |
| [`e9f274bb`](https://github.com/NixOS/nixpkgs/commit/e9f274bb5715472aa8af583ccbf666ddbdb50291) | `ddnet: 15.5.4 -> 15.6.2`                                                                     |
| [`e6dd8c65`](https://github.com/NixOS/nixpkgs/commit/e6dd8c652ea6066e3c010aa5d23b94b57afee22e) | `Add missing postgresql14Packages`                                                            |
| [`666abf9a`](https://github.com/NixOS/nixpkgs/commit/666abf9a4a9edf1c3c6ff4bce61cb6a5c5153650) | `maintainers: add rewine`                                                                     |
| [`0bae31b6`](https://github.com/NixOS/nixpkgs/commit/0bae31b6a85a4f237f1beaeeb6a9211fe2123212) | `python3Packages.translatepy: 2.1 -> 2.2`                                                     |
| [`5aa2b0f0`](https://github.com/NixOS/nixpkgs/commit/5aa2b0f0bff7b561565f62b08d9bd0017953f44e) | `python3Packages.pygame: 2.0.1 -> 2.1.0`                                                      |
| [`55b68d31`](https://github.com/NixOS/nixpkgs/commit/55b68d31884a7ab75eb8d48c8a3a20920113bfa3) | `timidity: enable darwin support`                                                             |
| [`37015cdf`](https://github.com/NixOS/nixpkgs/commit/37015cdfd3f74378a174c21fde8e2c87db101eb6) | `tagutil: prePatch -> postPatch`                                                              |
| [`4a6977ef`](https://github.com/NixOS/nixpkgs/commit/4a6977ef2aa2c1786899b0b4157c2afe2ce8b971) | `checkov: 2.0.549 -> 2.0.554`                                                                 |
| [`a27ca079`](https://github.com/NixOS/nixpkgs/commit/a27ca079150a1276435d8dc85bc9b61b4f3f70dc) | `tinycbor: 0.5.4 -> 0.6.0`                                                                    |
| [`afbc5757`](https://github.com/NixOS/nixpkgs/commit/afbc5757eae4eea80e56db5bfe166bfecd0f8ba3) | `shellharden: 4.1.2 -> 4.1.3`                                                                 |
| [`8b172178`](https://github.com/NixOS/nixpkgs/commit/8b172178c8407aaed506753374400c7b70df0850) | `vscode-extensions.ms-python.python: 2021.10.1365161279 -> 2021.11.1422169775`                |
| [`253b4665`](https://github.com/NixOS/nixpkgs/commit/253b466563ae4afba0078da6b15c60cbeef5e715) | `vscode-extensions.ms-python.python: 2021.10.1336267007 -> 2021.10.1365161279`                |
| [`28deca80`](https://github.com/NixOS/nixpkgs/commit/28deca80866cd7cd069331d4feb2ea9f4a7fa9f2) | `vscode-extensions.ms-vscode.cpptools: 1.7.0 -> 1.7.1`                                        |
| [`2ccca428`](https://github.com/NixOS/nixpkgs/commit/2ccca428632387a1e9b2b65ebc42605b78aba287) | `vscode-extensions.vscode-wakatime.WakaTime: 17.0.8 -> 17.1.0`                                |
| [`a533fb17`](https://github.com/NixOS/nixpkgs/commit/a533fb1788eeb53639b6e8131a734fff5d49e8fc) | `vscode-extensions.ms-vscode.cpptools: 1.6.0 -> 1.7.0`                                        |
| [`a4320e7f`](https://github.com/NixOS/nixpkgs/commit/a4320e7f16082608df41cd4c0b65a1adbe7c37b5) | `vscode-extensions.ms-python.python: 2021.9.1246542782 -> 2021.10.1336267007`                 |
| [`74c2c269`](https://github.com/NixOS/nixpkgs/commit/74c2c2692e307a32603d8f552ea1e21b0020293e) | `vscode-extensions.ms-vscode.cpptools: fix OpenDebugAD7 path`                                 |
| [`fdf78664`](https://github.com/NixOS/nixpkgs/commit/fdf78664f89052882e5e64ef8fc96b7185e6f54c) | `vscode-extensions.WakaTime.vscode-wakatime: 4.0.9 -> 17.0.8`                                 |
| [`238eae39`](https://github.com/NixOS/nixpkgs/commit/238eae397572c5e784498d13f3fd8ab3ec4bd7ea) | `wakatime: 13.0.7 -> 1.18.7`                                                                  |
| [`41a611a2`](https://github.com/NixOS/nixpkgs/commit/41a611a2adfff3d4cc4e78573a8405b13475c5ae) | `vscode-extensions.ms-python.python: 2021.5.829140558 -> 2021.9.1246542782`                   |
| [`d1d5134a`](https://github.com/NixOS/nixpkgs/commit/d1d5134a94bcfde6c17dad8f9b05edfcadf3bdd6) | `vscode-extensions.ms-vscode.cpptools: 1.0.1 -> 1.6.0`                                        |
| [`71667c5d`](https://github.com/NixOS/nixpkgs/commit/71667c5d769188e850271501b5491942b6a475ac) | `tree-sitter: add beancount grammar`                                                          |
| [`580e5347`](https://github.com/NixOS/nixpkgs/commit/580e53479ac07bd4165989a372a51ea1dbfdb2f3) | `pythonPackages.bleak: 0.12.1 -> 0.13.0`                                                      |
| [`9467e117`](https://github.com/NixOS/nixpkgs/commit/9467e1178c5b5d711ed43e3c16c91b9e117d60c2) | `trayer: minor formatting`                                                                    |
| [`023922bc`](https://github.com/NixOS/nixpkgs/commit/023922bcd1ed9bf56fe3a0e122f604b6046b2354) | `tabbed: switch to pname+version, move with lib to meta`                                      |
| [`86bf5eb0`](https://github.com/NixOS/nixpkgs/commit/86bf5eb0bbdb5dcbeeff9e372d5743c520c728bf) | `ion-3: switch to pname+verison, format`                                                      |
| [`0c9bc761`](https://github.com/NixOS/nixpkgs/commit/0c9bc761b916ddb1a4d33fd64f68c8eeaaaf9294) | `nco: change prePatch to postPatch, minor formatting`                                         |
| [`d49083f4`](https://github.com/NixOS/nixpkgs/commit/d49083f40de085a2ab09fe3868645c6f03c5c89f) | `i3/lock-fancy: switch ot pname+version, cleanup postPatch`                                   |
| [`0a415f33`](https://github.com/NixOS/nixpkgs/commit/0a415f33c1e925c3f74b351da9240043c8c7f9b9) | `evilwm: change prePatch to postPatch`                                                        |
| [`4b0803dc`](https://github.com/NixOS/nixpkgs/commit/4b0803dc73f3b909069cd1587b51ba42898284d6) | `hexcurse: pull pending upstream inclusion fix for ncurses-6.3`                               |
| [`5e811cc8`](https://github.com/NixOS/nixpkgs/commit/5e811cc8534e1b2e90c53b6e4676161c59ff1574) | `gpxsee: 9.6 → 9.11`                                                                          |
| [`8adc5ddd`](https://github.com/NixOS/nixpkgs/commit/8adc5dddd817e25526fa117b27e30f91de533109) | `dunst: 1.7.0 -> 1.7.1`                                                                       |
| [`2aa37af3`](https://github.com/NixOS/nixpkgs/commit/2aa37af32d1bd308cbc7f0be44a6a63f31dd13d0) | `clisp: explicitly disable build parallelism due to missing depends`                          |
| [`bfa20507`](https://github.com/NixOS/nixpkgs/commit/bfa2050737905b14a32531576757c5f26775a36a) | `sqlfluff: 0.7.1 -> 0.8.1`                                                                    |
| [`977a3e5a`](https://github.com/NixOS/nixpkgs/commit/977a3e5a10af154c5769284702e52a77b46bd5f6) | `sfm: 0.3.1 → 0.4`                                                                            |
| [`07933763`](https://github.com/NixOS/nixpkgs/commit/07933763b07cc578bcb23fb91769098e47949c81) | `wolfssl: 4.8.1 -> 5.0.0`                                                                     |
| [`4e5a2458`](https://github.com/NixOS/nixpkgs/commit/4e5a245894f87ab4ed77babcf8db0e8081ad4234) | `obitools3: removed useless python restriction`                                               |
| [`7d6c626a`](https://github.com/NixOS/nixpkgs/commit/7d6c626a3963525e7e9697776c90b5d382fab22c) | `tree-sitter: only strip on Linux`                                                            |
| [`1c67b0de`](https://github.com/NixOS/nixpkgs/commit/1c67b0deeff770b79193ba2cc657144c1b8ba5c1) | `dhall docs: replace two paths with more general versions`                                    |
| [`048939c5`](https://github.com/NixOS/nixpkgs/commit/048939c593c85df1a66b562af3c12c5ebb43e3c9) | `dhall docs: change code block formatting to use ShellSession instead of bash`                |
| [`10c5a4cc`](https://github.com/NixOS/nixpkgs/commit/10c5a4cca54d21071ded19f553a466eb10567f40) | `dhallPackages.buildDhallUrl: change argument from dhall-hash to dhallHash`                   |
| [`9b54511a`](https://github.com/NixOS/nixpkgs/commit/9b54511a8e2b050d3359110ff038f26de5ee09f2) | `whitesur-icon-theme: 20211013 -> 20211108`                                                   |
| [`7f7780da`](https://github.com/NixOS/nixpkgs/commit/7f7780daa55e8f2de87acc7563078a3db85e7feb) | `nixos/prometheus: throw a helpful error when services.prometheus.environmentFile is defined` |
| [`0e4abb0d`](https://github.com/NixOS/nixpkgs/commit/0e4abb0df773cf7d9ff8dc2792358c0b8508d5eb) | `nixos/prometheus: remove services.prometheus.environmentFile`                                |
| [`c9d935da`](https://github.com/NixOS/nixpkgs/commit/c9d935da0b2e23001497869359d48197ea88ebb4) | `efivar: fix LTO build`                                                                       |
| [`233f4518`](https://github.com/NixOS/nixpkgs/commit/233f451841a0bfb0f22c3e36d2e6893a8e8e27a8) | `treewide: reenable LTO on i686`                                                              |
| [`dff528ef`](https://github.com/NixOS/nixpkgs/commit/dff528efbfa77a9ea65827ba4571a10ed5751b93) | `gcc: reenable LTO on i686`                                                                   |
| [`46ae8b60`](https://github.com/NixOS/nixpkgs/commit/46ae8b6074c891d78e0acc857b348b8fb9a0aa04) | `synapse-admin: init at 0.8.3`                                                                |
| [`4d729b3d`](https://github.com/NixOS/nixpkgs/commit/4d729b3d41d093449ed762d6fd8c5181bd4d97d5) | `python3Packages.zeroconf: 0.36.11 -> 0.36.12`                                                |
| [`c6e0550b`](https://github.com/NixOS/nixpkgs/commit/c6e0550bf9db9ef342a7be76873677f6a6a1ab89) | `nco: 5.0.1 -> 5.0.3`                                                                         |
| [`f7f37804`](https://github.com/NixOS/nixpkgs/commit/f7f3780473b0e09b1930899a8c71c219e02ad4e8) | `mackerel-agent: 0.72.2 -> 0.72.3`                                                            |
| [`b42f0a0b`](https://github.com/NixOS/nixpkgs/commit/b42f0a0b45d33dec4a25508ea5293a4a016697a9) | `libtorrent-rasterbar: 2.0.3 -> 2.0.4`                                                        |
| [`2e1d84e9`](https://github.com/NixOS/nixpkgs/commit/2e1d84e9fb5385eb4bb2f4cb93177fc1ee0dcc39) | `dhallPackages.buildDhallUrl: small formatting fixes`                                         |
| [`d63c063d`](https://github.com/NixOS/nixpkgs/commit/d63c063d8a426e0306cc0aa3506313075482866a) | `gb-backup: unstable-2021-08-16 -> unstable-2021-10-27`                                       |
| [`06a3718b`](https://github.com/NixOS/nixpkgs/commit/06a3718bc9d393727fbc7752fe9b6c094731dc8b) | `doc: Add explanation of --fixed-output-derivations arg for dhall-nixpkgs to Dhall section`   |
| [`6128cbe1`](https://github.com/NixOS/nixpkgs/commit/6128cbe13641c0dabf0c8bedf4db1b2281f65dc8) | `pywlroots: 0.14.8 -> 0.14.9`                                                                 |
| [`da437fc1`](https://github.com/NixOS/nixpkgs/commit/da437fc17024068324033e4bf503a385dbbd9b9f) | `qtile: add wayland backend dependencies`                                                     |
| [`e4ee8fcb`](https://github.com/NixOS/nixpkgs/commit/e4ee8fcb520760fce73af82b389cd7695446ce44) | `pywlroots: init at 0.14.8`                                                                   |
| [`506c85ab`](https://github.com/NixOS/nixpkgs/commit/506c85ab9b9f8737b83badc24de9988f8e394577) | `xkbcommon: init at 0.4`                                                                      |
| [`c00092af`](https://github.com/NixOS/nixpkgs/commit/c00092afde5f7647a5e1635bde9a0b91cb0632c0) | `pywayland: init at 0.4.7`                                                                    |
| [`9be3d05d`](https://github.com/NixOS/nixpkgs/commit/9be3d05d7ce0b7681a9c5e0c1739959ba13d686e) | `tests.dhall.buildDhallUrl: add test`                                                         |
| [`a201d974`](https://github.com/NixOS/nixpkgs/commit/a201d9744feeb6db3db5ba41b1f391f5878937b1) | `dhallPackages.buildDhallUrl: add this function`                                              |
| [`3ff3ec98`](https://github.com/NixOS/nixpkgs/commit/3ff3ec989cd9f7d7d426d3591bf9202323416b53) | `vpn-slice: 0.14 -> 0.15`                                                                     |