### PR TITLE
chore(flake/inputs/nixpkgs): `872ccff6` -> `bcfcdaab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1636474390,
-        "narHash": "sha256-nnm0Ar4OikD8FQWAlf3AGxEnrGHKQIqy4Cj/DCf0LxM=",
+        "lastModified": 1636592353,
+        "narHash": "sha256-keLNv3mLkbewKix9C7NN+7N2YIL9QojxWeFbnSlqqTc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "872ccff6c20e4741721a8c774108de8dbbdeea7d",
+        "rev": "bcfcdaabf7f0f2fe38c0685711233a23e8cfc011",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                    |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`9c1d31ce`](https://github.com/NixOS/nixpkgs/commit/9c1d31ce68bce3a4b9d10f0b98bf5abca6bebf83) | `nixos/tests/installer: comment out nixos-option test for now`                    |
| [`6a4d2207`](https://github.com/NixOS/nixpkgs/commit/6a4d2207b12c10b768a70f5d57d7dc2e216414eb) | `nixos/test/boot: nix verify -> nix store verify`                                 |
| [`5b636e47`](https://github.com/NixOS/nixpkgs/commit/5b636e4715050052ca36edc79a75cddebd8d3b1c) | `jet: init at 0.1.0`                                                              |
| [`391fac41`](https://github.com/NixOS/nixpkgs/commit/391fac4148b5d2b3f040cd1e149e7ba25ad45893) | `clojure: 1.10.3.1013 -> 1.10.3.1029`                                             |
| [`9174a036`](https://github.com/NixOS/nixpkgs/commit/9174a03677b7065082a32cab8bac7e2a027fd7d0) | `svtplay-dl: 4.8 -> 4.9`                                                          |
| [`f5c12e83`](https://github.com/NixOS/nixpkgs/commit/f5c12e831178d43db794b78c52c87fca83288d21) | `treewide: replace '-git' packages with 'unstable-' in version (#145396)`         |
| [`aabbed57`](https://github.com/NixOS/nixpkgs/commit/aabbed57e7fa75ed396626f5ac693b98883f89e2) | `proj: Patch test OPEN_MAX limit assumption (#145371)`                            |
| [`47d794a7`](https://github.com/NixOS/nixpkgs/commit/47d794a7e26ed35d8d76332373ec7113a88d2508) | `zita-resampler: patchPhase -> postPatch`                                         |
| [`b3f59f20`](https://github.com/NixOS/nixpkgs/commit/b3f59f2089722ec4f0d4a032d329d33ddd63a226) | `helm-docs: init at 1.5.0`                                                        |
| [`c3456b0e`](https://github.com/NixOS/nixpkgs/commit/c3456b0e3cf72c4489491ac227734aef2aa4e5d5) | `maintainers: add sagikazarmark`                                                  |
| [`99556983`](https://github.com/NixOS/nixpkgs/commit/995569833b1591f06ba1670359bbfd085505ce07) | `signal-desktop: 5.23.0 -> 5.23.1`                                                |
| [`dbe6e96d`](https://github.com/NixOS/nixpkgs/commit/dbe6e96d0a25ca1df89dfa25253c641aca755438) | `lib/systems: add x86_64-darwin hostPlatform`                                     |
| [`c4e467e4`](https://github.com/NixOS/nixpkgs/commit/c4e467e4c865ad3a677146d5384a86ef30673d9d) | `chromiumDev: 97.0.4688.2 -> 97.0.4692.8`                                         |
| [`0faf3230`](https://github.com/NixOS/nixpkgs/commit/0faf3230fbb26775d836362867ab5066942e0882) | `coreboot-toolchain: Improve reproducibility`                                     |
| [`b834903c`](https://github.com/NixOS/nixpkgs/commit/b834903c0d9b9d15bdc237dbec98e71b4dae239f) | `Fix "session-management-for-emacs" license`                                      |
| [`5e74077c`](https://github.com/NixOS/nixpkgs/commit/5e74077c3fef465c8b4ded7b3c50638f49dc4f3c) | `python3Packages.deepdiff: fix tests on darwin`                                   |
| [`ee2417a2`](https://github.com/NixOS/nixpkgs/commit/ee2417a226c8631576a508d634b120702a1c9679) | `coreboot-toolchain: 4.14 -> 4.15`                                                |
| [`60d10330`](https://github.com/NixOS/nixpkgs/commit/60d1033025add04c1f5e14dadeb3180ddef8f0cd) | `coreboot-toolchain: Rework update script`                                        |
| [`4e75ca5b`](https://github.com/NixOS/nixpkgs/commit/4e75ca5bae03449edc4915c8b78267976d719d6e) | `coreboot-toolchain: Disable fetching of submodules`                              |
| [`a904faa3`](https://github.com/NixOS/nixpkgs/commit/a904faa362c6497b2eb0d403307cd50be9cafa40) | `wrangler: 1.19.4 -> 1.19.5`                                                      |
| [`cdcc4307`](https://github.com/NixOS/nixpkgs/commit/cdcc4307dfba4c2ab59a6c8fbc7db20392dd9983) | `rmapi: 0.0.15 -> 0.0.17 (#145369)`                                               |
| [`9ce9722b`](https://github.com/NixOS/nixpkgs/commit/9ce9722bb094042de4ad8981184b61e721a2751f) | `cargo-outdated: 0.9.17 -> 0.9.18`                                                |
| [`b5dafef7`](https://github.com/NixOS/nixpkgs/commit/b5dafef72e232728b1dba385e64377816c8aef1f) | `top-level: remove extra /default.nix`                                            |
| [`c0ffaefb`](https://github.com/NixOS/nixpkgs/commit/c0ffaefb89164003b52c16a9543a19900b816271) | `python3Packages.faraday-plugins: 1.5.5 -> 1.5.6`                                 |
| [`a5f1139b`](https://github.com/NixOS/nixpkgs/commit/a5f1139b5423c818b8fd5fe58c6cff43ae29a134) | `routinator: 0.10.1 -> 0.10.2`                                                    |
| [`c8054351`](https://github.com/NixOS/nixpkgs/commit/c8054351344c65b636781dbfbc4a760d123c9d1c) | `simple-scan: 40.5 → 40.6`                                                        |
| [`4ad135cb`](https://github.com/NixOS/nixpkgs/commit/4ad135cb7ff6effb137661bda7a924713531a354) | `gnome.gnome-desktop: 41.0 → 41.1`                                                |
| [`412ee75d`](https://github.com/NixOS/nixpkgs/commit/412ee75d07dcc862151a9c44c85c50189b51776b) | `gnome.gnome-shell: 41.0 → 41.1`                                                  |
| [`8d5118b1`](https://github.com/NixOS/nixpkgs/commit/8d5118b1ea3054377375ede642b9488a5abbf9ec) | `tracker-miners: 3.2.0 → 3.2.1`                                                   |
| [`fc724458`](https://github.com/NixOS/nixpkgs/commit/fc7244587262aa5d8d8f291a955bb763486a5688) | `gnome.mutter: 41.0 → 41.1`                                                       |
| [`abd21e27`](https://github.com/NixOS/nixpkgs/commit/abd21e27005b892d309df2e4cf8caf7c2b9af4e8) | `python3Packages.pyopenuv: 2.2.1 -> 2021.10.0`                                    |
| [`313d5ff8`](https://github.com/NixOS/nixpkgs/commit/313d5ff8566117d142dfef69dab23341935cfbbe) | `exploitdb: 2021-11-06 -> 2021-11-09`                                             |
| [`bfd4f216`](https://github.com/NixOS/nixpkgs/commit/bfd4f21603e4fee775d567321b03a9c6cd6fd8a9) | `gradle: 7.2 -> 7.3`                                                              |
| [`d0c864cf`](https://github.com/NixOS/nixpkgs/commit/d0c864cf8ee8dc94d2618a235fae326a6139e5d7) | `puppet-lint: 2.3.6 -> 2.5.2`                                                     |
| [`b50d43cc`](https://github.com/NixOS/nixpkgs/commit/b50d43cc947fe45aa9d8d266c2ea665c903e1934) | `yosys: remove pointless patching`                                                |
| [`65072f80`](https://github.com/NixOS/nixpkgs/commit/65072f8018ca5d09b3d9d816676d914af844e50c) | `warzone2100: 4.2.0 -> 4.2.1`                                                     |
| [`d97bf8f6`](https://github.com/NixOS/nixpkgs/commit/d97bf8f68d86ea11307317060a5d9fd9e6194679) | `cargo-deny: 0.10.0 -> 0.10.1`                                                    |
| [`a57f8649`](https://github.com/NixOS/nixpkgs/commit/a57f864975cee5ad867e26d292a1aca2097108d2) | `carp: 0.5.0 -> 0.5.3 (#145281)`                                                  |
| [`bb17e2c9`](https://github.com/NixOS/nixpkgs/commit/bb17e2c937f1873c3aaea92f4ec2b3bd418d1ce3) | `vscodium: 1.62.0 -> 1.62.1`                                                      |
| [`7d9f89fb`](https://github.com/NixOS/nixpkgs/commit/7d9f89fb0543375b62766e44952312e84f00bd31) | `python3Packages.aiorecollect: 1.0.8 -> 2021.10.0`                                |
| [`b654f383`](https://github.com/NixOS/nixpkgs/commit/b654f383f9e7759d7ad842b5dccc8c4b82313e20) | `plasma-workspace: remove patch merged upstream`                                  |
| [`a192536d`](https://github.com/NixOS/nixpkgs/commit/a192536d7c0b74bc07d84e79b76057b096717564) | `plasma5: 5.23.2 -> 5.23.3`                                                       |
| [`8d016c63`](https://github.com/NixOS/nixpkgs/commit/8d016c63d76ca89fce894b03cd8f5a62e0387da8) | `python3Packages.types-requests: 2.25.12 -> 2.26.0`                               |
| [`0cf19745`](https://github.com/NixOS/nixpkgs/commit/0cf19745a641c590c65f6eb6169e5cbb94bdf213) | `python3Packages.pyairvisual: 5.0.9 -> 2021.10.0`                                 |
| [`1b36833f`](https://github.com/NixOS/nixpkgs/commit/1b36833f2c1bf1f9972c1f745966ed3a3f66f40d) | `pkgsMusl.libieee1284: fix build`                                                 |
| [`17ae4163`](https://github.com/NixOS/nixpkgs/commit/17ae4163e38515b16090552299b4b24670bfb70c) | `python3Packages.starkbank-ecdsa: 2.0.1 -> 2.0.2`                                 |
| [`8f6a0499`](https://github.com/NixOS/nixpkgs/commit/8f6a04992077bc30c80ca636e1b316a053a3a98a) | `your-editor: 1203 -> 1206 (#145241)`                                             |
| [`03a257e5`](https://github.com/NixOS/nixpkgs/commit/03a257e5a34db7dcf56e74a4da121843d5a17799) | `treewide: quote urls according to rfc 0045 (#145260)`                            |
| [`379d24e4`](https://github.com/NixOS/nixpkgs/commit/379d24e478f4a14cdca4a46f777e07947f10f3ef) | `keychain: cleanup, formatting, add me as maintainer`                             |
| [`7148439d`](https://github.com/NixOS/nixpkgs/commit/7148439d8965c3c7c9ed5b9ee0d329743b0df33c) | `netease-cloud-music-gtk: init at 1.2.2`                                          |
| [`36ca1984`](https://github.com/NixOS/nixpkgs/commit/36ca19848ccbcf78a229830b787743f91c7df3e1) | `mosh: minor formatting, add SuperSandor2000 as maintainer`                       |
| [`4225cf39`](https://github.com/NixOS/nixpkgs/commit/4225cf39035bf79f13b0c3df47f53ccab42a3c4b) | `python3Packages.pyiqvia: 1.1.0 -> 2021.10.0`                                     |
| [`6e50a3fe`](https://github.com/NixOS/nixpkgs/commit/6e50a3fee360c621d33724736270c34d1e697fc7) | `python3Packages.pycfdns: 1.2.1 -> 1.2.2`                                         |
| [`4436d1f6`](https://github.com/NixOS/nixpkgs/commit/4436d1f6a2428aab75c099b0bc57ec98b17f6ee0) | `hstr: pull pending upstream inclusion fix for ncurses-6.3`                       |
| [`0c3d1e84`](https://github.com/NixOS/nixpkgs/commit/0c3d1e841db8c4be791b28453b5db9ce9fb512f4) | `python3Packages.identify: 2.3.3 -> 2.3.5`                                        |
| [`79643f83`](https://github.com/NixOS/nixpkgs/commit/79643f831962640561159ba042039946e1bafb45) | `python3Packages.mypy-boto3-s3: 1.20.0 -> 1.20.1`                                 |
| [`b79219bf`](https://github.com/NixOS/nixpkgs/commit/b79219bf390ad1de1e801c4b33f3af48e9cb633b) | `python3Packages.crownstone-cloud: 1.4.8 -> 1.4.9`                                |
| [`ab2f3c2e`](https://github.com/NixOS/nixpkgs/commit/ab2f3c2ede9bf15f7ce1f4535bd72126a72b35f1) | `python3Packages.cachetools: 4.2.3 -> 4.2.4`                                      |
| [`f9817ccd`](https://github.com/NixOS/nixpkgs/commit/f9817ccd57d0da836cb88fb5645d09ff904669b1) | `ioccheck: remove constraint of vt-py`                                            |
| [`bcea841e`](https://github.com/NixOS/nixpkgs/commit/bcea841e10e134d5969b8816d032fd6cd1edd6b8) | `vscode-extensions.valentjn.vscode-ltex: init at 13.0.0 (#145001)`                |
| [`ed15fa0a`](https://github.com/NixOS/nixpkgs/commit/ed15fa0a4a1de78ffb12c2d77c76f7b8a63cefb2) | `openttd-jgrpp: 0.43.1 -> 0.44.0`                                                 |
| [`93efc884`](https://github.com/NixOS/nixpkgs/commit/93efc8846c0036ddc615ade13009d88428c893e0) | `python3Packages.vt-py: 0.7.6 -> 0.8.0`                                           |
| [`cc29da0b`](https://github.com/NixOS/nixpkgs/commit/cc29da0bc31bf667d140743c3d9c9b854251ed58) | `ocamlPackages.ppx_cstubs: use default version of ppxlib`                         |
| [`d60b9516`](https://github.com/NixOS/nixpkgs/commit/d60b95168e471178e7c7bb23f9c959e02d7330a2) | `openttd: 12.0 -> 12.1`                                                           |
| [`951e23dd`](https://github.com/NixOS/nixpkgs/commit/951e23dddd4e22c45b1b65db91398acccc91729f) | `kubescape: 1.0.128 -> 1.0.130`                                                   |
| [`260a145c`](https://github.com/NixOS/nixpkgs/commit/260a145cc5ab1dc62ee695e7837a07f7f60b6404) | `gdu: 5.9.0 -> 5.10.0`                                                            |
| [`95b2f5d4`](https://github.com/NixOS/nixpkgs/commit/95b2f5d40b25544aa736b6ecbe7552e564ab0532) | `python3Packages.peewee: 3.14.4 -> 3.14.8`                                        |
| [`06d11b09`](https://github.com/NixOS/nixpkgs/commit/06d11b099ea533e531f1df9446a55c9d954c19d1) | `nali: init at 0.3.2`                                                             |
| [`c5eef209`](https://github.com/NixOS/nixpkgs/commit/c5eef209f23d2df34596a81bffaaec5653843c06) | `ocamlPackages.yuscii: fix tests on macOS`                                        |
| [`4f3f6259`](https://github.com/NixOS/nixpkgs/commit/4f3f62599d3892f496831ad4201cb732002ee1b9) | `add fortune as the main program`                                                 |
| [`637efc81`](https://github.com/NixOS/nixpkgs/commit/637efc8128e7506164a49125ce42864e3b3b4d84) | `brave: 1.31.87 -> 1.31.91`                                                       |
| [`46d85da1`](https://github.com/NixOS/nixpkgs/commit/46d85da10e1f1c9a009108722a13197e2d11acfb) | `apkeep: init at 0.6.0`                                                           |
| [`76b697b7`](https://github.com/NixOS/nixpkgs/commit/76b697b7b67943505a7b9ffa84f3c38d3be81d09) | `octofetch: 0.3.1 -> 0.3.3`                                                       |
| [`bb7c17f1`](https://github.com/NixOS/nixpkgs/commit/bb7c17f1e1c29c153ca79f9853dd61c76ae74820) | `roon-server: use makeBinPath instead of propagatedBuildInputs`                   |
| [`99ee3ee2`](https://github.com/NixOS/nixpkgs/commit/99ee3ee2907f64c33eba06fd2f8c086b90204ee6) | `present: init at 0.6.0`                                                          |
| [`33c50db6`](https://github.com/NixOS/nixpkgs/commit/33c50db65d0590755db7c48786ba387e55a6a045) | `cliscord: init at unstable-2020-12-08`                                           |
| [`edc5b763`](https://github.com/NixOS/nixpkgs/commit/edc5b763a1dee35172c24ee3487a05f01380cc22) | `tmpmail: unstable-2021-02-10 -> 1.1.4`                                           |
| [`6cbf1d42`](https://github.com/NixOS/nixpkgs/commit/6cbf1d42410c844e8c472dd2ece4021c8145d81e) | `keymapviz: init at 1.9.0`                                                        |
| [`6e08d6b5`](https://github.com/NixOS/nixpkgs/commit/6e08d6b5f880387a74c76d4b99ca0b8ed834dbde) | `heisenbridge: 1.4.1 -> 1.5.0`                                                    |
| [`a4266d37`](https://github.com/NixOS/nixpkgs/commit/a4266d37289d0d769644b15ab071ec61584ba5fb) | `session-management-for-emacs: fix lib attr missing`                              |
| [`546d60c5`](https://github.com/NixOS/nixpkgs/commit/546d60c5e6748b0479aceba50acd58e741daecf3) | `nixos/tests/misc: fix nix 2.4 support`                                           |
| [`c03040cf`](https://github.com/NixOS/nixpkgs/commit/c03040cfd5fef7dc99a7663c30e33df5ebec6984) | `nix-direnv: use nix (2.4) and remove enableFlakes`                               |
| [`73df68c1`](https://github.com/NixOS/nixpkgs/commit/73df68c1ab6ebe0cafd834f7317669c0a58d516c) | `sqlitebrowser: fix darwin build`                                                 |
| [`14102274`](https://github.com/NixOS/nixpkgs/commit/1410227449644c48ead3f53ab50b875aa7339841) | `zita-resampler: fix build for aarch64`                                           |
| [`93c293ed`](https://github.com/NixOS/nixpkgs/commit/93c293ed21acc2cc4befbc6c9120ebf35ca01450) | `perceptualdiff: set "meta.platforms = platforms.unix"`                           |
| [`1c07bb51`](https://github.com/NixOS/nixpkgs/commit/1c07bb514ffda3fbd50fc43d9f3f6d0fc019859e) | `id3lib: fix build on aarch64-darwin`                                             |
| [`df17da77`](https://github.com/NixOS/nixpkgs/commit/df17da77298f13a3a92366056252ec703b6a9b35) | `virtualbox: remove ? null from inputs, remove optional (), other minor cleanups` |
| [`14bbc387`](https://github.com/NixOS/nixpkgs/commit/14bbc387a9fffe6e58515119168d6d3f0453c141) | `fastnlo_toolkit: 2.5.0pre-2823 -> 2.5.0-2826`                                    |
| [`7e2a123a`](https://github.com/NixOS/nixpkgs/commit/7e2a123acb70a34b0cd5399324c8f0b701b0e40f) | `fastnlo_toolkit: fix on darwin`                                                  |
| [`d849eaee`](https://github.com/NixOS/nixpkgs/commit/d849eaee70c97071921b5e64653ffd6a062f8083) | `plasma5Packages.kwin: fix expected output`                                       |
| [`6db345c5`](https://github.com/NixOS/nixpkgs/commit/6db345c50e70e18908ac7936e12c9f2156025d56) | `moodle: 3.11.2 -> 3.11.4 (#145172)`                                              |
| [`9b496683`](https://github.com/NixOS/nixpkgs/commit/9b49668324a7ef7ca3036cbe7f9ca79e3cd40918) | `python3Packages.onnx: 1.10.1 -> 1.10.2`                                          |
| [`b67444cc`](https://github.com/NixOS/nixpkgs/commit/b67444cc491927d7a2b34c9b199330aeb47087a1) | `fluxcd: 0.20.1 -> 0.21.1`                                                        |
| [`26d329e7`](https://github.com/NixOS/nixpkgs/commit/26d329e7a898f8695fafd4543c828241d59711b6) | `vscode: 1.62.0 -> 1.62.1`                                                        |
| [`94b44236`](https://github.com/NixOS/nixpkgs/commit/94b44236a0ae3f2ca399c867f4c41105d4181ce0) | `plasma5Packages.baloo: fix default output, fix broken symlinks in dev output`    |
| [`12e3937e`](https://github.com/NixOS/nixpkgs/commit/12e3937ec95a77eaf4b0b788f6aa141b9ce061e3) | `todoman: disable failing tests`                                                  |
| [`a56d0d16`](https://github.com/NixOS/nixpkgs/commit/a56d0d167b3e74aeef39cca12e4960a9748ed7eb) | `minio-certgen: add myself as maintainer`                                         |
| [`4d765cae`](https://github.com/NixOS/nixpkgs/commit/4d765caecdc91e6efa61822499f2275b59926dee) | `create_amis.sh: fix logic for non-zfs amis`                                      |
| [`87514586`](https://github.com/NixOS/nixpkgs/commit/875145864970a72dbec4928c562d22c86ead6bf7) | `rust-script: 0.17.0 -> 0.18.0`                                                   |
| [`00cf347b`](https://github.com/NixOS/nixpkgs/commit/00cf347b9b5a27b742c5470c0772f7564321c8d3) | `tfk8s: add myself as maintainer`                                                 |
| [`55fa5e28`](https://github.com/NixOS/nixpkgs/commit/55fa5e286fbebebf6af29e9c156819429f0a3d88) | `opentelemetry-collector: 0.31.0 -> 0.38.0`                                       |
| [`c83bfca9`](https://github.com/NixOS/nixpkgs/commit/c83bfca9f1205cb61311d3a1b7cd3d5503bcbc47) | `python3Packages.cle: 9.0.10409 -> 9.0.10534`                                     |
| [`016c0ddc`](https://github.com/NixOS/nixpkgs/commit/016c0ddca3c2f462d8139d673758d932fdd73261) | `python3Packages.angrop: 9.0.10409 -> 9.0.10534`                                  |
| [`2fde954a`](https://github.com/NixOS/nixpkgs/commit/2fde954af31eb85c7b5bf37936bf71ca02da7ac6) | `python3Packages.angr: 9.0.10409 -> 9.0.10534`                                    |
| [`839c7ce0`](https://github.com/NixOS/nixpkgs/commit/839c7ce0882ba2954994a9004cb263a4e40967a8) | `python3Packages.claripy: 9.0.10409 -> 9.0.10534`                                 |
| [`802710a9`](https://github.com/NixOS/nixpkgs/commit/802710a91ad9368d2708b0ee16eab383a76e3a20) | `python3Packages.pyvex: 9.0.10409 -> 9.0.10534`                                   |
| [`a2f12d8b`](https://github.com/NixOS/nixpkgs/commit/a2f12d8be395c8dc7fe4bad87daee0439814b467) | `python3Packages.ailment: 9.0.10409 -> 9.0.10534`                                 |
| [`82577ee1`](https://github.com/NixOS/nixpkgs/commit/82577ee122a9f0609d42944e4ed12bd27483f722) | `python3Packages.archinfo: 9.0.10409 -> 9.0.10534`                                |
| [`1e061fc8`](https://github.com/NixOS/nixpkgs/commit/1e061fc8892de1a9ea05f1bfc51ad0c24d5623e8) | `img: Add myself as a maintainer`                                                 |
| [`d3ebcec8`](https://github.com/NixOS/nixpkgs/commit/d3ebcec8c441485b7b8b637f5b5f69505be006a4) | `pidgin: remove ? null from inputs, format, cleanups`                             |
| [`f5b089b6`](https://github.com/NixOS/nixpkgs/commit/f5b089b626baa2dcd5560ad77e250fc58a307621) | `netbsd: add missing rsync native build inputs`                                   |
| [`1fbe5a69`](https://github.com/NixOS/nixpkgs/commit/1fbe5a691270716797d72298d7da67ee2a9b1cac) | `ndn-tools: init at 0.7.1 (#144012)`                                              |
| [`289bc160`](https://github.com/NixOS/nixpkgs/commit/289bc160ac56de907749fe21b594a2753ea6a471) | `irqbalance: pull pending upstream inclusion fix for ncurses-6.3`                 |
| [`cb0d662a`](https://github.com/NixOS/nixpkgs/commit/cb0d662a75d7bfef12473cef134e417df1555f86) | `python3Packages.nbval: disable failing tests`                                    |
| [`7f99b55d`](https://github.com/NixOS/nixpkgs/commit/7f99b55db7e8d8b7c513b927d3960cae59b05a0c) | `intel-cmt-cat: init at 4.2.0 (#144190)`                                          |
| [`be26c847`](https://github.com/NixOS/nixpkgs/commit/be26c8471a7a872d56ba9b1d83fc38e2b65074a7) | `fail2ban: Fix for darwin`                                                        |
| [`10a145c5`](https://github.com/NixOS/nixpkgs/commit/10a145c518b4bfef99165d4f9d4cb5ed658b7e9c) | `singularity: 3.8.3 -> 3.8.4`                                                     |
| [`33ffba99`](https://github.com/NixOS/nixpkgs/commit/33ffba995d853658fb4db5f63ffb8ddc454c666f) | `NixOS: Document impurity issues with boot.binfmt.emulatedSystems (#142778)`      |