### PR TITLE
chore(flake/inputs/nixpkgs): `788119f7` -> `872ccff6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1636426614,
-        "narHash": "sha256-QZ2pDFRXEctAunRa84DZM1CloMwmOuF2TneJ+V+egaE=",
+        "lastModified": 1636474390,
+        "narHash": "sha256-nnm0Ar4OikD8FQWAlf3AGxEnrGHKQIqy4Cj/DCf0LxM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "788119f78101a10b2c58de0690c23572ac348076",
+        "rev": "872ccff6c20e4741721a8c774108de8dbbdeea7d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`872ccff6`](https://github.com/NixOS/nixpkgs/commit/872ccff6c20e4741721a8c774108de8dbbdeea7d) | `python3Packages.pymarshal: init at 2.2.0`                                |
| [`94a8d38d`](https://github.com/NixOS/nixpkgs/commit/94a8d38dcda29a72f5320f52ff547b3bb3f8eb87) | `gnome.gnome-todo: Use patch to fix build race condition`                 |
| [`40e0078b`](https://github.com/NixOS/nixpkgs/commit/40e0078b9ce720d28e71f3149e00b368dfa568b4) | `python3Packages.flask-admin: 1.5.6 -> 1.5.8`                             |
| [`f1ab1081`](https://github.com/NixOS/nixpkgs/commit/f1ab10812a1185e7cfa11cccc2a6456e9f384916) | `sublime-music: 0.11.13 -> 0.11.14`                                       |
| [`7e0eb9ec`](https://github.com/NixOS/nixpkgs/commit/7e0eb9ecf00849a50a38b8964063c836c4123127) | `plexamp: 3.8.0 -> 3.8.2`                                                 |
| [`951e9002`](https://github.com/NixOS/nixpkgs/commit/951e9002edd8bc53018fa46d52ddfca9e3a8f7f0) | `matomo: 4.4.1 -> 4.5.0`                                                  |
| [`69a54df9`](https://github.com/NixOS/nixpkgs/commit/69a54df996d11498a86458780ca08917ab112d9e) | `matomo: add vendor/matomo/matomo-php-tracker/run_tests.sh to filesToFIx` |
| [`11f1d862`](https://github.com/NixOS/nixpkgs/commit/11f1d8620ab38c12b9c120615810592c7a1f7284) | `nixos/matomo: delete tmp folder to fix borked upgrades`                  |
| [`769f20e2`](https://github.com/NixOS/nixpkgs/commit/769f20e20ae047a69e084c105e57d66ba87d0da9) | `nixos/matomo: allow changing hostname easily`                            |
| [`b982294b`](https://github.com/NixOS/nixpkgs/commit/b982294b6f5a69d30180f498ffa561d568e0d1fb) | `python2.7-filelock: Init version 3.2.1 for Python 2`                     |
| [`94a047ca`](https://github.com/NixOS/nixpkgs/commit/94a047ca74cb4a596bf3b2e7b8902a8366822b13) | `yosys: fix build on darwin`                                              |
| [`8da24573`](https://github.com/NixOS/nixpkgs/commit/8da24573e609f6459012e2be078ccfb047081bfc) | `zettlr: 2.0.1 -> 2.0.2`                                                  |
| [`f3ac53f1`](https://github.com/NixOS/nixpkgs/commit/f3ac53f14ea9a27c2601969cec5d218e1ff78bd7) | `python3Packages.pytile: 5.2.4 -> 2021.10.0`                              |
| [`c3449f13`](https://github.com/NixOS/nixpkgs/commit/c3449f13339ce8cb617ac2e61ba7cb848bd87c35) | `checkov: 2.0.554 -> 2.0.556`                                             |
| [`34a701a8`](https://github.com/NixOS/nixpkgs/commit/34a701a87f87a96624365930d27bd56cfc089430) | `python3Packages.aioasuswrt: 1.3.4 -> 1.4.0`                              |
| [`b9012ca7`](https://github.com/NixOS/nixpkgs/commit/b9012ca748fff76c85a0cbfc5d3585cc8631efbd) | `python3Packages.asyncssh: 2.7.2 -> 2.8.0`                                |
| [`d320d0b5`](https://github.com/NixOS/nixpkgs/commit/d320d0b5ff8ed793589ad5d7355f4aed132a5377) | `python3Packages.pytest-cases: 3.6.4 -> 3.6.5`                            |
| [`9f43d5d3`](https://github.com/NixOS/nixpkgs/commit/9f43d5d31359a99ab3fcf316e5151243abb18b51) | `python3Packages.pytradfri: 7.1.1 -> 7.2.0`                               |
| [`cda29d52`](https://github.com/NixOS/nixpkgs/commit/cda29d527796f15d5ac36a0157ef7d4020280ab3) | `python3Packages.env-canada: 0.5.15 -> 0.5.16`                            |
| [`8ce56fa0`](https://github.com/NixOS/nixpkgs/commit/8ce56fa0c9f3f1d8802a2dfbc8ba9d5c25070ccb) | `python3Packages.mypy-boto3-s3: 1.19.12 -> 1.20.0`                        |
| [`8539149c`](https://github.com/NixOS/nixpkgs/commit/8539149c7ccc29d5a655ee555a9af0336c9ce74b) | `python3Packages.pyswitchbot: 0.12.0 -> 0.13.0`                           |
| [`63494114`](https://github.com/NixOS/nixpkgs/commit/63494114082a3b910768007d7d2e8bad30b33fe6) | `python3Packages.pyvicare: 2.13.1 -> 2.14.0`                              |
| [`09af1585`](https://github.com/NixOS/nixpkgs/commit/09af1585ca43f9a015398f0a99f66a58c92577d6) | `godns: add missing ldflags`                                              |
| [`dac0fabd`](https://github.com/NixOS/nixpkgs/commit/dac0fabd5e6befc959ea36098bc04866562649a7) | `godns: 2.5 -> 2.5.1`                                                     |
| [`c10a0755`](https://github.com/NixOS/nixpkgs/commit/c10a07551721f713392d777c27ac802c99e697bd) | `clinfo: enable on darwin`                                                |
| [`98b65cc0`](https://github.com/NixOS/nixpkgs/commit/98b65cc0a037f22b75c1b5b87592c8804d91104b) | `python3Packages.asyncio-mqtt: 0.10.0 -> 0.11.0`                          |
| [`69db2b90`](https://github.com/NixOS/nixpkgs/commit/69db2b90f8ec9af6ae03ecb4dbf1ac664a419f6f) | `python3Packages.aiomusiccast: 0.12.0 -> 0.13.1`                          |
| [`7fb9e944`](https://github.com/NixOS/nixpkgs/commit/7fb9e9440738ad1e2ae66e464220e2c9ba2f2553) | `invidious: unstable-2021-10-15 -> unstable-2021-11-08`                   |
| [`0c3a756f`](https://github.com/NixOS/nixpkgs/commit/0c3a756ffa6ffd1ffbac92fdf562adb767d88214) | `python3Packages.systembridge: 2.2.1 -> 2.2.3`                            |
| [`50b75596`](https://github.com/NixOS/nixpkgs/commit/50b75596accbb4a353003fd6549de3ca800fbb6e) | `python3Packages.async-upnp-client: 0.22.10 -> 0.22.12`                   |
| [`d6ed5e13`](https://github.com/NixOS/nixpkgs/commit/d6ed5e13e7441aed91ec9faf75b39ee79edcecfd) | `python3Packages.velbus-aio: 2021.11.0 -> 2021.11.6`                      |
| [`351c3241`](https://github.com/NixOS/nixpkgs/commit/351c32411a3db92d4c10e459941f385c2b1024fb) | `mmtc: 0.2.13 -> 0.2.14`                                                  |
| [`ee2ebfc6`](https://github.com/NixOS/nixpkgs/commit/ee2ebfc6c356defbf6bca1132480cdf3f421d9a3) | `libfyaml: 0.7.1 -> 0.7.2`                                                |
| [`62567711`](https://github.com/NixOS/nixpkgs/commit/625677111a2a597ea9b2a401d896bb3b05387d7c) | `gallery-dl: 1.19.1 -> 1.19.2`                                            |
| [`6c2190f3`](https://github.com/NixOS/nixpkgs/commit/6c2190f3980a1597cf5562e1ccf01cc1573276d5) | `smpq: replace hardcoded version string with ${version}`                  |
| [`f7b51c1d`](https://github.com/NixOS/nixpkgs/commit/f7b51c1dcf8c4e952ac54c462c8950b57dcf4bc5) | `devilutionx: pass static version of SDL2 into derivation`                |
| [`9d8e24e8`](https://github.com/NixOS/nixpkgs/commit/9d8e24e85485e263440c3a84a0f639d3425d7668) | `samba4: Fix all libraries`                                               |
| [`d8727c36`](https://github.com/NixOS/nixpkgs/commit/d8727c36bc6dd2abc170aed11a5e863a45f0e198) | `kodi.packages.iagl: init at 1101521-2`                                   |
| [`d5b8ea84`](https://github.com/NixOS/nixpkgs/commit/d5b8ea84f0bef3aa18e128c9f00a334d7baa20af) | `kodi.packages.archive_tool: init at 2.0.3`                               |
| [`f487c6a5`](https://github.com/NixOS/nixpkgs/commit/f487c6a5af51549290b8bd7655ba9911f90f0031) | `opam: 2.1.0 -> 2.1.1`                                                    |
| [`c56c434d`](https://github.com/NixOS/nixpkgs/commit/c56c434dbadfd2ae789f7dfb6a79db1ef75de360) | `goverlay: 0.6.3 → 0.6.4`                                                 |
| [`5f42a6d6`](https://github.com/NixOS/nixpkgs/commit/5f42a6d626ad5d96c05e8775a6d46198648d93eb) | `pulumi-bin: 3.16.0 -> 3.17.0`                                            |
| [`cbfd92d5`](https://github.com/NixOS/nixpkgs/commit/cbfd92d51c87f11e98b00513e96b81db8ce103a5) | `libofx: 0.10.2 -> 0.10.3`                                                |
| [`8b62b013`](https://github.com/NixOS/nixpkgs/commit/8b62b01325e74f696c479d90d5ad249ef29892cc) | `neovim: Remove X11 dependency`                                           |