### PR TITLE
chore(flake/inputs/home-manager): `2917ef23` -> `1e5c8e9b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -62,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1636274622,
-        "narHash": "sha256-tZYuGhqcfH7piCsrUrIYM0P3oPJcoBxGkuxeFNVxkCc=",
+        "lastModified": 1636520380,
+        "narHash": "sha256-gBiQ8+AQG6Dia34rqJDuqs6VFe/J1SjIhOZBeTXCKQI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2917ef23b398a22ee33fb34b5766b28728228ab1",
+        "rev": "1e5c8e9bff00d0844bc3d25d1a98eab5633e600b",
         "type": "github"
       },
       "original": {

--- a/users/cloud/core/default.nix
+++ b/users/cloud/core/default.nix
@@ -33,10 +33,7 @@
   programs = {
     direnv = {
       enable = true;
-      nix-direnv = {
-        enable = true;
-        enableFlakes = true;
-      };
+      nix-direnv.enable = true;
     };
 
     bat = {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                   |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`1e5c8e9b`](https://github.com/nix-community/home-manager/commit/1e5c8e9bff00d0844bc3d25d1a98eab5633e600b) | `direnv.nix-direnv: remove enableFlakes (#2458)` |