### PR TITLE
chore(flake/inputs/nixpkgs): `d14a8e37` -> `1950b7d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1636807505,
-        "narHash": "sha256-owMJ7+K/8nu3fY8B1wdCl0QaqZLBjdog/6wSxMrnHbA=",
+        "lastModified": 1636851273,
+        "narHash": "sha256-0jiZEG0J4Mm7/CBY2tPQMJyfV7P1ZaZ6Fi5DhCDsyk0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d14a8e372f5c0d8801471a2e5884b196f6d1ae73",
+        "rev": "1950b7d6f005c487674d53c4e7393957b57ee67c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                 |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`781ccc51`](https://github.com/NixOS/nixpkgs/commit/781ccc51dfbf17cd826624bc170c62dcd1ac1b3a) | `offlineimap: 7.3.4 -> 8.0.0 (#145527)`                                        |
| [`d73c2f3a`](https://github.com/NixOS/nixpkgs/commit/d73c2f3a0e77ad7c51c64abb5c28856340172898) | `libsbsms: init at 2.0.2 and 2.3.0`                                            |
| [`dae93c6b`](https://github.com/NixOS/nixpkgs/commit/dae93c6be1e3b9ac54c49c1d0af4e7333bdb36cb) | `ytree: 2.03 -> 2.04`                                                          |
| [`3df74bdd`](https://github.com/NixOS/nixpkgs/commit/3df74bdd3fd3f90d05bf321c22a59a9f319e0658) | `kernel: enable core scheduling on 5.14+ kernels`                              |
| [`6604d111`](https://github.com/NixOS/nixpkgs/commit/6604d111bea56432369eac1901c749ae9ceaf27a) | `linuxPackages.rtl88xxau-aircrack: remove unused fetchpatch`                   |
| [`b0249fdf`](https://github.com/NixOS/nixpkgs/commit/b0249fdf998d782e1058b0cf3239091e59e393ef) | `pkgs.misc: remove unused args`                                                |
| [`87ca1442`](https://github.com/NixOS/nixpkgs/commit/87ca1442f995a87f364982150a15b0c671090ada) | `trellis: fix build for darwin`                                                |
| [`25ae74d8`](https://github.com/NixOS/nixpkgs/commit/25ae74d8553b872b090abb5daf56f1908b342693) | `glitter: 1.5.3 -> 1.5.4`                                                      |
| [`df99f232`](https://github.com/NixOS/nixpkgs/commit/df99f2326ee60ea5e44ecea403f92d98313e1a1f) | `nixosTests.domination: init`                                                  |
| [`fd9cbb1b`](https://github.com/NixOS/nixpkgs/commit/fd9cbb1bed26fa9687c8ca0d7d57f586ee355d63) | `ckb-next: fix audio by adding libpulseaudio (#143023)`                        |
| [`3efa5631`](https://github.com/NixOS/nixpkgs/commit/3efa5631b2f4d6c359c34a9ccd3c2e77fb40c8e9) | `nethogs: pull upstream fix for ncurses-6.3`                                   |
| [`d664b7e3`](https://github.com/NixOS/nixpkgs/commit/d664b7e32701c6fe5a577f20ccbecf1132c34c0d) | `tty-clock: pull pending upstream inclusion fix for ncurses-6.3`               |
| [`436874a7`](https://github.com/NixOS/nixpkgs/commit/436874a70d9ea576be933ffebb39fcf41b75c5d4) | `lifelines: pull pending upstream inclusion fix for ncurses-6.3`               |
| [`159b90f1`](https://github.com/NixOS/nixpkgs/commit/159b90f118b5c54e3cf86bd134916728958f8f38) | `python3Packages.python-jenkins: skip test failing on darwin`                  |
| [`dfc142b3`](https://github.com/NixOS/nixpkgs/commit/dfc142b35ba66a6fc07ce051214da1a7138522e1) | `wordpress: 5.8.1 -> 5.8.2`                                                    |
| [`79268016`](https://github.com/NixOS/nixpkgs/commit/792680167b2a0798e4a75d874e32d6ccc41ca213) | `flex: delete unreferenced file`                                               |
| [`bbc5688e`](https://github.com/NixOS/nixpkgs/commit/bbc5688e8f674aeeefd1070519bbe88c7bf63a47) | `tree: fix cross-compile`                                                      |
| [`60cee110`](https://github.com/NixOS/nixpkgs/commit/60cee1103dc0ad7294ca862cfa3ecd14313c91ed) | `Apply suggestions from code review`                                           |
| [`42ace190`](https://github.com/NixOS/nixpkgs/commit/42ace190f762465381e88bf92d37b26fea5cbbeb) | `maintainers: add keys to legendofmiracles`                                    |
| [`4e50d999`](https://github.com/NixOS/nixpkgs/commit/4e50d99934fe6cd137738763ce045f4916c5e9ab) | `soldat-unstable: build using CMake`                                           |
| [`d37d84bd`](https://github.com/NixOS/nixpkgs/commit/d37d84bdcae7d248e8fe638a0289d1bf216adbd2) | `soldat-unstable: 2021-04-27 -> 2021-11-01`                                    |
| [`23805c77`](https://github.com/NixOS/nixpkgs/commit/23805c77bc128f574b2500974bc61eab32ce71eb) | `gamenetworkingsockets: propagate OpenSSL`                                     |
| [`b127a6f8`](https://github.com/NixOS/nixpkgs/commit/b127a6f81aae8052a621ca4f610bca6a151c985f) | `gamenetworkingsockets: 1.2.0 -> 1.3.0`                                        |
| [`df177cf3`](https://github.com/NixOS/nixpkgs/commit/df177cf39b6d9e1a10967079cb32970401d91a25) | `domination: 1.2.3 -> 1.2.4`                                                   |
| [`5aaa5f5e`](https://github.com/NixOS/nixpkgs/commit/5aaa5f5e75b3795e8f40d18dce211f50cceb6693) | `pluginupdate.py: fix compatibility with nix 2.4`                              |
| [`cacb8de5`](https://github.com/NixOS/nixpkgs/commit/cacb8de58f3553470f84800390aff1fc616b625b) | `bespokesynth: fixup trailing whitespace`                                      |
| [`e7200f58`](https://github.com/NixOS/nixpkgs/commit/e7200f58102c685862fc5f057c6b38da4e96243c) | `glitter: 1.5.2 -> 1.5.3`                                                      |
| [`5419cf40`](https://github.com/NixOS/nixpkgs/commit/5419cf40465e8084860b5c66f80da5d06be1277a) | `bespokesynth: mark unfree`                                                    |
| [`7c6bd2bc`](https://github.com/NixOS/nixpkgs/commit/7c6bd2bc4597585e3bf26d65ad514cd2d663a07b) | `python3Packages.build: skip test failing on darwin`                           |
| [`23f7e1d0`](https://github.com/NixOS/nixpkgs/commit/23f7e1d054ff5d8c34b2bb0c81c711cf262b5822) | `python3Packages.pg8000: 1.22.1 -> 1.23.0`                                     |
| [`001ac664`](https://github.com/NixOS/nixpkgs/commit/001ac664326deb3adf6b432e0f85ded816f9263d) | `python3Packages.fiona: skip some tests failing on aarch64`                    |
| [`9b001407`](https://github.com/NixOS/nixpkgs/commit/9b001407a104fbdbb8fbcb72db7d0586bdc76795) | `pkgs.development.python-modules: remove unused args`                          |
| [`b9f30c20`](https://github.com/NixOS/nixpkgs/commit/b9f30c203c4c4803792a95951320eb3e6079353e) | `enlightenment.terminology: 1.10.0 -> 1.11.0`                                  |
| [`f3784bc5`](https://github.com/NixOS/nixpkgs/commit/f3784bc57c4abc035ad7c0a2c08c648926eec27c) | `faas-cli: 0.13.13 -> 0.13.15`                                                 |
| [`c8bc708b`](https://github.com/NixOS/nixpkgs/commit/c8bc708b3c6f3c525d6ca98631c7673461bc80cb) | `pueue: 1.0.3 -> 1.0.4`                                                        |
| [`f17e7e68`](https://github.com/NixOS/nixpkgs/commit/f17e7e684dd90ee02988b5045d2e474ace0b92c4) | `linux_zen: 5.15.1-zen1 -> 5.15.2-zen1`                                        |
| [`21727e49`](https://github.com/NixOS/nixpkgs/commit/21727e4915fe605d479e0ec342e02558dd4fa962) | `bazel: replace additional usages of md5sum`                                   |
| [`5bb24d50`](https://github.com/NixOS/nixpkgs/commit/5bb24d504b6c41b38479519e3c7c7270a4a1da5f) | `linux/hardened/patches/5.4: 5.4.157-hardened1 -> 5.4.158-hardened1`           |
| [`dd5de73e`](https://github.com/NixOS/nixpkgs/commit/dd5de73eba4bc9f8e20559356f9f2c644f89517b) | `linux/hardened/patches/5.14: 5.14.16-hardened1 -> 5.14.17-hardened1`          |
| [`3b035cff`](https://github.com/NixOS/nixpkgs/commit/3b035cff603293c0a0ada8697025379585004c02) | `linux/hardened/patches/5.10: 5.10.77-hardened1 -> 5.10.78-hardened1`          |
| [`b5353b29`](https://github.com/NixOS/nixpkgs/commit/b5353b2905b8754903a3df2a7cfa7554cf367d36) | `linux/hardened/patches/4.19: 4.19.215-hardened1 -> 4.19.216-hardened1`        |
| [`c6d68911`](https://github.com/NixOS/nixpkgs/commit/c6d6891185632d000076a4f42e5298773c2497e8) | `linux: 5.4.158 -> 5.4.159`                                                    |
| [`e5d1ac06`](https://github.com/NixOS/nixpkgs/commit/e5d1ac060f0af563cf632461b70d9b475e3f53cd) | `linux: 5.15.1 -> 5.15.2`                                                      |
| [`43ebf911`](https://github.com/NixOS/nixpkgs/commit/43ebf911768d80d39314c756a5b218e8c1f958de) | `linux: 5.14.17 -> 5.14.18`                                                    |
| [`6caad489`](https://github.com/NixOS/nixpkgs/commit/6caad489e23b0a934f08fddcf0f00501ee317611) | `linux: 5.10.78 -> 5.10.79`                                                    |
| [`e2e94278`](https://github.com/NixOS/nixpkgs/commit/e2e94278730774290b25f35f32489be92989dfc7) | `linux: 4.9.289 -> 4.9.290`                                                    |
| [`cf1d695b`](https://github.com/NixOS/nixpkgs/commit/cf1d695ba6125c382a467d2f10d5e426b73ce5e2) | `linux: 4.4.291 -> 4.4.292`                                                    |
| [`c3bbc214`](https://github.com/NixOS/nixpkgs/commit/c3bbc214cdddeaeb1fd0c0c28c2afcca46624247) | `linux: 4.19.216 -> 4.19.217`                                                  |
| [`d35645f0`](https://github.com/NixOS/nixpkgs/commit/d35645f0778492244b7f35f8af907ed6bdc7f6a8) | `linux: 4.14.254 -> 4.14.255`                                                  |
| [`ecc55a61`](https://github.com/NixOS/nixpkgs/commit/ecc55a619d1981cc8442e059bbd68680fcf48454) | `octave: 6.3.0 -> 6.4.0`                                                       |
| [`34ec80c1`](https://github.com/NixOS/nixpkgs/commit/34ec80c1e17e140b77be6e72804a70ab6c8133c9) | `rivet: 3.1.4 -> 3.1.5`                                                        |
| [`4e7c9c1e`](https://github.com/NixOS/nixpkgs/commit/4e7c9c1eb8359c788b63514ba5cb831c9e64031f) | `yoda: 1.9.1 -> 1.9.2`                                                         |
| [`3f89726b`](https://github.com/NixOS/nixpkgs/commit/3f89726b4bf20df63e6bb8763d0560880740e364) | `python3Packages.ocrmypdf: 12.7.0 -> 12.7.2`                                   |
| [`104b1e77`](https://github.com/NixOS/nixpkgs/commit/104b1e776e8667c7033fea084409320a567656e0) | `python3Packages.pikepdf: 3.2.0 -> 4.0.1.post1`                                |
| [`3124df04`](https://github.com/NixOS/nixpkgs/commit/3124df04137894a2fdbdb5e003d4cf8fda59433a) | `luabind: switch to fetchFromGitHub`                                           |
| [`3149762b`](https://github.com/NixOS/nixpkgs/commit/3149762bbfb19085b9a8d053dfc03019ae9d9467) | `nco: switch to fetchFromGitHub`                                               |
| [`9587435e`](https://github.com/NixOS/nixpkgs/commit/9587435e265e6e9d5deeb2bb7b7b1f1c2cb2fa9b) | `netcdf-cxx4: switch to fetchFromGitHub`                                       |
| [`ac38bd86`](https://github.com/NixOS/nixpkgs/commit/ac38bd869e5c7431f888ef3ea3cbb2efaa3950ce) | `netcdf-fortran: switch to fetchFromGitHub`                                    |
| [`6a66defa`](https://github.com/NixOS/nixpkgs/commit/6a66defae05eb72ff4dadb41d937430378086f1f) | `ogre: switch to fetchFromGitHub`                                              |
| [`ab052237`](https://github.com/NixOS/nixpkgs/commit/ab052237873e32b8d78bc6ba3e35569b5fb1652e) | `ogrepaged: switch to fetchFromGitHub`                                         |
| [`14550c58`](https://github.com/NixOS/nixpkgs/commit/14550c58c663a5c491c5fdf2082ed21b0d8b4178) | `openbabel: switch to fetchFromGitHub`                                         |
| [`e4d3fd05`](https://github.com/NixOS/nixpkgs/commit/e4d3fd0531aab5f212de8d0100d360b57d52adea) | `openlibm: switch to fetchFromGitHub`                                          |
| [`e4d87695`](https://github.com/NixOS/nixpkgs/commit/e4d876957f67e01c87da13d546650091b5fa35c0) | `primesieve: switch to fetchFromGitHub`                                        |
| [`c83dbfae`](https://github.com/NixOS/nixpkgs/commit/c83dbfae34e23009f997ff77276c0692c57065c0) | `sfml: switch to fetchFromGitHub`                                              |
| [`512b6d19`](https://github.com/NixOS/nixpkgs/commit/512b6d19df1cf8ab47625b552c7f885a4d001545) | `stxxl: switch to fetchFromGitHub`                                             |
| [`258b28b0`](https://github.com/NixOS/nixpkgs/commit/258b28b03e3d2414cc9121209c5da1057344daf7) | `vaapi-intel-hybrid: switch to fetchFromGitHub`                                |
| [`1a54992c`](https://github.com/NixOS/nixpkgs/commit/1a54992c09a924aa169176af063bd399edfb5636) | `vigra: switch to fetchFromGitHub`                                             |
| [`cc8f33e0`](https://github.com/NixOS/nixpkgs/commit/cc8f33e08fc23f5f31974e12429fa278e4229628) | `vo-amrwbenc: switch to fetchFromGitHub`                                       |
| [`596f4764`](https://github.com/NixOS/nixpkgs/commit/596f47648ed594d0ad35c871b3ba8c9176ad3442) | `imgpatchtools: switch to fetchFromGitHub`                                     |
| [`1c6dc994`](https://github.com/NixOS/nixpkgs/commit/1c6dc994a85365509cd5b7b11894613c65c44ca7) | `yoda-with-root: fix sandboxed build`                                          |
| [`5fd4c742`](https://github.com/NixOS/nixpkgs/commit/5fd4c742d89bf2f4f8240608e4cb4794a738e231) | `python3Packages.wavefile: init at 1.5`                                        |
| [`d3c28b6f`](https://github.com/NixOS/nixpkgs/commit/d3c28b6f842ad813c61edb7330e012e3da3fb6bb) | `highlight: remove with lib; convert prePatch to postPatch`                    |
| [`c02d778b`](https://github.com/NixOS/nixpkgs/commit/c02d778b1c07c3ed944844bcbbd99cae45e9df65) | `python3.pkgs.jedi-language-server: init at 0.34.8`                            |
| [`0a79063b`](https://github.com/NixOS/nixpkgs/commit/0a79063bacd15b7b1668335a5a50fb7073b55c64) | `python3.pkgs.docstring-to-markdown: init at 0.9`                              |
| [`9480444d`](https://github.com/NixOS/nixpkgs/commit/9480444dae9d35419e4d06777f8ca2f6013d6984) | `treewide: rename name to pname&version`                                       |
| [`181dd7e7`](https://github.com/NixOS/nixpkgs/commit/181dd7e7422a13dc5449d5a24590c1bdbf58db23) | `fedigroups: init at 0.4.4`                                                    |
| [`21d8230c`](https://github.com/NixOS/nixpkgs/commit/21d8230c7748a6c8afb4bd3f936489e9befbb43a) | `mark: 6.3 -> 6.4`                                                             |
| [`365c38c5`](https://github.com/NixOS/nixpkgs/commit/365c38c5a157da4a49fc1a9b2737c2eb1ecbdae1) | `lightwalletd: 0.4.7 -> 0.4.8`                                                 |
| [`d676fed5`](https://github.com/NixOS/nixpkgs/commit/d676fed581a61587b3b230b815169e1eebe4bb42) | `lfs: 1.1.0 -> 1.2.1`                                                          |
| [`12077e48`](https://github.com/NixOS/nixpkgs/commit/12077e48144a867f1d64e8b94437b98226e3c712) | `kubedb-cli: 0.21.0 -> 0.22.0`                                                 |
| [`6d4b016e`](https://github.com/NixOS/nixpkgs/commit/6d4b016e263ec5c7278cb9f5c476ee934366e46e) | `kubecfg: 0.21.0 -> 0.22.0`                                                    |
| [`93e6d807`](https://github.com/NixOS/nixpkgs/commit/93e6d80788eda5dcbcce11cc9d06fbf5f7ad906b) | `chezmoi: 2.7.3 -> 2.7.4`                                                      |
| [`6739a8c5`](https://github.com/NixOS/nixpkgs/commit/6739a8c5e8025972a00bb143e2284221985cddf7) | `matrix-synapse: unpin frozendict`                                             |
| [`722cdb0b`](https://github.com/NixOS/nixpkgs/commit/722cdb0bab034ea0d8d8fe24dd8602ffed2daaac) | `openrw: 2018-10-26 -> 2021-10-14`                                             |
| [`ef424f2d`](https://github.com/NixOS/nixpkgs/commit/ef424f2d81612ade1846cac6c71d565e59f9c727) | `xdotool: 3.20210903.1 -> 3.20211022.1`                                        |
| [`8cbe7f55`](https://github.com/NixOS/nixpkgs/commit/8cbe7f556415f2ff7b10d4deb74103444a493b55) | `stb: 20180211 -> unstable-2021-09-10`                                         |
| [`6c173bb1`](https://github.com/NixOS/nixpkgs/commit/6c173bb1170faab19368317542cba7edfb4cdad7) | `vdrPlugins.vaapidevice: ffmpeg_3 -> ffmpeg`                                   |
| [`e922fad9`](https://github.com/NixOS/nixpkgs/commit/e922fad91498310b2a169303d4510d325d979d2e) | `kubelet: Disable cgroupsv2 for kubelet hosts`                                 |
| [`b1dc7e5f`](https://github.com/NixOS/nixpkgs/commit/b1dc7e5fba9bf76bba25bee2f13b841844e3cc2e) | `Update pkgs/servers/http/nginx/modules.nix`                                   |
| [`79318225`](https://github.com/NixOS/nixpkgs/commit/79318225d14b2c8fd0ca22e75c7d8904fcddb2db) | `nginxModules.video-thumbextractor: update to unstable and switch to ffmpeg_4` |
| [`0e527631`](https://github.com/NixOS/nixpkgs/commit/0e527631be2cabb8ce3f3bfab8be2b7e75a2feb3) | `dvd-slideshow: use ffmpeg instead of ffmpeg_3`                                |