### PR TITLE
chore(flake/inputs/nixos-hardware): `fd6f34af` -> `4045d5f4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -77,11 +77,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1636317251,
-        "narHash": "sha256-u1cWvvtGH5mfGkeIKrqw2usk4IL7wDiRcnJkUSiZq3Q=",
+        "lastModified": 1636877509,
+        "narHash": "sha256-0c2fnIlpNqcgxg8JK6Qa3iY4r93MFn2TQ4/3y9W5B7g=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "fd6f34afcf062761fb5035230f6297752bfedcba",
+        "rev": "4045d5f43aff4440661d8912fc6e373188d15b5b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                |
| ----------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`82ada4b2`](https://github.com/NixOS/nixos-hardware/commit/82ada4b2b3b96f4f2a149051a835d0431a13f80f) | `add supermicro x12scz-tln4f` |
| [`1464b7f9`](https://github.com/NixOS/nixos-hardware/commit/1464b7f955a239e59d93e9a77309beb860c76155) | `fix github workflow`         |
| [`debc98ff`](https://github.com/NixOS/nixos-hardware/commit/debc98ff9c873ff9d0755d2c9ac8ebd241053b4f) | `add dell poweredge r7515`    |
| [`e819a299`](https://github.com/NixOS/nixos-hardware/commit/e819a2993ac491aeb98846d5d8cabd6264208a2b) | `fix github workflow`         |