### PR TITLE
chore(flake/inputs/nixpkgs): `43b394b9` -> `bf346b55`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1636635602,
-        "narHash": "sha256-h1DBlHjn7/JiBzT65HwDcYkFZ6v1VQqDlsLRBj1EWuQ=",
+        "lastModified": 1636678824,
+        "narHash": "sha256-NDB9CenPn5z2xbmG/X+Mg6Jd8iUEf7dfprQfXxSD6X8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "43b394b98e352562a6ea63db387b9fbdd858727f",
+        "rev": "bf346b557b76ffce74167f37752656dede5957f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                        |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`87f0af7b`](https://github.com/NixOS/nixpkgs/commit/87f0af7b690071abb0d0b9ac636096e82fbf07c6) | `curlie: 1.6.2 -> 1.6.7`                                              |
| [`ed551607`](https://github.com/NixOS/nixpkgs/commit/ed5516072847ffd66f640e8d927dd2db17decf83) | `ferdi: 5.6.2 -> 5.6.3`                                               |
| [`2644b4df`](https://github.com/NixOS/nixpkgs/commit/2644b4df663706ced7df9615afb2644f67ce3a41) | `pcre2: ftp.pcre.org looks defunct (#145546)`                         |
| [`1c2b368f`](https://github.com/NixOS/nixpkgs/commit/1c2b368fcf22059cb761ab0fa38575804861f47b) | `python3Packages.sievelib: 1.1.1 -> 1.2.1`                            |
| [`84fdde6c`](https://github.com/NixOS/nixpkgs/commit/84fdde6cddc3f33c3aaec9b4877fc98fdea601d8) | `bklk: fix builds on darwin`                                          |
| [`424f4541`](https://github.com/NixOS/nixpkgs/commit/424f4541cdd8b4218fcbe3df357e1b80583cb2bc) | `steampipe: 0.9.0 -> 0.9.1`                                           |
| [`717506b6`](https://github.com/NixOS/nixpkgs/commit/717506b6f4139ebb1a8fedeb6549888ae874432e) | `i3status-rust: 0.20.5 -> 0.20.6`                                     |
| [`4d02d703`](https://github.com/NixOS/nixpkgs/commit/4d02d7036a3370abc9aaa85be62176efedf3ab55) | `checkov: 2.0.563 -> 2.0.566`                                         |
| [`3119604c`](https://github.com/NixOS/nixpkgs/commit/3119604c2d23842d9d5bf4159b036e2a67498e98) | `pipewire-media-session: 0.4.0 -> 0.4.1`                              |
| [`c1a493bd`](https://github.com/NixOS/nixpkgs/commit/c1a493bdcdeb7725ea6c4d8c06cedf0280b25553) | `pipewire: 0.3.39 -> 0.3.40`                                          |
| [`a923032c`](https://github.com/NixOS/nixpkgs/commit/a923032c74a4705d8ceac13a67f5cf8e7f6e708b) | `metrics: set NIX_STORE_DIR`                                          |
| [`750f9aaa`](https://github.com/NixOS/nixpkgs/commit/750f9aaac938d50e2c93d57f197cc9968fa9b577) | `hash-slinger: 2.7 -> 3.1`                                            |
| [`361cd4b7`](https://github.com/NixOS/nixpkgs/commit/361cd4b7ded97453348305f4f89f40566b3abdf0) | `tinyssh: init at 20210601-unstable (#144029)`                        |
| [`375493e2`](https://github.com/NixOS/nixpkgs/commit/375493e22765a551938492dffe666911ac9d8c35) | `mkpasswd: minor cleanup`                                             |
| [`7da895a4`](https://github.com/NixOS/nixpkgs/commit/7da895a43aeb08ac976d7777ed6d0d57d5ad5963) | `dub: enable aarch64-darwin`                                          |
| [`842a7793`](https://github.com/NixOS/nixpkgs/commit/842a77939daad1f5aeb0a71beecd82c7364099f7) | `python3Packages.simple-di: also rename directory`                    |
| [`f0aec20c`](https://github.com/NixOS/nixpkgs/commit/f0aec20cd74d3080fdad4283aa103c10bc9bef38) | `create-amis.sh: possible deprecation`                                |
| [`e520ea8e`](https://github.com/NixOS/nixpkgs/commit/e520ea8eb62246d1a833575df6f5cd5def5fd2f6) | `exploitdb: 2021-11-09 -> 2021-11-11`                                 |
| [`d83603ec`](https://github.com/NixOS/nixpkgs/commit/d83603ec2c8b326e96aea85ccbe01b54edc0adbd) | `vimPlugins.ron-vim: init at 2020-08-22`                              |
| [`ed7252ca`](https://github.com/NixOS/nixpkgs/commit/ed7252ca24d62acb2b71aa30b7b6bdc8bfb021f2) | `vimPlugins.cmp-nvim-lsp-document-symbol: init at 2021-10-28`         |
| [`e757f1fc`](https://github.com/NixOS/nixpkgs/commit/e757f1fc7154f964c470f741a3e4b335adfab26e) | `vimPlugins.cmp-cmdline: init at 2021-11-08`                          |
| [`882d9ee7`](https://github.com/NixOS/nixpkgs/commit/882d9ee7131183455d156a2044d100b7ca8c8afe) | `vimPlugins: update`                                                  |
| [`dd3c8d22`](https://github.com/NixOS/nixpkgs/commit/dd3c8d2262839d153e941456ee343d5ed2227396) | `vimPlugins: fix update.py`                                           |
| [`422eda39`](https://github.com/NixOS/nixpkgs/commit/422eda39b4d419175ae6c677d154f967471df5eb) | `anytype: 0.20.9 -> 0.21.1`                                           |
| [`1cc0429a`](https://github.com/NixOS/nixpkgs/commit/1cc0429a8823b938dd2e015fca2908a4c1577b02) | `python3Packages.pyaftership: 21.1.0 -> 21.11.0`                      |
| [`49d03d07`](https://github.com/NixOS/nixpkgs/commit/49d03d07bec8104c69b51f16eea2d9423c07d039) | `vimPlugins.vim-fzf-coauthorship: init at 2021-07-14 (#145146)`       |
| [`f21e29d8`](https://github.com/NixOS/nixpkgs/commit/f21e29d83b4bad7ec3a2a4d683548ec5935f7828) | `youtube-dl: fix youtube.com download throttling`                     |
| [`e3bc4786`](https://github.com/NixOS/nixpkgs/commit/e3bc478689b49a9a830bb0cd0f30e473dd02065c) | `python3Packages.cirq-rigetti: relax certifi constraint`              |
| [`36e16d69`](https://github.com/NixOS/nixpkgs/commit/36e16d6979bec9ab3458b88a1a8804a975dadc8d) | `openmw: 0.46 -> 0.47`                                                |
| [`b6a5fe29`](https://github.com/NixOS/nixpkgs/commit/b6a5fe2963cef94f2dcbbb13c4c1daf553b2bdba) | `pkgsStatic.pixman: fix build`                                        |
| [`8437f3ac`](https://github.com/NixOS/nixpkgs/commit/8437f3acaf0f10a3aa8171cb7ed5b3a3740d9ab9) | `ouch: don't use vendored sources`                                    |
| [`0aa2edcd`](https://github.com/NixOS/nixpkgs/commit/0aa2edcd9e1b4a0d750016d911a20994617507ba) | `portmod: 2.0.3 -> 2.1.0 (#144847)`                                   |
| [`4cb7014e`](https://github.com/NixOS/nixpkgs/commit/4cb7014e1401c6c2dea0924ddc43910e7e522751) | `giflib: fix static build (#144919)`                                  |
| [`9a3de685`](https://github.com/NixOS/nixpkgs/commit/9a3de685693caec5d4b42cf5121c24d200909217) | `python39Packages.swspotify: put patching in proper phase`            |
| [`13cd7982`](https://github.com/NixOS/nixpkgs/commit/13cd7982473b846611410de12d6fb0cf6f93fb41) | `rbw: remove extra string concatination`                              |
| [`44e71586`](https://github.com/NixOS/nixpkgs/commit/44e7158618397ac3541bf71575364d51e2a90b50) | `python3Packages.distributed: 2021.9.1 -> 2021.10.0`                  |
| [`37d00bbc`](https://github.com/NixOS/nixpkgs/commit/37d00bbcf112de941872ba24233b71fbc89aa9a5) | `python3Packages.streamz: 0.6.2 -> 0.6.3`                             |
| [`e3003d54`](https://github.com/NixOS/nixpkgs/commit/e3003d541f455bdcc27e00f6406f4988da2150a0) | `python3Packages.dask: 2021.09.1 -> 2021.10.0`                        |
| [`4759d5e6`](https://github.com/NixOS/nixpkgs/commit/4759d5e60c30f6619e30dc2eeb18629242f5ec8c) | `glog: remove extra lib`                                              |
| [`662abd6a`](https://github.com/NixOS/nixpkgs/commit/662abd6a3cb32aef2b15a3d437a9ed2715693951) | `helm-docs: remove default platform`                                  |
| [`38a9cc17`](https://github.com/NixOS/nixpkgs/commit/38a9cc1745418694c15ff2db1ef22804367d1a2e) | `smartdeblur: switch to fetchFromGitHub, update meta`                 |
| [`ae5c365f`](https://github.com/NixOS/nixpkgs/commit/ae5c365f14f6d0b48bdecf2502c0cbe9581fb7db) | `python3Packages.pytautulli: 21.10.1 -> 21.11.0`                      |
| [`6d497c8b`](https://github.com/NixOS/nixpkgs/commit/6d497c8b5bce009aec5a92f90e5770b6305ae343) | `python3Packages.xarray: 0.19.0 -> 0.20.1`                            |
| [`3c754c3b`](https://github.com/NixOS/nixpkgs/commit/3c754c3b4561f455ce24f74163888815b9006620) | `tilix: fix nixpkgs-review-checks suggestion`                         |
| [`fc9a7448`](https://github.com/NixOS/nixpkgs/commit/fc9a7448ebbbb2a16ec021270d320001b2dbc20e) | `home-assistant: update component-packages`                           |
| [`64668593`](https://github.com/NixOS/nixpkgs/commit/646685933ed90c70bfd4ef637ecb1f60f121a2f4) | `python3Packages.panacotta: init at 0.1`                              |
| [`b400b651`](https://github.com/NixOS/nixpkgs/commit/b400b6514c48557a281f29704fd3491700df07a3) | `python3Packages.goalzero: 0.2.0 -> 0.2.1`                            |
| [`32bd7aaf`](https://github.com/NixOS/nixpkgs/commit/32bd7aaf320a14f209df61c2f82fd4dc4a71c44b) | `sublime-music: 0.11.14 -> 0.11.16`                                   |
| [`dc8a634b`](https://github.com/NixOS/nixpkgs/commit/dc8a634b45db3afa9a58e53d6f99a2a5328e7aec) | `terraform: 1.0.10 -> 1.0.11`                                         |
| [`873df62d`](https://github.com/NixOS/nixpkgs/commit/873df62da2c73cbbc2bcceee8942b8d40f179706) | `hydrus: 460 -> 461`                                                  |
| [`ed417073`](https://github.com/NixOS/nixpkgs/commit/ed4170733c141b610484fc452f1d0a0302213abd) | `amis: enable setting ami boot mode on registration`                  |
| [`84dbadf8`](https://github.com/NixOS/nixpkgs/commit/84dbadf81a0ab6291c978452d2479f5014cfd08d) | `openscenegraph: fix collada support`                                 |
| [`0d726864`](https://github.com/NixOS/nixpkgs/commit/0d7268648eae7fbb9d05a2c76c893e84a6a0116d) | `collada-dom: init at rdiankov-2020-01-03`                            |
| [`943cfb9a`](https://github.com/NixOS/nixpkgs/commit/943cfb9a2fd7bab8051411e0bd82c559be5a87c4) | `waydroid: 1.1.1 -> 1.2.0`                                            |
| [`2f5c7845`](https://github.com/NixOS/nixpkgs/commit/2f5c78458b146d1fa9f3d49625108ce416be090f) | `waydroid: Add missing dependencies`                                  |
| [`aff0f579`](https://github.com/NixOS/nixpkgs/commit/aff0f5792be20059c35d1e740302255465e2cd27) | `plausible: add remote connection with iex`                           |
| [`14580c7f`](https://github.com/NixOS/nixpkgs/commit/14580c7f4deabea627e07b46118651b84759ad6d) | `logisim-evolution: 3.5.0 -> 3.7.1`                                   |
| [`5641c103`](https://github.com/NixOS/nixpkgs/commit/5641c103cd1146833e7608e4422e8b7a9e76abaf) | `recastnavigation: init at 2021-03-05`                                |
| [`d9e363ca`](https://github.com/NixOS/nixpkgs/commit/d9e363ca12b62e1ae34460182f9514fbff1e8a77) | `surge-XT: init at unstable-2021-11-07`                               |
| [`5a4df47e`](https://github.com/NixOS/nixpkgs/commit/5a4df47ec78fee539941d4f56cf2897c7d3c9189) | `aether-lv2: init at 1.2.1`                                           |
| [`d4f4b721`](https://github.com/NixOS/nixpkgs/commit/d4f4b721bcdb394749f072a2679ac06d580bc003) | `openafs: Add upstream patches for Linux kernel 5.15`                 |
| [`c504b013`](https://github.com/NixOS/nixpkgs/commit/c504b013318a7c65b158fedbd3084bf498f6e4f4) | `nixosTests.seafile: link the committed test`                         |
| [`7a51cf9c`](https://github.com/NixOS/nixpkgs/commit/7a51cf9c1dcfd4e987c59ad3a93337000c2916ee) | `librepcb: 0.1.5 -> 0.1.6`                                            |
| [`7c6d4c90`](https://github.com/NixOS/nixpkgs/commit/7c6d4c902a049d70e4b7638d190cce20be2d1aeb) | `staticjinja: 4.1.0 -> 4.1.1`                                         |
| [`df5fd558`](https://github.com/NixOS/nixpkgs/commit/df5fd5580c8df80f59eee5a39f0402767dac491f) | `linux_lqx: 5.14.15 -> 5.14.16`                                       |
| [`d86143af`](https://github.com/NixOS/nixpkgs/commit/d86143af529b03cf432e7ef9cc6e2e2e761e97a0) | `fortran-language-server: init at 1.12.0`                             |
| [`7eaf05af`](https://github.com/NixOS/nixpkgs/commit/7eaf05af307861a348bdada0645c425fac595d15) | `most: enable parallel building`                                      |
| [`d382dd51`](https://github.com/NixOS/nixpkgs/commit/d382dd518fc4456d317672fa245cc5231f7dc1f5) | `binance: set electron version on top-level`                          |
| [`5d7683fc`](https://github.com/NixOS/nixpkgs/commit/5d7683fcae9f3958bf5e200aeb5b0d0fb6c452dd) | `nixos/zabbixWeb: remove added whitespace to the passwordFile option` |
| [`f5cfdee7`](https://github.com/NixOS/nixpkgs/commit/f5cfdee7084e69244e85403aa670269117b5af43) | `linux_lqx: 5.14.14 -> 5.14.15`                                       |
| [`8b81b49e`](https://github.com/NixOS/nixpkgs/commit/8b81b49ecde61c1595b2a013ef55d7e4c23f3167) | `faustPhysicalModeling: 2.33.1 -> 2.37.3`                             |
| [`1ff9d877`](https://github.com/NixOS/nixpkgs/commit/1ff9d8770574d6b6ce4d85136df9c5e08216c93a) | `python39Packages.vispy: 0.9.1 -> 0.9.3`                              |
| [`639941bc`](https://github.com/NixOS/nixpkgs/commit/639941bcfc0c51d7a1e468a66de7156f32fc145b) | `python38Packages.jellyfish: 0.8.8 -> 0.8.9`                          |
| [`61312e68`](https://github.com/NixOS/nixpkgs/commit/61312e68a35d1525fe316313f76d766a7477b77d) | `python38Packages.jaeger-client: 4.6.1 -> 4.8.0`                      |
| [`0b949588`](https://github.com/NixOS/nixpkgs/commit/0b949588a66ec9f978e5167175bb45ab3e459323) | `python38Packages.zarr: 2.10.1 -> 2.10.2`                             |
| [`5e2ebc73`](https://github.com/NixOS/nixpkgs/commit/5e2ebc73dfb06fdb6e00db99e88f3c99efa9f33b) | `python38Packages.pytest-flakes: 4.0.3 -> 4.0.4`                      |
| [`9bf24496`](https://github.com/NixOS/nixpkgs/commit/9bf244964dcee435d2464e0054c558822e3184ab) | `runInLinuxImage: Add missing backing format`                         |
| [`06251217`](https://github.com/NixOS/nixpkgs/commit/062512179362d5c082c4121cf3f476bdebf8442b) | `buildInDebian: fix test`                                             |
| [`d3751a11`](https://github.com/NixOS/nixpkgs/commit/d3751a11dbebc5028c0a6114ee6e91abfa723ec9) | `python38Packages.exchangelib: 4.5.2 -> 4.6.0`                        |
| [`aa92ca3c`](https://github.com/NixOS/nixpkgs/commit/aa92ca3c857e43e7e73db87226bbc945dd13f890) | `python38Packages.django_environ: 0.7.0 -> 0.8.1`                     |
| [`d0992629`](https://github.com/NixOS/nixpkgs/commit/d0992629edf15f1a756130104f4eaa2b216a8dce) | `python38Packages.nbdime: 3.1.0 -> 3.1.1`                             |
| [`e83647df`](https://github.com/NixOS/nixpkgs/commit/e83647df364f78a1612cab19db4f57fde8afd418) | `python38Packages.azure-mgmt-network: 19.1.0 -> 19.2.0`               |
| [`ae3ce386`](https://github.com/NixOS/nixpkgs/commit/ae3ce3861c008cf8fe4c65a9b0037fdc2bd9e12e) | `vista-fonts: install cambria.ttc as well`                            |
| [`0da88ff0`](https://github.com/NixOS/nixpkgs/commit/0da88ff0a0289dbfe32929a704588152a11faee9) | `yquake2: 7.43 -> 8.00`                                               |
| [`e750ba7e`](https://github.com/NixOS/nixpkgs/commit/e750ba7e6b49517b775ea1427a3316523c97ac21) | `python38Packages.azure-mgmt-recoveryservicesbackup: 2.0.0 -> 3.0.0`  |
| [`29e06158`](https://github.com/NixOS/nixpkgs/commit/29e06158ef44ac16296a71721d7cc080f67a690d) | `python38Packages.authheaders: 0.13.0 -> 0.14.1`                      |
| [`22f53225`](https://github.com/NixOS/nixpkgs/commit/22f532258cc2fc0faa030bbbe7c3139f1ab4ac64) | `python38Packages.pyopencl: 2021.2.8 -> 2021.2.9`                     |
| [`8549dfea`](https://github.com/NixOS/nixpkgs/commit/8549dfea8d57ebf5a9fe4a6ba456f19fbdc26eb8) | `python38Packages.easy-thumbnails: 2.7.1 -> 2.7.2`                    |
| [`afa29746`](https://github.com/NixOS/nixpkgs/commit/afa297466f35c90bb3a1c5f2ebd38537d2de5301) | `python38Packages.sagemaker: 2.63.0 -> 2.63.1`                        |
| [`fa87afd7`](https://github.com/NixOS/nixpkgs/commit/fa87afd754177b8ad376cf40ab3adc7e2f1a8d67) | `python38Packages.icalendar: 4.0.8 -> 4.0.9`                          |
| [`92ed4748`](https://github.com/NixOS/nixpkgs/commit/92ed47487f148061fab7396eb39b80df6eee5400) | `qemu: drop obsolete musl patch`                                      |
| [`a5a4b0c3`](https://github.com/NixOS/nixpkgs/commit/a5a4b0c3163ed3c89309b53860375e149e02c23b) | `nss-mdns: patch unconditionally`                                     |
| [`a3e5b793`](https://github.com/NixOS/nixpkgs/commit/a3e5b793b52b27807b06d92993e09add8cc92388) | `python38Packages.azure-mgmt-containerinstance: 9.0.0 -> 9.1.0`       |
| [`30453bbf`](https://github.com/NixOS/nixpkgs/commit/30453bbf3095739c2d3d110cd06893d41ee03ad8) | `python3Packages.MDP: reenable tests`                                 |
| [`4bd6390d`](https://github.com/NixOS/nixpkgs/commit/4bd6390df1c820826f217645f40ea30d3bb2bce0) | `python38Packages.tweepy: 3.10.0 -> 4.0.1`                            |
| [`78709d2d`](https://github.com/NixOS/nixpkgs/commit/78709d2d03af827d2fc2f6488f8bee9c1b7a45a0) | `python38Packages.azure-mgmt-authorization: 1.0.0 -> 2.0.0`           |
| [`e93889e8`](https://github.com/NixOS/nixpkgs/commit/e93889e81c9d42be6cbf6e3d2213f888f16a6dec) | `python3Packages.huawei-lte-api: 1.4.18 -> 1.5.2`                     |