### PR TITLE
chore(flake/inputs/sops-nix): `517628cc` -> `a8cbd0c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1636295684,
-        "narHash": "sha256-vm8GaHZFnBcftqrfpIr27rCNfU9g3ZqByks9dto6D3M=",
+        "lastModified": 1636497917,
+        "narHash": "sha256-8U0Tvot7U5KJ8vpn6xR611v7b441QdAQC04xhxjMHOc=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "517628cc1defc90191f0e1380f8f83e590dd6b56",
+        "rev": "a8cbd0c796e4678f0fd2e59f274e49705ee523ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                            |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`80eb349c`](https://github.com/Mic92/sops-nix/commit/80eb349cc83d633d2728fd45bc63fbaf5d159411) | `Support arbitrary environment variables` |
| [`af29ac4d`](https://github.com/Mic92/sops-nix/commit/af29ac4d8490eb6c674a1894593cad809c423b39) | `Prune old secrets generations`           |