### PR TITLE
chore(flake/inputs/home-manager): `1e5c8e9b` -> `39c5c739`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -62,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1636520380,
-        "narHash": "sha256-gBiQ8+AQG6Dia34rqJDuqs6VFe/J1SjIhOZBeTXCKQI=",
+        "lastModified": 1636761661,
+        "narHash": "sha256-7SCLyYrf/PTZFAFq5pS3c6T/mhs0vEhx5LR2mc6SeE4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1e5c8e9bff00d0844bc3d25d1a98eab5633e600b",
+        "rev": "39c5c7397ed27aa4146a63cb1a27c0a4d4030224",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                  |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`39c5c739`](https://github.com/nix-community/home-manager/commit/39c5c7397ed27aa4146a63cb1a27c0a4d4030224) | `docs: improve description of extraSpecialArgs` |
| [`be1ad305`](https://github.com/nix-community/home-manager/commit/be1ad30503024129477956289ea5e51593d3a445) | `Remove remaining `allowSubstitutes = false``   |