### PR TITLE
chore(flake/inputs/home-manager): `520adafc` -> `accfbdf2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -62,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1636762692,
-        "narHash": "sha256-t3NygvOfUXalLOCsD0crt41p2BmjdIuIxiX1FoATWuQ=",
+        "lastModified": 1636847964,
+        "narHash": "sha256-hH2lbDgOPwCtlWDwp0wVCcOK7x0mtLf4nrNWfvUWrA8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "520adafcb993bf382e9c3e20742c9b4f998330bf",
+        "rev": "accfbdf215dbf39eac2fbae67b574dac0be83d51",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                        |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`accfbdf2`](https://github.com/nix-community/home-manager/commit/accfbdf215dbf39eac2fbae67b574dac0be83d51) | `docs: add license section in readme`                 |
| [`0f5d9311`](https://github.com/nix-community/home-manager/commit/0f5d93119c1e87f6ea44b5a8f4db17f3ff9d5e81) | `docs: move usage section to chapter in manual`       |
| [`426830a1`](https://github.com/nix-community/home-manager/commit/426830a174ca032f62225ea968fdb19f2b24ab0d) | `home-manager: minor reorder of generated `home.nix`` |
| [`f7a37ad0`](https://github.com/nix-community/home-manager/commit/f7a37ad0b6a3ed256a3d9d36fd78918989427244) | `email: add fastmail.com email flavor (#2457)`        |