### PR TITLE
chore(flake/inputs/nixpkgs): `bf346b55` -> `db93862a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1636678824,
-        "narHash": "sha256-NDB9CenPn5z2xbmG/X+Mg6Jd8iUEf7dfprQfXxSD6X8=",
+        "lastModified": 1636719998,
+        "narHash": "sha256-iWm7lgzgGd+yK9XX/UR3ztcgcGQht+E56BXXPlBtqsA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bf346b557b76ffce74167f37752656dede5957f3",
+        "rev": "db93862a2c777135e0af3e9c7b0bbcba642c8343",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                     |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`4302a675`](https://github.com/NixOS/nixpkgs/commit/4302a67531dd89b989502d37bb7b361e97532646) | `zerotierone: 1.8.1 -> 1.8.2`                                                      |
| [`c810f7be`](https://github.com/NixOS/nixpkgs/commit/c810f7befc3f6642ebeaf68cdc9e9e0c90a42559) | `openmolcas: 20.06 -> 20.10`                                                       |
| [`ca7dd700`](https://github.com/NixOS/nixpkgs/commit/ca7dd700e52bb3a9064a59afa87587abf216d594) | `octopus: 10.5 -> 11.2`                                                            |
| [`64144e80`](https://github.com/NixOS/nixpkgs/commit/64144e80dfd96486dfed1c4d9fa180c67b22e546) | `bazel_4: disable install check on aarch64-darwin`                                 |
| [`99da871c`](https://github.com/NixOS/nixpkgs/commit/99da871c5b9cd8627a53f8be5ebf13f201dcb5cf) | `postfix: 3.6.2 -> 3.6.3`                                                          |
| [`7c38f44d`](https://github.com/NixOS/nixpkgs/commit/7c38f44db53932b195f50c294f28ec54140802fa) | `metasploit: 6.1.13 -> 6.1.14`                                                     |
| [`be6effcd`](https://github.com/NixOS/nixpkgs/commit/be6effcd43d2137fd02a9b578b3406e27996b970) | `tilt: 0.22.9 -> 0.22.15`                                                          |
| [`3fd29590`](https://github.com/NixOS/nixpkgs/commit/3fd2959087ed83a703dd610b91eba504a9e19c4c) | `maintainers.expipiplus1: add key`                                                 |
| [`92c881b6`](https://github.com/NixOS/nixpkgs/commit/92c881b6a72abce5bb2f5db3f903b4871d13aaa9) | `innernet: 1.5.0 -> 1.5.1`                                                         |
| [`75c771c0`](https://github.com/NixOS/nixpkgs/commit/75c771c0edc2fba327e8a8936b3b97525ed301ed) | `snapcast: add pulseaudio support (#144674)`                                       |
| [`0cc4bb57`](https://github.com/NixOS/nixpkgs/commit/0cc4bb5776b99e329ead88008e9e32c89134d855) | `python3Packages.boost-histogram: 1.1.0 -> 1.2.1`                                  |
| [`0437e902`](https://github.com/NixOS/nixpkgs/commit/0437e90238b64b0267b5dc1f62eb0bc042e8a9c0) | `7zz: 21.01 -> 21.04 (#145031)`                                                    |
| [`24965d7d`](https://github.com/NixOS/nixpkgs/commit/24965d7d17f88d478a96bf0dd01e10e68ce22939) | `haskellPackages: mark packages depending on webkitgtk as not supported on darwin` |
| [`41d9a2e4`](https://github.com/NixOS/nixpkgs/commit/41d9a2e4970b79f1037ad0e40d2ea3ec9956df68) | `argocd: add myself as maintainer`                                                 |
| [`968cdb48`](https://github.com/NixOS/nixpkgs/commit/968cdb481526fa50e6d3651633ebd4b0f29a6395) | `haskellPackages: mark builds failing on hydra as broken`                          |
| [`47428eb5`](https://github.com/NixOS/nixpkgs/commit/47428eb5510028b56afa44003ff5b6120d628ce6) | `haskellPackages: mark builds failing on hydra as broken`                          |
| [`fda6439c`](https://github.com/NixOS/nixpkgs/commit/fda6439cead6e9a1d75e3d984a2e92c86cd58c99) | `vscode: 1.62.1 -> 1.62.2`                                                         |
| [`84b639b0`](https://github.com/NixOS/nixpkgs/commit/84b639b02797bbb58982fc8e19952e9ab96c71ac) | `python3Packages.mailman-hyperkitty: mailman is available for one release`         |
| [`589fec71`](https://github.com/NixOS/nixpkgs/commit/589fec71d4a2abfecbde16dfdc2b5551c4662f0c) | `python3Packages.atpublic: add pythonImportsCheck`                                 |
| [`731c09d8`](https://github.com/NixOS/nixpkgs/commit/731c09d826e888ee91d181e0621fec2addc9b4f9) | `python3Packages.aiosmtpd: enable tests`                                           |
| [`2c00db1e`](https://github.com/NixOS/nixpkgs/commit/2c00db1ead747f04dacf7db0532f5942e4146ea0) | `nextcloud22: 22.2.0 -> 22.2.1`                                                    |
| [`65dfe535`](https://github.com/NixOS/nixpkgs/commit/65dfe535af7eba63b70538a87bebc94b38a2795e) | `iosevka: 10.3.1 → 11.0.1`                                                         |
| [`8deb742e`](https://github.com/NixOS/nixpkgs/commit/8deb742e5537c42d875a33df5e78920d8ef5df49) | `python3Packages.anybadge: 1.7.0 -> 1.8.0`                                         |
| [`657b435b`](https://github.com/NixOS/nixpkgs/commit/657b435b123090c53eac2f4cd198a5592ffed1b9) | `libdeltachat: 1.63.0 -> 1.64.0`                                                   |
| [`a9252b22`](https://github.com/NixOS/nixpkgs/commit/a9252b2275a6ae663d5df1429a3d837138a76ed6) | `buf: 1.0.0-rc7 -> 1.0.0-rc8`                                                      |
| [`48cec203`](https://github.com/NixOS/nixpkgs/commit/48cec203c85bd5c55c681b844342eabc1c0a1906) | `python3Packages.imgaug: disable some flaky tests`                                 |
| [`647258aa`](https://github.com/NixOS/nixpkgs/commit/647258aa7c3aacdb4759ab82358d45ced88d363e) | `sfm: fix cross-compilation`                                                       |
| [`407e981f`](https://github.com/NixOS/nixpkgs/commit/407e981f7c202abfeae97fa8416b01c1b28d1b95) | `pkgsStatic.valgrind: mark broken`                                                 |
| [`718c7b49`](https://github.com/NixOS/nixpkgs/commit/718c7b497268a14092312e4a09d206919924d263) | `home-assistant: update component-packages`                                        |
| [`efe55aae`](https://github.com/NixOS/nixpkgs/commit/efe55aae34bfabb57e96a5f12702a9c6c65cc200) | `python3Packages.pylaunches: init at 1.2.0`                                        |
| [`94e8a12a`](https://github.com/NixOS/nixpkgs/commit/94e8a12a7a476d734f2a50bb2abe4751c3ecb271) | `python3Packages.pybalboa: init at 0.13`                                           |
| [`3973f7a6`](https://github.com/NixOS/nixpkgs/commit/3973f7a67071ac78fed257e9629df89fe9aba254) | `haskellPackages.purenix: add myself as a maintainer`                              |
| [`804bb254`](https://github.com/NixOS/nixpkgs/commit/804bb2546d537cfe36d3d8b8822cb068f0f2a22d) | `haskellPackages.purenix: get building`                                            |
| [`c2b56b01`](https://github.com/NixOS/nixpkgs/commit/c2b56b0162f1aba547b6d375be926f0f4da10809) | `haskellPackages.happy_1_19_9: removed no-longer-used version`                     |
| [`749f0c35`](https://github.com/NixOS/nixpkgs/commit/749f0c355e3f611a2740389275dd0141d6920b0f) | `haskellPackages.purescript: get building again`                                   |
| [`af0eedf5`](https://github.com/NixOS/nixpkgs/commit/af0eedf531086935f53ce3fdb640279011598129) | `haskell.packages.ghc921.invariant: drop now upstreamed patch`                     |
| [`34503b8b`](https://github.com/NixOS/nixpkgs/commit/34503b8bb7841d947d17ac424dffae845ea91aef) | `dolphinEmu{Master}: rename to dolphin-emulator{-beta}`                            |
| [`d68033af`](https://github.com/NixOS/nixpkgs/commit/d68033afae8476a840a3d6866f9119a78e5dec84) | `haskellPackages.mkDerivation: add doHaddockInterfaces option`                     |
| [`940f3b60`](https://github.com/NixOS/nixpkgs/commit/940f3b60b931415761ab56702135777e386b0b42) | `dolphinEmuMaster: remove unnecessary symlink, force xcb`                          |
| [`1269a421`](https://github.com/NixOS/nixpkgs/commit/1269a421d1f3965f5aec68b10d7a25a8390c1715) | `haskellPackages.language-javascript_0_7_0_0: add for use with purescript`         |
| [`ea8a637c`](https://github.com/NixOS/nixpkgs/commit/ea8a637c66e6ceb8c3c59b60c9b9032b1b74d976) | `haskellPackages.purescript-cst: get building`                                     |
| [`7f407040`](https://github.com/NixOS/nixpkgs/commit/7f407040debf7dd65e5a56f95bb45562e5d0c168) | `terranix: use wrapProgram on terranix-doc-json`                                   |
| [`068869dd`](https://github.com/NixOS/nixpkgs/commit/068869dd03b16b7bd777c1b44a2e4d50f3cc09de) | `haskellPackages.lapack-ffi: apply configuration change unbreaking it`             |
| [`cc61d6cc`](https://github.com/NixOS/nixpkgs/commit/cc61d6cca06aaa46ccde79a92cd94dbb27c634a7) | `haskellPackages.ghc-bignum: pin to 1.0 for 8.10.* support`                        |
| [`e6272c17`](https://github.com/NixOS/nixpkgs/commit/e6272c17151eedf63f33d949b186f5f6dcd1cd80) | `haskellPackages.futhark: pin to < 0.20.6 to avoid aeson 2.0.0.0`                  |
| [`d25b3d60`](https://github.com/NixOS/nixpkgs/commit/d25b3d60af640566067ae44cccdb4aa7370f822c) | `haskellPackages.streamly_0_8_0: provide new dep Cocoa on darwin`                  |
| [`398a9481`](https://github.com/NixOS/nixpkgs/commit/398a9481917df6eb4d61b8ba3237941ab32fdf67) | `haskellPackages.ghcup: fix libyaml-streamly inheriting stale broken`              |
| [`50f969fb`](https://github.com/NixOS/nixpkgs/commit/50f969fb18984add94ec12c59f7f48a01178423b) | `haskellPackages.git-annex: update sha256 for 8.20211028`                          |
| [`a8bf7797`](https://github.com/NixOS/nixpkgs/commit/a8bf7797ed8e75069558a3d75fb0f0fee4b2599e) | `haskellPackages.dsv: run now fixed test suite`                                    |
| [`07c7f8e2`](https://github.com/NixOS/nixpkgs/commit/07c7f8e267f024db5fd332f993fcca9ece6fb211) | `haskellPackages.assoc-list{,like}: run now fixed test suite`                      |
| [`6ec50700`](https://github.com/NixOS/nixpkgs/commit/6ec50700ae0dd190cd052f986703d6b417c4860a) | `haskellPackages.base16: run now fixed testsuite`                                  |
| [`e4bb4090`](https://github.com/NixOS/nixpkgs/commit/e4bb4090ace07e71405a4e022b8da5106c3e95d4) | `haskellPackages.plots: remove now unnecessary jailbreak`                          |
| [`17e2591d`](https://github.com/NixOS/nixpkgs/commit/17e2591d9b216634ab501293efa2ba4c55ff6bc9) | `haskell.packages.ghc901.autoapply: jailbreak`                                     |
| [`2413ab9e`](https://github.com/NixOS/nixpkgs/commit/2413ab9e72fe4933c832cc216d6fbc23beef2f10) | `haskellPackages.developPackage: Use haskell.lib.compose correctly`                |
| [`15ae25f3`](https://github.com/NixOS/nixpkgs/commit/15ae25f36ce057c1750f02e30bcd7b6dc38d523b) | `haskell: switch from haskell.lib to haskell.lib.compose`                          |
| [`518f09f2`](https://github.com/NixOS/nixpkgs/commit/518f09f2d0e8829c3ef77c0f535df309f49ed6d9) | `haskell.lib.compose: init`                                                        |
| [`8b7c314e`](https://github.com/NixOS/nixpkgs/commit/8b7c314eae6c608084d3ba5365617405f66167a6) | `haskellPackages.lua: remove unnecessary patch`                                    |
| [`62ecf444`](https://github.com/NixOS/nixpkgs/commit/62ecf444fe8c0f2d396754e72b705eabc991d843) | `haskellPackages.hledger_1_23: override hledger-lib dependency version`            |
| [`1756231e`](https://github.com/NixOS/nixpkgs/commit/1756231ea52264d396e9ccaa855d64f32fa35efa) | `haskell.packages.ghc921.ghc-lib*: use 9.2.1 version by default`                   |
| [`18b531b5`](https://github.com/NixOS/nixpkgs/commit/18b531b514e4a0a623f36a6d6389c9881f3495df) | `cwltool: 3.1.20210628163208 -> 3.1.20211104071347`                                |
| [`8e6a8f9c`](https://github.com/NixOS/nixpkgs/commit/8e6a8f9cee643679389aa1691467197b06e1ec00) | `python3Packages.schema-salad: 8.2.20210918131710 -> 8.2.20211104054942`           |
| [`5102894b`](https://github.com/NixOS/nixpkgs/commit/5102894b0862883838aeb064124ff95d8162775b) | `haskellPackages: regenerate package set based on current config`                  |
| [`12e5c650`](https://github.com/NixOS/nixpkgs/commit/12e5c6505e5af28a23ba8119ede280e47284d453) | `haskellPackages.hadolint: remove override`                                        |
| [`7c182a10`](https://github.com/NixOS/nixpkgs/commit/7c182a1002df7cd6d1a7e91d8284fe957a98167a) | `configuration-ghc-9.2.x.nix: update overrides`                                    |
| [`1278c772`](https://github.com/NixOS/nixpkgs/commit/1278c772dac0afca8864a36d51be974c927efbcc) | `configuration-ghc-9.2.x.nix: `aeson_2_0_1_0`-related overrides`                   |
| [`a1f0dff4`](https://github.com/NixOS/nixpkgs/commit/a1f0dff4a71aa4367dae205d058b03a8cf786442) | `haskellPackages: make ghc-lib* package versions GHC 9.0.1 available`              |
| [`c6b8abd7`](https://github.com/NixOS/nixpkgs/commit/c6b8abd70aaeca25343ef2d6758ad118cb62be76) | `haskell.packages.ghc901.th-desugar: use 1.13 to fix eval`                         |
| [`b38d0a80`](https://github.com/NixOS/nixpkgs/commit/b38d0a808655d67253c91a5d724130a31e0aedb2) | `configuration-ghc-9.2.x.nix: update overrides`                                    |
| [`64a5e322`](https://github.com/NixOS/nixpkgs/commit/64a5e322cb8cd8b33883ef37ed30d902fbcf512d) | `haskellPackages.hadolint: patch to permit our language-docker version`            |
| [`7a2ef11a`](https://github.com/NixOS/nixpkgs/commit/7a2ef11ae1aa23c8770250906030ef8805c726c7) | `haskellPackages.ghcup: overrideScope for new versions and jailbreak`              |
| [`be3aabda`](https://github.com/NixOS/nixpkgs/commit/be3aabda6bedd553e9e681e63649b0f1e2ea89aa) | `haskellPackages.haskell-ci-unstable: bump attoparsec dependency`                  |
| [`02fb0e22`](https://github.com/NixOS/nixpkgs/commit/02fb0e220223377f46dfefb0bab7a09a37cde8e9) | `haskellPackages.ghcup: remove obsolete test fix`                                  |
| [`a744a741`](https://github.com/NixOS/nixpkgs/commit/a744a7413d107078764fd8279df7bf0dc2d8ced1) | `haskellPackages.language-docker: remove obsolete fix`                             |
| [`0f125bc2`](https://github.com/NixOS/nixpkgs/commit/0f125bc220396aa1010ff1dccbd26bf146178bf1) | `haskell.packages.ghc901.semialign: 1.2 -> 1.2.0.1`                                |
| [`0669baa8`](https://github.com/NixOS/nixpkgs/commit/0669baa8275bd66c02d68c7988601bc2ec66c5c2) | `haskellPackages.hnix: bump semialign dependency`                                  |
| [`fc00be62`](https://github.com/NixOS/nixpkgs/commit/fc00be62ad84244075f4846cb0f98463c23cb9a0) | `haskellPackages: regenerate package set based on current config`                  |
| [`bd742755`](https://github.com/NixOS/nixpkgs/commit/bd742755f146939813d82a847aec1e7961f5e3d3) | `all-cabal-hashes: 2021-10-23T04:57:02Z -> 2021-11-05T06:34:09Z`                   |
| [`a48d50d7`](https://github.com/NixOS/nixpkgs/commit/a48d50d751a6ed59b27e1c721a3a0bd7073c2d32) | `haskellPackages: stackage-lts 18.13 -> 18.15`                                     |
| [`81e6c92e`](https://github.com/NixOS/nixpkgs/commit/81e6c92ec074b15ee362350d9dde51bde49fc6fd) | `lego: 4.5.2 -> 4.5.3`                                                             |
| [`fc04ef07`](https://github.com/NixOS/nixpkgs/commit/fc04ef07be15e2d4257143b289cad5032c8b43ca) | `iptstate: 2.2.6 -> 2.2.7`                                                         |
| [`26cf8bdd`](https://github.com/NixOS/nixpkgs/commit/26cf8bddfff48720913e888ac00f3ba0d6095970) | `binaryen: 101 -> 102`                                                             |
| [`18989fe3`](https://github.com/NixOS/nixpkgs/commit/18989fe325eeb00f12ae9d409cfc2450832bd177) | `python3Packages.anyio: 3.3.1 -> 3.3.2`                                            |