### PR TITLE
chore(flake/inputs/pre-commit-hooks): `06fa8032` -> `433808cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -116,11 +116,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1634595438,
-        "narHash": "sha256-hV9D41fqTateTligwNd9dmJKQ0R0w6RpCN92xR3LhHk=",
+        "lastModified": 1636583591,
+        "narHash": "sha256-NJIMtEPJIeQf1t8H5+/Fx+vBF9o9n+HMeDZ8QQcPQp0=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "06fa80325b6fe3b28d136071dd0ce55d4817e9fd",
+        "rev": "433808cba23975201a48a3bb8ebc76029191fafd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                           |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
| [`8467d19a`](https://github.com/cachix/pre-commit-hooks.nix/commit/8467d19af507d61d9b148318563da259b8be6bdd) | `Add isort`                                              |
| [`7d76159d`](https://github.com/cachix/pre-commit-hooks.nix/commit/7d76159d67582912ad557ba2ed1b46055eb45111) | `chore(deps): bump actions/checkout from 2.3.5 to 2.4.0` |