### PR TITLE
chore(flake/inputs/nixpkgs): `db93862a` -> `d14a8e37`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1636719998,
-        "narHash": "sha256-iWm7lgzgGd+yK9XX/UR3ztcgcGQht+E56BXXPlBtqsA=",
+        "lastModified": 1636807505,
+        "narHash": "sha256-owMJ7+K/8nu3fY8B1wdCl0QaqZLBjdog/6wSxMrnHbA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "db93862a2c777135e0af3e9c7b0bbcba642c8343",
+        "rev": "d14a8e372f5c0d8801471a2e5884b196f6d1ae73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                 |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| [`802bd2b7`](https://github.com/NixOS/nixpkgs/commit/802bd2b7e3c2efc7bbb3fecf94fea9bffa3b1790) | `Revert "follow up to pname+version switch: libs"`                                             |
| [`3e84e0fd`](https://github.com/NixOS/nixpkgs/commit/3e84e0fd7da610668bde7a5f9a548d9f02ee2ac8) | `coqPackages.graph-theory: enable for Coq 8.14`                                                |
| [`551c8493`](https://github.com/NixOS/nixpkgs/commit/551c849344b90f605ad61e193337582e16116fdb) | `ocamlPackages.elpi: use recent version of ppxlib`                                             |
| [`a5c670a4`](https://github.com/NixOS/nixpkgs/commit/a5c670a45fe6c66da6a1c4779dc8312a61ad01ad) | `mu: 1.6.9 -> 1.6.10`                                                                          |
| [`f745b93d`](https://github.com/NixOS/nixpkgs/commit/f745b93d86b51003f7c3e179211de777c4bfd1cd) | `tree: fix package`                                                                            |
| [`53d0d3e4`](https://github.com/NixOS/nixpkgs/commit/53d0d3e4b7aee7e097d84b15415c60fc2bb4a097) | `flat-remix-gnome: 20211028 -> 20211113`                                                       |
| [`dd8b662b`](https://github.com/NixOS/nixpkgs/commit/dd8b662bf56a5f441faf6751120c7d8277a928d1) | `monado: build with libbsd`                                                                    |
| [`6e2f2506`](https://github.com/NixOS/nixpkgs/commit/6e2f25061dda509977f4013061ee777f75a19254) | `amass: 3.14.3 -> 3.15.0`                                                                      |
| [`ef73f580`](https://github.com/NixOS/nixpkgs/commit/ef73f580b8cbe56de787a8533d5804dfc2c76c68) | `roxterm: 3.7.5 -> 3.11.1`                                                                     |
| [`aca795f9`](https://github.com/NixOS/nixpkgs/commit/aca795f9005e08a76315acee0a6a63dcbcddfd76) | `sameboy: 0.14.5 -> 0.14.6`                                                                    |
| [`c6b8047e`](https://github.com/NixOS/nixpkgs/commit/c6b8047eb1280c883020aefd7b18a3ac3c09dc16) | `oggvideotools: fix build on gcc-12`                                                           |
| [`990cb2a6`](https://github.com/NixOS/nixpkgs/commit/990cb2a6eb599d8d22f56507249124450e8305d2) | `freetube: 0.15.0 -> 0.15.1`                                                                   |
| [`6d3f429a`](https://github.com/NixOS/nixpkgs/commit/6d3f429a203fac36639cf89d3cf85e5d74fe7d14) | `ocamlPackages.bistro: 0.5.0 -> unstable-2021-07-13`                                           |
| [`b4049127`](https://github.com/NixOS/nixpkgs/commit/b40491279c15df1b0e24c6884965357363960a0f) | `sfeed: fix cross-compilation`                                                                 |
| [`ce70bbbb`](https://github.com/NixOS/nixpkgs/commit/ce70bbbbd8c5769267aba51c290edeb265ead889) | `protobuf: pin to 3.17 for Python 2`                                                           |
| [`aa5f5658`](https://github.com/NixOS/nixpkgs/commit/aa5f5658993acc6b7d98eebd9eaca3ac747f3c7e) | `Add "arrch64-darwin" to badPlatforms`                                                         |
| [`17ed1381`](https://github.com/NixOS/nixpkgs/commit/17ed13814d490fcfea0d0c1585fdee1dbacfa8f1) | `exploitdb: 2021-11-11 -> 2021-11-13`                                                          |
| [`015cc5d9`](https://github.com/NixOS/nixpkgs/commit/015cc5d95942e7f79fe528a17825571484e7a0da) | `dstp: init at 0.3.0`                                                                          |
| [`a3d17b38`](https://github.com/NixOS/nixpkgs/commit/a3d17b38a1f250dd7df259baf8f8ea1441ab6bb6) | `build(deps): bump cachix/install-nix-action from 14 to 15`                                    |
| [`0a88f58e`](https://github.com/NixOS/nixpkgs/commit/0a88f58ec8e480c9dbb91b3aab2dbe1920f6f72a) | `metadata-cleaner: 1.0.7 -> 2.0.1`                                                             |
| [`0d6fceb2`](https://github.com/NixOS/nixpkgs/commit/0d6fceb24a7a0a3595e25a04c8f6743c52e057a5) | `spoof-mac: add pythonImportsCheck`                                                            |
| [`869a386e`](https://github.com/NixOS/nixpkgs/commit/869a386eedd003ea113f216e9a059a840101301b) | `vc_0_7: fix darwin build`                                                                     |
| [`d372457b`](https://github.com/NixOS/nixpkgs/commit/d372457bf00a6f32f9cf4df8b66f3a1074ebba77) | `levant: init at 0.3.0`                                                                        |
| [`46bc8d3b`](https://github.com/NixOS/nixpkgs/commit/46bc8d3b1048513df8f3874d527b6990fdac6049) | `maintainers: add max-niederman`                                                               |
| [`2043dbb6`](https://github.com/NixOS/nixpkgs/commit/2043dbb6faa9e21b0fb500161542e30d6c8bc680) | `pkgs.development.python-modules: remove unused args`                                          |
| [`87ef832e`](https://github.com/NixOS/nixpkgs/commit/87ef832e49f9cdcdd76cab9605c090a15bd17b0e) | `nixos: mjolnir: literalExample -> literalExpression`                                          |
| [`cd84d7fd`](https://github.com/NixOS/nixpkgs/commit/cd84d7fd5772fac04420870f489ab5e36420c5d0) | `maloader: switch to fetchFromGitHub`                                                          |
| [`ea25bea6`](https://github.com/NixOS/nixpkgs/commit/ea25bea65ac46d8ea61de35daa26d50ab8cc6718) | `iaca: cleanup with lib`                                                                       |
| [`28468178`](https://github.com/NixOS/nixpkgs/commit/284681784712e73991c8c5d1f3643d61fcc261e9) | `tokyo-tyrant: format, remove arbitrary choice`                                                |
| [`86da7c95`](https://github.com/NixOS/nixpkgs/commit/86da7c95cd2a5075da6ebe20ffed1b5577b1d819) | `telepathy.qt: cleanup inherit, update meta`                                                   |
| [`1564d88c`](https://github.com/NixOS/nixpkgs/commit/1564d88c41726feb3e5b2764ed2a5fb24b806701) | `redprl: unstable-2017-03-28 -> unstable-2019-11-04`                                           |
| [`8fff522f`](https://github.com/NixOS/nixpkgs/commit/8fff522ff9cb8d5982dd5de24359e64fa7099a51) | `glitter: 1.5.1 -> 1.5.2`                                                                      |
| [`bbd3f7f3`](https://github.com/NixOS/nixpkgs/commit/bbd3f7f31c2233a301082d5c671c3ae7a3ce2ffc) | `stfl: use normal make phase`                                                                  |
| [`60cef5d9`](https://github.com/NixOS/nixpkgs/commit/60cef5d908cee6485a056622efa43f34984d6f1f) | `fftw: switch to pname+version, minor formatting, fix input option, remove ? null from inputs` |
| [`7111193e`](https://github.com/NixOS/nixpkgs/commit/7111193ee69553c4ba3011b148926fb6f23d5a10) | `writers: fix writeRust on darwin`                                                             |
| [`90e46a5e`](https://github.com/NixOS/nixpkgs/commit/90e46a5ed52aac588bdcea915da9fd9343398840) | `uwuify: mark supported platforms`                                                             |
| [`5470dfc4`](https://github.com/NixOS/nixpkgs/commit/5470dfc4ae86e01a33522c0a590114ddaaf399cb) | `turses: override tweepy`                                                                      |
| [`c0cdc7d9`](https://github.com/NixOS/nixpkgs/commit/c0cdc7d9046a08ad8db7238c5b7cffab5d62a7a0) | `ioccheck: override tweepy`                                                                    |
| [`95ca86f9`](https://github.com/NixOS/nixpkgs/commit/95ca86f925f578d80b2fc6d6ea559456e0ab1bf1) | `nextcloud22: 22.2.1 -> 22.2.2`                                                                |
| [`df6bfa5e`](https://github.com/NixOS/nixpkgs/commit/df6bfa5e3a06d0a4d84a7d2b95bea023552e4599) | `linuxPackages.rtl88xxau-aircrack: fix build for linux 5.15`                                   |
| [`be723e51`](https://github.com/NixOS/nixpkgs/commit/be723e5168cc6e42edef024032080f9de8bd0338) | `python3Packages.tweepy: 4.0.1 -> 4.3.0`                                                       |
| [`a1f38401`](https://github.com/NixOS/nixpkgs/commit/a1f3840107e6cc0c18a2a767bb42860b1ec4e29a) | `python3Packages.cirq-core: fix for aarch64`                                                   |
| [`5ee3ff33`](https://github.com/NixOS/nixpkgs/commit/5ee3ff33e509a393c22a4a5e36ee6acbf5808878) | `dhall-grafana: Update 2021-11-06->2021-11-12. (#145674)`                                      |
| [`8956b48f`](https://github.com/NixOS/nixpkgs/commit/8956b48fa13020684b8d096c86c89bffe0f3daa7) | `python3Packages.libcst: 0.3.20 -> 0.3.21`                                                     |
| [`2af01eee`](https://github.com/NixOS/nixpkgs/commit/2af01eee3d6b919e1bc251648d17cc2f2dab0c8f) | `python3Packages.json-schema-for-humans: 0.31.0 -> 0.39.1`                                     |
| [`66fa5559`](https://github.com/NixOS/nixpkgs/commit/66fa5559c0964f1ab250159f74715ef7eab37060) | `python3Packages.cyclonedx-python-lib: 0.11.0 -> 0.11.1`                                       |
| [`eb6d8378`](https://github.com/NixOS/nixpkgs/commit/eb6d8378554e7692cb92a5e5e76ed5e1d365cbab) | `checkov: 2.0.566 -> 2.0.568`                                                                  |
| [`d0ba9b6e`](https://github.com/NixOS/nixpkgs/commit/d0ba9b6e00035952b6e8b3f6d520b0a9febab65a) | `kubescape: 1.0.130 -> 1.0.131`                                                                |
| [`1afd18c9`](https://github.com/NixOS/nixpkgs/commit/1afd18c94580f8da86814288e4fadedfda6db328) | `python3Packages.cachecontrol: 0.12.8 -> 0.12.10`                                              |
| [`df45fe09`](https://github.com/NixOS/nixpkgs/commit/df45fe09d8a8c979ec7cb232698772346df02d16) | `python3Packages.bimmer-connected: 0.7.21 -> 0.7.22`                                           |
| [`b318373c`](https://github.com/NixOS/nixpkgs/commit/b318373cf057f5d4f40a58278ae4957d460c85bf) | `whatsapp-for-linux: 1.2.1 -> 1.3.0, fix it`                                                   |
| [`201661a6`](https://github.com/NixOS/nixpkgs/commit/201661a628ccc8c78f96f64ecd4e5546962e0f55) | `bitcoin: fix build on Darwin`                                                                 |
| [`33abc7d1`](https://github.com/NixOS/nixpkgs/commit/33abc7d1007fe4a9941e1459d18f8a0aaeb84cd8) | `python3Packages.crownstone-uart: 2.1.0 -> 2.2.0`                                              |
| [`80123b1b`](https://github.com/NixOS/nixpkgs/commit/80123b1b563cb051141af1e947ff24893c7e9267) | `python3Packages.crownstone-core: 3.0.1 -> 3.1.0`                                              |
| [`11975dc4`](https://github.com/NixOS/nixpkgs/commit/11975dc4665c14c8880c6249dfd06f5aa7b84d88) | `python3Packages.elgato: 2.1.1 -> 2.2.0`                                                       |
| [`4a8b67a0`](https://github.com/NixOS/nixpkgs/commit/4a8b67a09a0ba7cf4f7897d9ce07d1cbdfcdf0cc) | `python3Packages.nettigo-air-monitor: 1.1.1 -> 1.2.0`                                          |
| [`3190ece3`](https://github.com/NixOS/nixpkgs/commit/3190ece3b279ee3e779a844b23082b2b52bfb41b) | `glitter: 1.5.0 -> 1.5.1`                                                                      |
| [`3f7abba2`](https://github.com/NixOS/nixpkgs/commit/3f7abba2fac91d9c144dc8eda9171cd6933995e4) | `python3Packages.mill-local: init at 0.1.0`                                                    |
| [`4ded651d`](https://github.com/NixOS/nixpkgs/commit/4ded651d13a41353ec6ce2b3a103e049c81a7fcc) | `python3Packages.adax: 0.1.1 -> 0.2.0`                                                         |
| [`f70401b0`](https://github.com/NixOS/nixpkgs/commit/f70401b07dff4f8a0ba914b636287e9b03ee76dd) | `python3Packages.open-garage: 0.1.6 -> 0.2.0`                                                  |
| [`b38750c9`](https://github.com/NixOS/nixpkgs/commit/b38750c9c9656228a962870fe0931f22b26d445f) | `python3Packages.pymetno: 0.8.4 -> 0.9.0`                                                      |
| [`928b9e29`](https://github.com/NixOS/nixpkgs/commit/928b9e29e3f41f4b335c3218485b5059df6f64d4) | `flashrom: fix build on aarch64`                                                               |
| [`77b8934f`](https://github.com/NixOS/nixpkgs/commit/77b8934f7dc6a1661eb1ce558a21cd3771b26165) | `gmni: unstable-2021-03-26 → 1.0`                                                              |
| [`f8c288d3`](https://github.com/NixOS/nixpkgs/commit/f8c288d30673bf4e425641d499371a417efd0927) | `gmnisrv: unstable-2021-05-16 → 1.0`                                                           |
| [`2d47affb`](https://github.com/NixOS/nixpkgs/commit/2d47affbfb2d961b721a435513710ee7921d3dfd) | `ocamlPackages.phylogenetics: unstable-2020-11-23 -> 0.0.0`                                    |
| [`1493e60f`](https://github.com/NixOS/nixpkgs/commit/1493e60f77224ad6a5138505010cd546c1327cf0) | `pngquant: fix cross-compilation`                                                              |
| [`49b20f94`](https://github.com/NixOS/nixpkgs/commit/49b20f946e03bd2fe8376818f15f6814c105d0c4) | `nvidia_x11_legacy470: 470.82.00 -> 470.86`                                                    |
| [`885db6d6`](https://github.com/NixOS/nixpkgs/commit/885db6d60dd68bd4471a85c57fb918159e30fcf0) | `libsemanage: enable parallel building`                                                        |
| [`9d144b3d`](https://github.com/NixOS/nixpkgs/commit/9d144b3d78b34b08eef6e2890735ede4aa9d83d8) | `libsemanage: fix cross; strict deps`                                                          |
| [`177ab8af`](https://github.com/NixOS/nixpkgs/commit/177ab8af28b1efee9ad43d28821f5d3bab221682) | `chromiumBeta: 96.0.4664.35 -> 96.0.4664.45`                                                   |
| [`201d9e89`](https://github.com/NixOS/nixpkgs/commit/201d9e896dca0bf993cb4248a27ee0fa6a622d9e) | `pcre: ftp.pcre.org defunct`                                                                   |
| [`881c708d`](https://github.com/NixOS/nixpkgs/commit/881c708d0377aee90a90b7fe327f435f62dc5364) | `python3Packages.pymetno: 0.8.3 -> 0.8.4`                                                      |
| [`398ee970`](https://github.com/NixOS/nixpkgs/commit/398ee970467f96daf29d6008bc786274bc20b2f3) | `home-assistant: pin huawei-lte-api at 1.4.18`                                                 |
| [`afa46f82`](https://github.com/NixOS/nixpkgs/commit/afa46f82b035241478279127ab0c886a9a5a09d2) | `alex: init at 10.0.0`                                                                         |
| [`fa6b4a93`](https://github.com/NixOS/nixpkgs/commit/fa6b4a932060f8b2a6339bb4908449a3815bee0f) | `lucenepp: 3.0.7 -> 3.0.8 (#134481)`                                                           |
| [`0e5b5462`](https://github.com/NixOS/nixpkgs/commit/0e5b5462e71fa973085388bda88ba484a1be9ba0) | `ran: remove default platform`                                                                 |
| [`3a30e0b8`](https://github.com/NixOS/nixpkgs/commit/3a30e0b8064d9ac534430e26bc9d89ac634f47cf) | `python3Packages.nbclient: add erictapen as maintainer`                                        |
| [`214033c0`](https://github.com/NixOS/nixpkgs/commit/214033c0840d2fe5e1294ac8bbb55af2bb87b39d) | `python3Packages.nbclient: 0.5.4 -> 0.5.8`                                                     |
| [`554495a7`](https://github.com/NixOS/nixpkgs/commit/554495a75f39265220376da4299039dedf9b2296) | `top-level: remove all extra pkgs`                                                             |
| [`2631d851`](https://github.com/NixOS/nixpkgs/commit/2631d851f9d4d5f5ae650c52d53156e68e66d0da) | `displaylink: 5.4.0-55.153 -> 5.4.1-55.174`                                                    |
| [`eb85a479`](https://github.com/NixOS/nixpkgs/commit/eb85a479909a184da5eead1da586772f1f8f6227) | `roon-server: 1.8-846 -> 1.8-850`                                                              |
| [`8e3d2553`](https://github.com/NixOS/nixpkgs/commit/8e3d255347f7c9d28390563d1830da89af7ef867) | `[nixos/lightdm] allow for background option to be either path or color`                       |
| [`37865914`](https://github.com/NixOS/nixpkgs/commit/378659148dbc0a376fa1d59b388fd156c4620f59) | `tree: cleanup, take maintainership`                                                           |
| [`e50ea674`](https://github.com/NixOS/nixpkgs/commit/e50ea67472deb591c2eafa02892876f6dd0d508e) | `hqplayerd: 4.27.0-70 -> 4.27.2-72`                                                            |
| [`4f513756`](https://github.com/NixOS/nixpkgs/commit/4f5137569b39e844a9e816ef6be0dd4804c0bc81) | `petsc, p4est: strict dependencies (#130156)`                                                  |
| [`82037871`](https://github.com/NixOS/nixpkgs/commit/82037871bb12293e55092b5a7b6b4fa2dfce433c) | `nixos/postfix: Use better types for submissionOptions and submissionsOptions (#138205)`       |
| [`4f766388`](https://github.com/NixOS/nixpkgs/commit/4f7663881055de3468d3a2f4a38fc523cff7592a) | `pass-secret-service: fix tests`                                                               |
| [`72b193e7`](https://github.com/NixOS/nixpkgs/commit/72b193e7c11684e0f0d09f88efcc268b6661f874) | `python3Packages.scikitimage: 0.18.1 -> 0.18.3 (#137038)`                                      |
| [`1c6329c2`](https://github.com/NixOS/nixpkgs/commit/1c6329c2ef46e5446eae4aee0d4b067635e4d010) | `xdg-desktop-portal: patch GTK issue`                                                          |
| [`568dd5cf`](https://github.com/NixOS/nixpkgs/commit/568dd5cfa793ce0c3a5cde9b558b1cbacfe32437) | `pinentry: remove libcap null override`                                                        |
| [`023f0060`](https://github.com/NixOS/nixpkgs/commit/023f0060a68b31079f8f8bd4fef4e9cfb97bf798) | `cmigemo: fix cross`                                                                           |
| [`640e83f8`](https://github.com/NixOS/nixpkgs/commit/640e83f82122f21460f765e4cdf2ffc4d111b73c) | `skk-dicts: broaden platforms`                                                                 |
| [`ac1f7fdf`](https://github.com/NixOS/nixpkgs/commit/ac1f7fdffb2eb4157fdef2175c6ea9d4495f3b5a) | `skk-dicts: enable parallel builds`                                                            |
| [`be1f676c`](https://github.com/NixOS/nixpkgs/commit/be1f676cfafce0f694cc090061296cf21310df17) | `skk-dicts: fix cross`                                                                         |
| [`95ca539f`](https://github.com/NixOS/nixpkgs/commit/95ca539f40ca8bf738f970be1be08ad49a9191ac) | `python3Packages.jupyter-repo2docker: add missing dependencies`                                |
| [`334f9d97`](https://github.com/NixOS/nixpkgs/commit/334f9d976695dd7238d3dc69b30f5e297609dc84) | `knockknock: switch patchPhase to postPatch`                                                   |
| [`992b117a`](https://github.com/NixOS/nixpkgs/commit/992b117aae76a3f187d78bf2710a8cf611a02e77) | `gaphor: init at 2.6.5`                                                                        |
| [`57c2d278`](https://github.com/NixOS/nixpkgs/commit/57c2d27876821e719d6b7c1e03df49aa25a17098) | `knockknock: enable on darwin`                                                                 |
| [`c6f83b34`](https://github.com/NixOS/nixpkgs/commit/c6f83b3433c04c948d6990b02e0e2b32d89a48ef) | `basex: 9.4.3 → 9.6.3, enable on darwin`                                                       |
| [`67a769d2`](https://github.com/NixOS/nixpkgs/commit/67a769d2f5b5b7985642f09e33b15cf2ab1ba987) | `pidgin-with-plugins: fix evaluation failure in use of non-existent 'm… (#145321)`             |
| [`3eb567aa`](https://github.com/NixOS/nixpkgs/commit/3eb567aa9bdd89866b90ac691718997aaabdfeca) | `matrix-commander: 2021-04-18 -> 2021-08-05`                                                   |
| [`f8e32471`](https://github.com/NixOS/nixpkgs/commit/f8e3247113f6ac632a733c503d241c76397abdf7) | `nimPackages.spry: init at 0.9.0`                                                              |
| [`455f5b98`](https://github.com/NixOS/nixpkgs/commit/455f5b983b1b691df993b72c80802c5c923b2fc7) | `pulumi-bin: 3.17.0 -> 3.17.1`                                                                 |
| [`be90e854`](https://github.com/NixOS/nixpkgs/commit/be90e854f9d03c06df0d9b0668eed5672b73f748) | `python3Packages.pg8000: 1.22.0 -> 1.22.1`                                                     |
| [`b786c93a`](https://github.com/NixOS/nixpkgs/commit/b786c93a6aae729509850d0269ffa5c915e02cdb) | `vimPlugins.blueballs-neovim: init at 2021-09-09`                                              |
| [`af115051`](https://github.com/NixOS/nixpkgs/commit/af115051b8cb3fed175bdfefca0e95efe76966d2) | `vimPlugins: update`                                                                           |
| [`2421f55b`](https://github.com/NixOS/nixpkgs/commit/2421f55bca8bf00d6084357aa61544785f074180) | `spotify-unwrapped: 1.1.68.632.g2b11de83 -> 1.1.72.439.gc253025e`                              |
| [`5f0b60a4`](https://github.com/NixOS/nixpkgs/commit/5f0b60a4637c8ec86dd58e83b1e23347acd8a14f) | `vscodium: 1.62.1 -> 1.62.2`                                                                   |
| [`f8f10158`](https://github.com/NixOS/nixpkgs/commit/f8f101588500562a544b09db6b611b16770dda5d) | `git-big-picture: enable on darwin`                                                            |
| [`61c12142`](https://github.com/NixOS/nixpkgs/commit/61c121424daf3efdbeb2fb3172ef6afc2cbb5e3a) | `bazel_4: link to issue about aarch64-darwin`                                                  |
| [`5fe151db`](https://github.com/NixOS/nixpkgs/commit/5fe151db46c5cbf7fe6ddedbb2cfd04b52cae6ba) | `qmapshack: fix localization`                                                                  |
| [`407ac21b`](https://github.com/NixOS/nixpkgs/commit/407ac21b1a1a7a2a2c66a00b091ac88a47f34125) | `python3Packages.twitterapi: 2.7.5 -> 2.7.7`                                                   |
| [`7ea6b65f`](https://github.com/NixOS/nixpkgs/commit/7ea6b65f583356a7a43b4e459aa57452717945bb) | `python3Packages.adafruit-platformdetect: 3.17.1 -> 3.17.2`                                    |
| [`b534b85c`](https://github.com/NixOS/nixpkgs/commit/b534b85ce8fbdc41ed498542e1295e4159bc5b9e) | `python3Packages.graphviz: 0.17 -> 0.18`                                                       |
| [`3b83eeb9`](https://github.com/NixOS/nixpkgs/commit/3b83eeb9033e6f400348a87e55ebe48935af9315) | `resholve: 0.6.6 -> 0.6.8`                                                                     |
| [`e1fb83d3`](https://github.com/NixOS/nixpkgs/commit/e1fb83d375c1af5563497b322f26e4cd2fc87876) | `heisenbridge: 1.5.0 -> 1.6.0`                                                                 |
| [`1dcf1331`](https://github.com/NixOS/nixpkgs/commit/1dcf13316520f1d6cf20380e0ccff77a8b5c4621) | `slack: 4.20.0 -> 4.21.1`                                                                      |
| [`16f7c722`](https://github.com/NixOS/nixpkgs/commit/16f7c72209dbe370b356b56ec1d144df0629438b) | `internetarchive: add alias to top-level`                                                      |
| [`21aea161`](https://github.com/NixOS/nixpkgs/commit/21aea16159a228fd86c4af2ee8b50091a607811b) | `acl2: fix build on darwin`                                                                    |
| [`433739b9`](https://github.com/NixOS/nixpkgs/commit/433739b9b3f350b58cfc65ae39d1f7dde1d8f0c0) | `glitter: 1.4.10 -> 1.5.0`                                                                     |
| [`63eaff4d`](https://github.com/NixOS/nixpkgs/commit/63eaff4dc1dfbfbd4665c86190e17f928ab20d79) | `xscreensaver: fix build for aarch64`                                                          |
| [`3abedd7d`](https://github.com/NixOS/nixpkgs/commit/3abedd7d7c0afb7d64e426076904fe20f09a8b02) | `python3Packages.hug: mark as broken`                                                          |
| [`06955985`](https://github.com/NixOS/nixpkgs/commit/069559851b33a76f9c6ab14450e89321309c6145) | `home-assistant: 2021.11.2 -> 2021.11.3`                                                       |
| [`ffb9a309`](https://github.com/NixOS/nixpkgs/commit/ffb9a309b6f553266309b220c5c6476d24dea377) | `buildDotnetPackage: move buildInputs to nativeBuildInputs`                                    |
| [`f77006c3`](https://github.com/NixOS/nixpkgs/commit/f77006c308e4a86d8dadfe7cb4441e6d55623370) | `buildDotnetPackage: fix nativeBuildInputs`                                                    |
| [`50edfafd`](https://github.com/NixOS/nixpkgs/commit/50edfafdbfa12e7948ed2cfada23c3b85037e56c) | `pinfo: fix build for ncurses-6.3`                                                             |
| [`1c95f5ce`](https://github.com/NixOS/nixpkgs/commit/1c95f5ce9c6554a515e435041def81d6382fcdf9) | `swtpm: change prePatch to postPatch`                                                          |