### PR TITLE
chore(flake/inputs/nixpkgs): `93c6633d` -> `788119f7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1636387988,
-        "narHash": "sha256-ojyXiWo8ygP8Z07J8V2ZyUu9UzaEMaY/wkSuzXNmOZA=",
+        "lastModified": 1636426614,
+        "narHash": "sha256-QZ2pDFRXEctAunRa84DZM1CloMwmOuF2TneJ+V+egaE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "93c6633d1f830f88be1bfee5717e54dc02538bae",
+        "rev": "788119f78101a10b2c58de0690c23572ac348076",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                               |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`788119f7`](https://github.com/NixOS/nixpkgs/commit/788119f78101a10b2c58de0690c23572ac348076) | `nextcloud-client: disable qml caching`                                      |
| [`52ffa1c3`](https://github.com/NixOS/nixpkgs/commit/52ffa1c36d6d79ea7b9285f5410a8128b74688ce) | `nextcloud-client: make autostart entry start client from path`              |
| [`afce4452`](https://github.com/NixOS/nixpkgs/commit/afce4452088cdc4d28058184a8df0c0407b8ccfe) | `lua/setup-hook: remove empty hook`                                          |
| [`e59e24b3`](https://github.com/NixOS/nixpkgs/commit/e59e24b3702745ca03fd9fb62ad42197ae060827) | `nextcloud-client: 3.3.5 -> 3.3.6`                                           |
| [`2248e8c1`](https://github.com/NixOS/nixpkgs/commit/2248e8c1d0c8795778f267ab885f98a97791d1a4) | `dotnetCorePackages: 6.0.0-rc.2 -> 6.0`                                      |
| [`d14ae626`](https://github.com/NixOS/nixpkgs/commit/d14ae62671fd4eaec57427da1e50f91d6a5f9605) | `nixos/terminfo: inherit TERMINFO* env vars also for doas`                   |
| [`bd25ccf3`](https://github.com/NixOS/nixpkgs/commit/bd25ccf3aa62eee3df0fa2df8dad43581547a1de) | `caddy: 2.4.5 -> 2.4.6`                                                      |
| [`8605fbd7`](https://github.com/NixOS/nixpkgs/commit/8605fbd737e526c40ff8f01219db42b5d0076e23) | `vim-utils: create less symlinks`                                            |
| [`74d277c8`](https://github.com/NixOS/nixpkgs/commit/74d277c8cd0241d44684a3187d51713c148ebf97) | `python38Packages.pyjet: fix build`                                          |
| [`4595cfb6`](https://github.com/NixOS/nixpkgs/commit/4595cfb6229f168909238220a74ed4a22135a359) | `jwm: 1685 -> 2.4.0`                                                         |
| [`6542059f`](https://github.com/NixOS/nixpkgs/commit/6542059fb588a0afb5f98966ca443b2d89cc7994) | `haskellPackages.lapack-ffi: remove from broken.yaml`                        |
| [`b65d4b02`](https://github.com/NixOS/nixpkgs/commit/b65d4b02de42163d70e7e136c0481bcf0a456b2f) | `vimPlugins: add package-info-nvim and SchemaStore`                          |
| [`383cbce5`](https://github.com/NixOS/nixpkgs/commit/383cbce57a5ac8a2172643d0d4530c5d46c6a418) | `buf: 0.54.1 -> 1.0.0-rc7`                                                   |
| [`2fddb8bd`](https://github.com/NixOS/nixpkgs/commit/2fddb8bd5cfa9ffdeaf5648bbe1d197963c5ae15) | `dunst: remove unused fetchpatch dependency`                                 |
| [`e128f089`](https://github.com/NixOS/nixpkgs/commit/e128f089eee57f606bf929a67389396ba9c90985) | `scala-cli: 0.0.7 -> 0.0.8`                                                  |
| [`45ca602e`](https://github.com/NixOS/nixpkgs/commit/45ca602e52bbc6db056133ba80c2e11f240d79d1) | `pur: switch to buildPythonApplication`                                      |
| [`7e7ce731`](https://github.com/NixOS/nixpkgs/commit/7e7ce7316ecaab68b9de403971b3d278cfc70220) | `nixos-generators: 1.4.0 -> 1.5.0`                                           |
| [`4c5fbc98`](https://github.com/NixOS/nixpkgs/commit/4c5fbc98d2989c5ddf63056db3ee382f42d87e9c) | `gcc-arm-embedded-{9,10}: enable on aarch64-darwin`                          |
| [`8ea85579`](https://github.com/NixOS/nixpkgs/commit/8ea85579554a49e55a0c6953ee305b3ad3b2f8f1) | `gcc-arm-embedded-10: 10.3-2021.07 -> 10.3-2021.10`                          |
| [`461dd059`](https://github.com/NixOS/nixpkgs/commit/461dd05989598684c2659a6a5f67446c11f12196) | `flips: unstable-2021-05-18 -> unstable-2021-10-28`                          |
| [`32884b4b`](https://github.com/NixOS/nixpkgs/commit/32884b4bf6d16be23a7ac4bf7c06df2cf6dfe518) | `python3Packages.skytemple-rust: unstable-2021-05-30 -> unstable-2021-08-11` |
| [`4ef967af`](https://github.com/NixOS/nixpkgs/commit/4ef967af205fc0ec6d064ebb8c561e3573a57564) | `clojure-lsp: mark it as broken on non-x86_64 platforms`                     |
| [`8a3a429d`](https://github.com/NixOS/nixpkgs/commit/8a3a429da6c149c743498b41e2bd6a36f6963d65) | `nixos/swap: add randomEncryption.allowDiscards option`                      |
| [`a2448316`](https://github.com/NixOS/nixpkgs/commit/a2448316fd0d7cbac13f3305885246ef2fa5890f) | `remove `with` expression`                                                   |
| [`c3ddce52`](https://github.com/NixOS/nixpkgs/commit/c3ddce527dea2490f6bfbb83a977f9ba8b2d9d9d) | `python3Packages.pur: 5.4.1 -> 5.4.2; fix build`                             |
| [`51bdef74`](https://github.com/NixOS/nixpkgs/commit/51bdef748ea5aa532131d16c52437a34bc37ed95) | `loki: 2.4.0 -> 2.4.1`                                                       |
| [`5c411a49`](https://github.com/NixOS/nixpkgs/commit/5c411a49952ceab86e7310b1834d689a3604104f) | `luajit_2_0: 2.1.0-2021-07-27 -> 2.0.5-2021-10-02`                           |
| [`90a564a1`](https://github.com/NixOS/nixpkgs/commit/90a564a133e1a1ebfed26666567182ae60c666ee) | `luajit_2_1: 2.1.0-2021-08-12 -> 2.1.0-2021-10-27`                           |
| [`916595e6`](https://github.com/NixOS/nixpkgs/commit/916595e6a1f040fdff8c886b9ba8d2fe65042de3) | `chia-plotter: unstable -> 1.1.7`                                            |
| [`7857183c`](https://github.com/NixOS/nixpkgs/commit/7857183c0b68bfa4b8cbeb32d20642303f52948b) | `plausible: update update.sh script`                                         |
| [`9c71958c`](https://github.com/NixOS/nixpkgs/commit/9c71958cfa5ae6ef0d1a1159ae4a10ae9f23dba9) | `plausible: use loadcredentials`                                             |
| [`3886aa35`](https://github.com/NixOS/nixpkgs/commit/3886aa3535c4b936babd7f9c45bbd99b7307b204) | `plausible: 1.3.0 -> 1.4.0`                                                  |
| [`4055c5b3`](https://github.com/NixOS/nixpkgs/commit/4055c5b38ccc9a7857588c73744eb9ae2034a68c) | `python3Packages.unidecode: 1.3.1 -> 1.3.2`                                  |
| [`b969e95b`](https://github.com/NixOS/nixpkgs/commit/b969e95b60e740ecdc16670e593c62bfa6a5f82a) | `spice: fix cross`                                                           |
| [`82de845f`](https://github.com/NixOS/nixpkgs/commit/82de845f3771fc4de047f3f609d4b3cbe44cd7ae) | `maintainers: add lrewega`                                                   |