### PR TITLE
chore(flake/inputs/nixpkgs): `1950b7d6` -> `0b239a47`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1636851273,
-        "narHash": "sha256-0jiZEG0J4Mm7/CBY2tPQMJyfV7P1ZaZ6Fi5DhCDsyk0=",
+        "lastModified": 1636894757,
+        "narHash": "sha256-QSwn2lqs/hWOWDFrQyj6ytpffbYp7pk7+M4XqOs3PVw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1950b7d6f005c487674d53c4e7393957b57ee67c",
+        "rev": "0b239a479cd2c6246195f76244d0939845f82634",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`17fdea06`](https://github.com/NixOS/nixpkgs/commit/17fdea06d8f89c4b05faa354f6561f129640e909) | `diskus: 0.6.0 -> 0.7.0`                                                             |
| [`7a6f0c1f`](https://github.com/NixOS/nixpkgs/commit/7a6f0c1f21d4a02ea079ebfe1e6c70ee38ca00f5) | `python38Packages.azure-mgmt-network: 19.2.0 -> 19.3.0`                              |
| [`c2aeddb9`](https://github.com/NixOS/nixpkgs/commit/c2aeddb9a0c7ec22b7472f30cbeca7b44ff1e23c) | `python38Packages.azure-mgmt-monitor: 2.0.0 -> 3.0.0`                                |
| [`5373aa79`](https://github.com/NixOS/nixpkgs/commit/5373aa7968d2d65a86c462a89a47a7cd2623ccad) | `python38Packages.azure-mgmt-iotcentral: 4.1.0 -> 9.0.0`                             |
| [`86dbe45b`](https://github.com/NixOS/nixpkgs/commit/86dbe45bea6098f9b58e672172f890ee04480801) | `python38Packages.azure-mgmt-eventgrid: 9.0.0 -> 10.0.0`                             |
| [`4594b456`](https://github.com/NixOS/nixpkgs/commit/4594b4562c10dba458efe6a862d1fe04411a9ace) | `python38Packages.azure-loganalytics: 0.1.0 -> 0.1.1`                                |
| [`303b5120`](https://github.com/NixOS/nixpkgs/commit/303b5120c0f19b8fd00c266763606391c896d6ab) | `python38Packages.azure-identity: 1.7.0 -> 1.7.1`                                    |
| [`c5bd5335`](https://github.com/NixOS/nixpkgs/commit/c5bd53355e7b17d8d9891dcb26a940ec999a1749) | `python38Packages.azure-appconfiguration: 1.2.0 -> 1.3.0`                            |
| [`1a5986ac`](https://github.com/NixOS/nixpkgs/commit/1a5986ac40313daa55b632afdf342f331c8c9893) | `python38Packages.awscrt: 0.12.5 -> 0.12.6`                                          |
| [`d5e0c3ae`](https://github.com/NixOS/nixpkgs/commit/d5e0c3ae0f38d349cc973feaf1b1918a84b35ff9) | `scdoc: 1.11.1 -> 1.11.2`                                                            |
| [`830a13f2`](https://github.com/NixOS/nixpkgs/commit/830a13f2e50461430017c7241d52b9b685375716) | `wallutils: remove myself as maintainer`                                             |
| [`34e9d9b2`](https://github.com/NixOS/nixpkgs/commit/34e9d9b2ecf9d5fbadefcf322b7a69390c0d087d) | `python38Packages.aws-lambda-builders: 1.8.1 -> 1.9.0`                               |
| [`2812d080`](https://github.com/NixOS/nixpkgs/commit/2812d0802acb7f5d15e3a1096fd7ca6c260551c6) | `wallutils: 5.9.0 -> 5.10.0`                                                         |
| [`4d539648`](https://github.com/NixOS/nixpkgs/commit/4d539648017dc07618eabb3a369226e675efe85e) | `zinit: zdharma/zinit -> zdharma-continuum/zinit`                                    |
| [`59e45f44`](https://github.com/NixOS/nixpkgs/commit/59e45f4474a378856e65b794c3aefc040ef9c595) | `psi-plus: 1.5.1556-2 -> 1.5.1576`                                                   |
| [`4ee7acde`](https://github.com/NixOS/nixpkgs/commit/4ee7acdef00d255ab1607bbc83ba5171b94c792f) | `gopass: 1.12.8 → 1.13.0`                                                            |
| [`cd1df7d3`](https://github.com/NixOS/nixpkgs/commit/cd1df7d3337bfa1fcc5d6bbb7ac3d4d1d163e00f) | `host: pull pending upstream inclusion fix for ncurses-6.3`                          |
| [`90af5cac`](https://github.com/NixOS/nixpkgs/commit/90af5cacfbcf6b3c57a33feb1e19be797b27e7e8) | `obs-studio: avoid double-wrapping the obs binary`                                   |
| [`566ef06c`](https://github.com/NixOS/nixpkgs/commit/566ef06cf5aba71b850838d2fe9bbd7828475e69) | `obs-studio: use wrapGAppsHook to add required org.gtk.Settings.ColorChooser schema` |
| [`a1ab38df`](https://github.com/NixOS/nixpkgs/commit/a1ab38dfc5cd11f3043dd56a351d7d843cbebb0f) | `hiredis: 1.0.0 -> 1.0.2`                                                            |
| [`c2725457`](https://github.com/NixOS/nixpkgs/commit/c27254571b48e46519f1fa3698000a5fe31faf8d) | `python38Packages.aiohttp-remotes: 1.0.0 -> 1.1.0`                                   |
| [`2ee0687c`](https://github.com/NixOS/nixpkgs/commit/2ee0687c305e29b18c1a3d60186546176bedb97e) | `pypi-mirror: 4.0.7 -> 4.1.0`                                                        |
| [`a84ba490`](https://github.com/NixOS/nixpkgs/commit/a84ba490c457f659300e54e09ab050528d4d1e12) | `abcmidi: 2021.10.11 -> 2021.10.15`                                                  |
| [`26ced3aa`](https://github.com/NixOS/nixpkgs/commit/26ced3aa14c9d6a6e700521639a0363a26eb3365) | `prowlarr: 0.1.1.1030 -> 0.1.2.1060`                                                 |
| [`d5ff6143`](https://github.com/NixOS/nixpkgs/commit/d5ff6143d09a4eafeafaa4101acc0bd06ac7e8b5) | `proselint: 0.12.0 -> 0.13.0`                                                        |
| [`e22ed89d`](https://github.com/NixOS/nixpkgs/commit/e22ed89d69368770772c5ac52821460fe9fb8231) | `pipenv: 2021.5.29 -> 2021.11.9`                                                     |
| [`916603e4`](https://github.com/NixOS/nixpkgs/commit/916603e490ad296a685b4b92d94b90552790bb49) | `oh-my-zsh: 2021-10-27 -> 2021-11-11`                                                |
| [`efa7406c`](https://github.com/NixOS/nixpkgs/commit/efa7406cc79befddc5d731ced046f949fe5068b2) | `nwg-wrapper: 0.0.2 -> 0.1.0`                                                        |
| [`89912c3d`](https://github.com/NixOS/nixpkgs/commit/89912c3d0ccc75e1cc95689cd983ed1253629a99) | `boxfort: mark broken on darwin to match upstream`                                   |
| [`0bf39172`](https://github.com/NixOS/nixpkgs/commit/0bf391720bebe4954a0fd76a78458c2c4c7e936d) | `python3Packages.zulip: 0.8.0 -> 0.8.1`                                              |
| [`1ed375db`](https://github.com/NixOS/nixpkgs/commit/1ed375dba1191fdd40fbfa74ab1c8c213a6263d1) | `mkgmap-splitter: 642 -> 643`                                                        |
| [`a446131b`](https://github.com/NixOS/nixpkgs/commit/a446131b68580b7fc79e93658d2a5e8e88487500) | `mkgmap: 4810 -> 4813`                                                               |
| [`538179d2`](https://github.com/NixOS/nixpkgs/commit/538179d2f08dc39f9c8ee0ff715f2ce89efc4535) | `klipper: unstable-2021-09-21 -> unstable-2021-11-10`                                |
| [`ba9578be`](https://github.com/NixOS/nixpkgs/commit/ba9578bed0d58ce64e62dfbc310904f321bda66c) | `chrony: Enable signed NTP`                                                          |
| [`fa591a4b`](https://github.com/NixOS/nixpkgs/commit/fa591a4b166b6b56befdcf8f3f942a703dfce2b8) | `gnome.gnome-calendar: 41.0 -> 41.1`                                                 |
| [`9149d366`](https://github.com/NixOS/nixpkgs/commit/9149d366b9f53fd202e9cb9dd6486d7f038b14a4) | `boolector: add patch fixing build on aarch64-linux`                                 |
| [`3b7766ea`](https://github.com/NixOS/nixpkgs/commit/3b7766eac26d1b706eedaeee05dc8e5c0528a32e) | `lingeling: pre1_03b4860d -> pre1_708beb26`                                          |
| [`04bfd3c8`](https://github.com/NixOS/nixpkgs/commit/04bfd3c8e16e9684dd018e2ef3f22a05ba1da817) | `git-machete: 3.4.1 -> 3.5.0`                                                        |
| [`9e09f721`](https://github.com/NixOS/nixpkgs/commit/9e09f7210d1f88c3a9542099405e178277c2917c) | `fluxcd: 0.21.1 -> 0.23.0`                                                           |
| [`87f9e3b3`](https://github.com/NixOS/nixpkgs/commit/87f9e3b3699c4fafaf0a895aefe90acb22cff3af) | `flameshot: 0.10.1 -> 0.10.2`                                                        |
| [`07dfa462`](https://github.com/NixOS/nixpkgs/commit/07dfa4624c50acf1532520dd7d143a658e4a347e) | `kn: 0.26.0 -> 0.27.0`                                                               |
| [`4e27b0a9`](https://github.com/NixOS/nixpkgs/commit/4e27b0a9a29094c401c32e4ae185b4b8678c8ca0) | `popeye: 0.9.7 -> 0.9.8`                                                             |
| [`b507efd2`](https://github.com/NixOS/nixpkgs/commit/b507efd2bc5d772baf1dcaa4f0313ffdb1e998ad) | `qt51{4,5}.qtwebengine: mark as broken on darwin`                                    |
| [`899f2d8b`](https://github.com/NixOS/nixpkgs/commit/899f2d8b7f94ce0b455e0f47bc624d20191d2843) | `nix-info: use `stdenv.hostPlatform.system``                                         |
| [`857507f6`](https://github.com/NixOS/nixpkgs/commit/857507f690c411269f66df74ecc18c8a6d06c4d2) | `freeimage: fix build on aarch64-darwin (#145785)`                                   |
| [`fa02bf0d`](https://github.com/NixOS/nixpkgs/commit/fa02bf0dfbeb050fa135a4b2eaf9c75258a8db34) | `cht-sh: unstable-2021-10-20 -> unstable-2021-11-13`                                 |
| [`08d0fed9`](https://github.com/NixOS/nixpkgs/commit/08d0fed9587e3251a850d38d0503b420e0476115) | `cargo-flamegraph: 0.4.0 -> 0.5.0`                                                   |
| [`3c2c3df1`](https://github.com/NixOS/nixpkgs/commit/3c2c3df1817604465170f60aa965a4cebe1dd70d) | `linux: add BT_HCIBTUSB_MTK to common kernel config`                                 |
| [`2c055cdf`](https://github.com/NixOS/nixpkgs/commit/2c055cdfa0a5969b2d4b2d533c4d215b950f4792) | `eudev: gperf is a nativeBuildInput`                                                 |
| [`ed35f91e`](https://github.com/NixOS/nixpkgs/commit/ed35f91ec85eadc70fe499328b26289c16a7e00c) | `ammonite: 2.4.0 -> 2.4.1`                                                           |
| [`592dca73`](https://github.com/NixOS/nixpkgs/commit/592dca73a9d44fd784d477c8e7931f01bdca98ef) | `nix-update: switch to stable (2.4) nix`                                             |
| [`0d2b8f59`](https://github.com/NixOS/nixpkgs/commit/0d2b8f591103167e3f7afa8e944452a3dea26afe) | `gnomeExtensions.dash-to-panel: 44 -> 45`                                            |
| [`dd5b304b`](https://github.com/NixOS/nixpkgs/commit/dd5b304b3ff044328d4cce812641ac3538654a59) | `gnomeExtensions.dash-to-panel: 43 -> 44`                                            |
| [`53a60ad3`](https://github.com/NixOS/nixpkgs/commit/53a60ad361e020275b3f50c68a7f17411e5f8fd2) | `isl: isl.gforge.inria.fr has been taken offline`                                    |
| [`db9590c0`](https://github.com/NixOS/nixpkgs/commit/db9590c0b873de18bf4f1c3a7e349ef0501d889f) | `dev86: explicitly disable build parallelism due to missing depends`                 |
| [`7db0e4a0`](https://github.com/NixOS/nixpkgs/commit/7db0e4a02ef8564de3ed041e712d5cbbbe93aa54) | `python3Packages.splinter: 0.15.0 -> 0.16.0`                                         |
| [`12fa46cb`](https://github.com/NixOS/nixpkgs/commit/12fa46cbf06535e02fb65324c5a8d0b2803f6328) | `home-assistant: disable tado water_heater tests`                                    |
| [`8d10569f`](https://github.com/NixOS/nixpkgs/commit/8d10569f79ff22e110f57e75621d7b80d7b608ac) | `python3Packages.phonenumbers: 8.12.36 -> 8.12.37`                                   |
| [`22fcead7`](https://github.com/NixOS/nixpkgs/commit/22fcead7b4f9f88b0362c2eea30292badad1160d) | `home-assistant: pin nettigo-air-monitor at 1.1.1`                                   |
| [`5c8bb6ac`](https://github.com/NixOS/nixpkgs/commit/5c8bb6ac0d1adbc02f8aec2fec51f3bfb253ddff) | `libretro.dolphin: 2020-03-06 -> 2021-11-01`                                         |
| [`ec27b244`](https://github.com/NixOS/nixpkgs/commit/ec27b2445230d6556b1961850c5e09c48f0f690b) | `libretro: mkLibRetroCore: allow specifying custom version`                          |
| [`59bdbbfa`](https://github.com/NixOS/nixpkgs/commit/59bdbbfa1700896e892a4e00b0652f014e5261c6) | `ogre1_10: fix for aarch64`                                                          |
| [`7a1b0adc`](https://github.com/NixOS/nixpkgs/commit/7a1b0adc2c8dbc36f9da6e19e6fa0bc8cea5965b) | `ogre1_9: fix for aarch64`                                                           |
| [`aa0e8072`](https://github.com/NixOS/nixpkgs/commit/aa0e8072a57e879073cee969a780e586dbe57997) | `ogre: fix for aarch64`                                                              |
| [`9de30004`](https://github.com/NixOS/nixpkgs/commit/9de30004dbe9db82b5bba67a0a38a277e204666c) | `python3.pkgs.capstone: mark broken on non-x86_64`                                   |
| [`c7f2520b`](https://github.com/NixOS/nixpkgs/commit/c7f2520b2a2e62dfc26b6be46841ccca5ab2d2d7) | `maintainers: add revol-xut`                                                         |
| [`a6063479`](https://github.com/NixOS/nixpkgs/commit/a60634790aec785fe0e33e15e95a7f344ff4d45d) | `PULL_REQUEST_TEMPLATE.md: change nixpkgs-review wip to rev HEAD`                    |
| [`c615e206`](https://github.com/NixOS/nixpkgs/commit/c615e20603bf6483938206116f75565b4e8ac34f) | `python3Packages.qiskit: 0.26.2 -> 0.32.0`                                           |
| [`b91e3c0d`](https://github.com/NixOS/nixpkgs/commit/b91e3c0d996b27cf1615f235b3ef867799b0a65d) | `python3Packages.qiskit-nature: init at 0.2.2`                                       |
| [`11670aa1`](https://github.com/NixOS/nixpkgs/commit/11670aa1654aba068b7e49d9e62edbd26fcff891) | `python3Packages.qiskit-machine-learning: init at 0.2.1`                             |
| [`e2f7f24f`](https://github.com/NixOS/nixpkgs/commit/e2f7f24fc9981d4d559e12a7a3cf58c8de2816a7) | `python3Packages.qiskit-optimization: init at 0.2.3`                                 |
| [`df2faa22`](https://github.com/NixOS/nixpkgs/commit/df2faa22ed5ceb2bb01c1127bc876189720ffe99) | `python3Packages.qiskit-finance: init at 0.2.1`                                      |
| [`acf4b64a`](https://github.com/NixOS/nixpkgs/commit/acf4b64a90805a2ff248b250913b23cc869f8db9) | `python3Packages.tweedledum: 1.0.0 -> 1.1.1`                                         |
| [`89ef192d`](https://github.com/NixOS/nixpkgs/commit/89ef192d11bc4fa71ba2f04d58832dd0ae6b127d) | `python3Packages.qiskit-ibmq-provider: 0.13.1 -> 0.18.0`                             |
| [`829f8c10`](https://github.com/NixOS/nixpkgs/commit/829f8c10d6678b3bb63931443be9acfeead94db6) | `python3Packages.qiskit-aqua: 0.9.1 -> 0.9.5`                                        |
| [`6f15bdbc`](https://github.com/NixOS/nixpkgs/commit/6f15bdbc3adabcbf195858ef39ebc11faf022bd4) | `python3Packages.qiskit-aer: 0.8.2 -> 0.9.1`                                         |
| [`16e8b9cb`](https://github.com/NixOS/nixpkgs/commit/16e8b9cb9e2cdd49afe317b1b3d3cbc3b7096451) | `python3Packages.qiskit-terra: 0.17.4 -> 0.18.3`                                     |
| [`3e74c100`](https://github.com/NixOS/nixpkgs/commit/3e74c1002d55a61dd2c2584178a3cf7787fcbc2a) | `lingua-franca: init with 0.1.0`                                                     |
| [`7ff8f9ab`](https://github.com/NixOS/nixpkgs/commit/7ff8f9ab3660d48a892f71de8b98c534efe7379b) | `openvscode-server: init at 1.62.0`                                                  |
| [`eaee897b`](https://github.com/NixOS/nixpkgs/commit/eaee897ba906f86e52a251254dcc3f86bd842618) | `leo-editor: 6.2.1 -> 6.5`                                                           |