### PR TITLE
chore(flake/inputs/nixpkgs): `bcfcdaab` -> `43b394b9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1636592353,
-        "narHash": "sha256-keLNv3mLkbewKix9C7NN+7N2YIL9QojxWeFbnSlqqTc=",
+        "lastModified": 1636635602,
+        "narHash": "sha256-h1DBlHjn7/JiBzT65HwDcYkFZ6v1VQqDlsLRBj1EWuQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bcfcdaabf7f0f2fe38c0685711233a23e8cfc011",
+        "rev": "43b394b98e352562a6ea63db387b9fbdd858727f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`2de530ad`](https://github.com/NixOS/nixpkgs/commit/2de530ad99deb9c0fe13af43ae20e40114092799) | `flexget: 3.1.149 -> 3.1.150`                                            |
| [`592d84b5`](https://github.com/NixOS/nixpkgs/commit/592d84b591967909dc7a283b78fb6ba6b6429946) | `ocamlPackages.ppx_bitstring: use default ppxlib version`                |
| [`14acb100`](https://github.com/NixOS/nixpkgs/commit/14acb1006290d27fa87e58f151fd483b3622b3d9) | `libbsd: make libmd a propagated build input`                            |
| [`87843991`](https://github.com/NixOS/nixpkgs/commit/87843991ef4b22c5b0e1dbdffcb6c1edfcbfef83) | `ocaml: fix assembler on darwin`                                         |
| [`5bfe45de`](https://github.com/NixOS/nixpkgs/commit/5bfe45de8bbcb47382e5788ed0040353457b2b39) | `home-assistant: enable uptimerobot tests`                               |
| [`32d63aec`](https://github.com/NixOS/nixpkgs/commit/32d63aec97c7bcf2f37bddbceb05fc55264213c3) | `home-assistant: update component-packages`                              |
| [`64572a82`](https://github.com/NixOS/nixpkgs/commit/64572a82cc8c8e60183ed4021c2a1d4b28c16ab1) | `python3Packages.pyuptimerobot: init at 21.11.0`                         |
| [`9122117a`](https://github.com/NixOS/nixpkgs/commit/9122117a424986e0c8f78135f4bb0f3ea2047311) | `home-assistant: enable traccar tests`                                   |
| [`60b0709f`](https://github.com/NixOS/nixpkgs/commit/60b0709f561eafe535fa8defe11af3b0f4de537f) | `home-assistant: update component-packages`                              |
| [`5c97298a`](https://github.com/NixOS/nixpkgs/commit/5c97298a87b74a13d2e7493327f2be06c9598c34) | `python3Packages.pytraccar: init at 0.10.0`                              |
| [`a1c4a5b8`](https://github.com/NixOS/nixpkgs/commit/a1c4a5b894afc4aeccab1345c514e153413c5526) | `pantheon.elementary-default-settings: cleanup`                          |
| [`2e645a11`](https://github.com/NixOS/nixpkgs/commit/2e645a1191170edb3df32bb0a2119ec7849fdbe6) | `linux_zen: 5.14.15-zen1 -> 5.15.1-zen1`                                 |
| [`0acf0ce9`](https://github.com/NixOS/nixpkgs/commit/0acf0ce9243c76b23676cc3ff3ff0c9a78b6427e) | `beats: fix build on x86_64-darwin`                                      |
| [`f356b5f6`](https://github.com/NixOS/nixpkgs/commit/f356b5f6dc7dfefb4b194f165b1081a6ac98846a) | `octofetch: fix darwin build`                                            |
| [`c48aeef1`](https://github.com/NixOS/nixpkgs/commit/c48aeef1e07a802ea8a8abc1f30569bd49b02d25) | `python3Packages.iso3166: update sha256`                                 |
| [`479787df`](https://github.com/NixOS/nixpkgs/commit/479787df3affe122d94b0021ce39e4db9131d8b2) | `yt-dlp: 2021.10.22 -> 2021.11.10.1`                                     |
| [`34c058ef`](https://github.com/NixOS/nixpkgs/commit/34c058ef850de17750656ae3c0c0dcb848fb52b4) | `ammonite: fix build on x86_64-darwin`                                   |
| [`b1df71e8`](https://github.com/NixOS/nixpkgs/commit/b1df71e8e277a6d96110f1a4d34ad3662e69e4e3) | `maintainers: add davidarmstronglewis`                                   |
| [`715a5e0d`](https://github.com/NixOS/nixpkgs/commit/715a5e0da1433cbfabf15156c0b9195630a40e4a) | `pactorio: 0.5.1 -> 0.5.2`                                               |
| [`920625bd`](https://github.com/NixOS/nixpkgs/commit/920625bdf8a90f4f5e2acc355f9e9f5853021076) | `vimPlugins.harpoon: init at 2021-11-09`                                 |
| [`d65e1b59`](https://github.com/NixOS/nixpkgs/commit/d65e1b5927f59f776caa610b1f04dcc63c47c3b5) | `python3Packages.pytmx: 3.27 -> 3.30`                                    |
| [`556a9817`](https://github.com/NixOS/nixpkgs/commit/556a9817333431bf0670a18e2d0d5a0e3085cdb0) | `kdeltachat: unstable-2021-09-10 -> unstable-2021-10-27`                 |
| [`c571aa76`](https://github.com/NixOS/nixpkgs/commit/c571aa7642edf85ddeb7a2a775640c22b3e3d0e9) | `libdeltachat: 1.60.0 -> 1.63.0`                                         |
| [`07838b73`](https://github.com/NixOS/nixpkgs/commit/07838b73e007f5685d87b9c19f68bc772488fcfb) | `theharvester: 4.0.0 -> 4.0.2`                                           |
| [`612c6bdd`](https://github.com/NixOS/nixpkgs/commit/612c6bddb0f29e85137dbd881e8a1da8e445de47) | `wpscan: 3.8.19 -> 3.8.20`                                               |
| [`a22334d8`](https://github.com/NixOS/nixpkgs/commit/a22334d8a57202638f3f755c02c296c9d3e9174f) | `python3Packages.pymysensors: 0.21.0 -> 0.22.0`                          |
| [`072f9306`](https://github.com/NixOS/nixpkgs/commit/072f93062f9b1bf092707db649b4a27288b8902d) | `checkov: 2.0.556 -> 2.0.563`                                            |
| [`4c4f6a47`](https://github.com/NixOS/nixpkgs/commit/4c4f6a4793c975d03f9ecccb8fafe631e81b2f50) | `powershell: remove misleading comment`                                  |
| [`69c30d7c`](https://github.com/NixOS/nixpkgs/commit/69c30d7c7f66eea9d58d45d51e5b70366e1c49f6) | `tfsec: 0.58.15 -> 0.59.0`                                               |
| [`f127a76d`](https://github.com/NixOS/nixpkgs/commit/f127a76d6a85f82f9f55fe4924419f304c3a1ef4) | `python3Packages.cyclonedx-python-lib: 0.10.2 -> 0.11.0`                 |
| [`0154c34b`](https://github.com/NixOS/nixpkgs/commit/0154c34b0ace4530d0d3528245e7a026bb85184b) | `python3Packages.types-setuptools: init at 57.4.2`                       |
| [`333bc1c0`](https://github.com/NixOS/nixpkgs/commit/333bc1c05843603e55b58f4b00973832f6f058d6) | `python3Packages.types-toml: init at 0.10.0`                             |
| [`ed256b9c`](https://github.com/NixOS/nixpkgs/commit/ed256b9c89cd625d35f75a183414a8865b335449) | `bismuth:init at 2.1.0`                                                  |
| [`dbcbf262`](https://github.com/NixOS/nixpkgs/commit/dbcbf262506692963ed5d87c6125783c90aa6ede) | `ldc-bootstrap: 1.19.0 -> 1.25.0`                                        |
| [`5a63a08c`](https://github.com/NixOS/nixpkgs/commit/5a63a08cce2a54e020f048b13d59868a0eb7f258) | `matrix-commander: Add notify2 dependency to enable --os-notify feature` |
| [`92fae323`](https://github.com/NixOS/nixpkgs/commit/92fae323123ed5116bffd9cf7c89022f27ead34e) | `powershell: 7.1.4 -> 7.2.0`                                             |
| [`73e2ce14`](https://github.com/NixOS/nixpkgs/commit/73e2ce14e05906430d4f37b4944b3904fdb064f7) | `home-assistant: 2021.11.1 -> 2021.11.2`                                 |
| [`5546b473`](https://github.com/NixOS/nixpkgs/commit/5546b473b99aee7e905723268ee248071ec5da69) | `python3Packages.velbus-aio: 2021.11.0 -> 2021.11.6`                     |
| [`b537ba3c`](https://github.com/NixOS/nixpkgs/commit/b537ba3c65c9d10fbea2c698270bdec2954fbea5) | `python3Packages.aioshelly: 1.0.2 -> 1.0.4`                              |
| [`29355883`](https://github.com/NixOS/nixpkgs/commit/29355883f7f97ba2204dcd5ec72e98f71058a3b5) | `python3Packages.aioguardian: 2021.10.0 -> 2021.11.0`                    |
| [`177d2766`](https://github.com/NixOS/nixpkgs/commit/177d2766d633a98fca984ea4737b9761673ed499) | `python3Packages.total-connect-client: 2021.8.3 -> 2021.11.2`            |
| [`59f7048a`](https://github.com/NixOS/nixpkgs/commit/59f7048a542c0e73710619f67790ad7cba764b79) | `emote: 2.0.0 -> 3.0.3`                                                  |
| [`e2df8d45`](https://github.com/NixOS/nixpkgs/commit/e2df8d459ad8ad96b85292757765a8f1f0ed1115) | `python3Packages.manimpango: init at 0.3.1`                              |
| [`da324abf`](https://github.com/NixOS/nixpkgs/commit/da324abf24bbc1fbb0dbe4caa29e7b3015df8f61) | `realvnc-vnc-viewer: 6.21.406 -> 6.21.920`                               |
| [`abf50beb`](https://github.com/NixOS/nixpkgs/commit/abf50beb0280fe159ad91bac5376056442e62324) | `python3Packages.pyrmvtransport: rename from PyRMVtransport`             |
| [`edab1a52`](https://github.com/NixOS/nixpkgs/commit/edab1a523a46ae3a883f742e987d5e957c23ab7a) | `home-assistant: 2021.11.0 -> 2021.11.1`                                 |