### PR TITLE
chore(flake/inputs/nixpkgs): `0b239a47` -> `935f133a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1636894757,
-        "narHash": "sha256-QSwn2lqs/hWOWDFrQyj6ytpffbYp7pk7+M4XqOs3PVw=",
+        "lastModified": 1636963175,
+        "narHash": "sha256-PC4jXUTAOHC5rrQKecPrTuJLqVFZj99BPIqvD5ylsOQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0b239a479cd2c6246195f76244d0939845f82634",
+        "rev": "935f133a7b58ef2910fb72b1b5b9546b2d90b7e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                             |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`79611823`](https://github.com/NixOS/nixpkgs/commit/796118237d3e3193404e2934e5ec7782cb85dc3f) | `tree-sitter: update grammars`                                             |
| [`7b284a8b`](https://github.com/NixOS/nixpkgs/commit/7b284a8bd5ffcc177b742cde598874c56a20dc58) | `tree-sitter-grammars: add recurseIntoAttrs for tree-sitter.builtGrammars` |
| [`91e808c0`](https://github.com/NixOS/nixpkgs/commit/91e808c099d0348bf27b30d4014cb5cffd3f0de1) | `kapp: 0.40.0 -> 0.42.0`                                                   |
| [`9c33e5aa`](https://github.com/NixOS/nixpkgs/commit/9c33e5aad9fbae6b716afb1e196ed32171beed40) | `python38Packages.qcs-api-client: 0.15.0 -> 0.16.0`                        |
| [`fbe394aa`](https://github.com/NixOS/nixpkgs/commit/fbe394aad2f57f17e16991e409c4f1afe48badc4) | `btop: 1.0.24 -> 1.1.0`                                                    |
| [`9c542ec2`](https://github.com/NixOS/nixpkgs/commit/9c542ec266ba2d6a9e5bdffcd955d9addd4b3032) | `raylib: 3.7.0 -> 4.0.0 (#146051)`                                         |
| [`81455278`](https://github.com/NixOS/nixpkgs/commit/814552782e1f83ee9ad6dcf8d517a8f7897742e9) | `blitz: fix build for darwin`                                              |
| [`a01d9a40`](https://github.com/NixOS/nixpkgs/commit/a01d9a406fa59f3d70642efd4d43569f42119125) | `python38Packages.pykrakenapi: 0.2.1 -> 0.2.2`                             |
| [`b554c3af`](https://github.com/NixOS/nixpkgs/commit/b554c3af7bd0767871d29616614dafc4cf5702d5) | `etcd_3_4: remove deleteVendor`                                            |
| [`416596bd`](https://github.com/NixOS/nixpkgs/commit/416596bd245db633b2c27ad7a2cfb7bbed6d3e34) | `etcd_3_4: 3.4.16 -> 3.4.18`                                               |
| [`5a3b358b`](https://github.com/NixOS/nixpkgs/commit/5a3b358be5c2f12b56d71e30944160feeaa5ca8c) | `etcd: 3.3.25 -> 3.3.27`                                                   |
| [`4f0c8d05`](https://github.com/NixOS/nixpkgs/commit/4f0c8d0512503ff15a0894cf81eb68c536b78aac) | `nvidia_x11: libPath: add libgbm/libGL libraries (#145439)`                |
| [`df304eeb`](https://github.com/NixOS/nixpkgs/commit/df304eeb8026941efa4cb123d28a12a3a5935b36) | `glitter: 1.5.4 -> 1.5.5`                                                  |
| [`e4362cea`](https://github.com/NixOS/nixpkgs/commit/e4362cea6f3c3d8df03ae5e7a2e4f7a5fb8a8422) | `monosat, python3Packages.monosat: fix for non-x86`                        |
| [`8622d7dc`](https://github.com/NixOS/nixpkgs/commit/8622d7dc11f19dc97cf060e4de25e64768f35f45) | `fail2ban: Make postInstall delete conditional`                            |
| [`61bb9d5d`](https://github.com/NixOS/nixpkgs/commit/61bb9d5d5d83aa40a1bac3d66fb54601981f4ea1) | `python3Packages.fritzconnection: 1.7.1 -> 1.7.2`                          |
| [`422c4e19`](https://github.com/NixOS/nixpkgs/commit/422c4e199e1a25902fde646d5a94c14bcaba4aa6) | `python38Packages.flexmock: 0.10.10 -> 0.11.1`                             |
| [`ef9ac538`](https://github.com/NixOS/nixpkgs/commit/ef9ac538ebaa6e23cd9dfe95c1d8bd8332351d4a) | `python38Packages.frozendict: 2.0.6 -> 2.0.7`                              |
| [`06b3bdbe`](https://github.com/NixOS/nixpkgs/commit/06b3bdbeffde1cbc3ce1818d9543a7bc4e860ab9) | `python38Packages.ftputil: 5.0.1 -> 5.0.2`                                 |
| [`cd7cfb6d`](https://github.com/NixOS/nixpkgs/commit/cd7cfb6def162c75171312cf3565f607a4744399) | `python38Packages.bandit: 1.7.0 -> 1.7.1`                                  |
| [`cbf234b3`](https://github.com/NixOS/nixpkgs/commit/cbf234b34b3471454da96e7f6b5f012647160bc4) | `python38Packages.gigalixir: 1.2.3 -> 1.2.4`                               |
| [`520c255e`](https://github.com/NixOS/nixpkgs/commit/520c255e7fc75eda7707b61bb8101022ae91b28e) | `python38Packages.gin-config: 0.4.0 -> 0.5.0`                              |
| [`64d7a326`](https://github.com/NixOS/nixpkgs/commit/64d7a3266b6327521cfb563d014c4e26876f4dfa) | `doc: Fix xref in functions description`                                   |
| [`b187fab9`](https://github.com/NixOS/nixpkgs/commit/b187fab93e5500d7ba6578f3657b5982e0888d03) | `tela-icon-theme: remove darwin from platforms (#145997)`                  |
| [`fa0761a7`](https://github.com/NixOS/nixpkgs/commit/fa0761a7c6a31ad1c00cd43f6964829c7513727b) | `python3Packages.pygame: fix source hash on HFS+ filesystems (#145986)`    |
| [`9a65a60a`](https://github.com/NixOS/nixpkgs/commit/9a65a60a206ad2be649793f987b780b0530ad70c) | `ArchiSteamFarm: 4.3.1.0 -> 5.1.5.3, use buildDotnetModule (#145542)`      |
| [`8a37d710`](https://github.com/NixOS/nixpkgs/commit/8a37d710fd73e17dde79012a641a85b33dfa98eb) | `nixos: zsh: Remove hack for zsh-nix-completions on nix 2.4`               |
| [`1c72fa65`](https://github.com/NixOS/nixpkgs/commit/1c72fa65ed742d9bfa69cf4576b66a4c8aa6abbc) | `nix-zsh-completions: Lower priority to avoid collisions with nix`         |
| [`488a5a37`](https://github.com/NixOS/nixpkgs/commit/488a5a3787b2b53a991f9554dc9da97951245c77) | `fuzzel: 1.6.4 -> 1.6.5`                                                   |
| [`68b7bc8e`](https://github.com/NixOS/nixpkgs/commit/68b7bc8eceeb7516684e307da1e6b03332b09260) | `python38Packages.google-cloud-websecurityscanner: 1.6.0 -> 1.6.1`         |
| [`fe478785`](https://github.com/NixOS/nixpkgs/commit/fe478785a91ef6a78aa75f59e8445facad73303c) | `python38Packages.google-cloud-vision: 2.6.1 -> 2.6.2`                     |
| [`73e29858`](https://github.com/NixOS/nixpkgs/commit/73e29858608a5c4fd367b05800f4f4bc9ad168cd) | `python38Packages.google-cloud-videointelligence: 2.5.0 -> 2.5.1`          |
| [`c81411f5`](https://github.com/NixOS/nixpkgs/commit/c81411f58f9cbe20d335e0d20f3bcce76e676371) | `python38Packages.google-cloud-translate: 3.6.0 -> 3.6.1`                  |
| [`145cae01`](https://github.com/NixOS/nixpkgs/commit/145cae01895e1b4d4c562f8d8ecaab1f83473bf6) | `nvimpager: 0.10 -> 0.10.4`                                                |
| [`f4174af6`](https://github.com/NixOS/nixpkgs/commit/f4174af6feb9ef68ff9c30d692a97b2485fb0e30) | `python38Packages.google-cloud-trace: 1.5.0 -> 1.5.1`                      |
| [`4c7c3f85`](https://github.com/NixOS/nixpkgs/commit/4c7c3f85fbcd9b39052aa46d5df625f58d6816ec) | `python38Packages.google-cloud-texttospeech: 2.7.0 -> 2.7.1`               |
| [`42adeef9`](https://github.com/NixOS/nixpkgs/commit/42adeef9ec4e1f73a65ec07baa50cfe26818b92a) | `nixos/qemu-guest-agent: use qemu_kvm`                                     |
| [`8c9f6c2b`](https://github.com/NixOS/nixpkgs/commit/8c9f6c2b723cb9c92b1f3b5301841a265d98accc) | `python38Packages.google-cloud-tasks: 2.7.0 -> 2.7.1`                      |
| [`f6584583`](https://github.com/NixOS/nixpkgs/commit/f65845839461c5564fcfc273aee217e664d45117) | `python38Packages.google-cloud-speech: 2.11.0 -> 2.11.1`                   |
| [`8d705305`](https://github.com/NixOS/nixpkgs/commit/8d705305ee185dc77a2c3523d15a23296a2cd422) | `python38Packages.google-cloud-secret-manager: 2.7.2 -> 2.8.0`             |
| [`4029da71`](https://github.com/NixOS/nixpkgs/commit/4029da716609b783cddfc0da2fbc2e989a621f60) | `python38Packages.google-cloud-resource-manager: 1.3.0 -> 1.3.2`           |
| [`2b7f7fee`](https://github.com/NixOS/nixpkgs/commit/2b7f7fee7b94563b3516ed62528cebb826d5e693) | `python3Packages.spectral-cube: 0.5.0 -> 0.6.0`                            |
| [`0749556d`](https://github.com/NixOS/nixpkgs/commit/0749556dd703da7bd0908be4c98dbf3c4ba490d0) | `python38Packages.google-cloud-redis: 2.4.0 -> 2.5.0`                      |
| [`69013197`](https://github.com/NixOS/nixpkgs/commit/690131976e9a00f25f3abe8e8b3bc75d694e45d7) | `python3Packages.casa-formats.io: init at 0.1`                             |
| [`a881bfed`](https://github.com/NixOS/nixpkgs/commit/a881bfed1249c731ca10ea3dbf24fb5963f7a4f1) | `python38Packages.google-cloud-pubsub: 2.8.0 -> 2.9.0`                     |
| [`d741f66e`](https://github.com/NixOS/nixpkgs/commit/d741f66ecb8dd5a9660855c27e671db53192442b) | `python38Packages.google-cloud-os-config: 1.7.0 -> 1.9.0`                  |
| [`a7044b30`](https://github.com/NixOS/nixpkgs/commit/a7044b306cdef47c90acf9e26d290a7173f1404b) | `python38Packages.google-cloud-org-policy: 1.2.0 -> 1.2.1`                 |
| [`b30aacb9`](https://github.com/NixOS/nixpkgs/commit/b30aacb9b22d75bd8f1ba73d7ca14bd38f10473d) | `python38Packages.google-cloud-monitoring: 2.6.0 -> 2.7.0`                 |
| [`46c3a0b7`](https://github.com/NixOS/nixpkgs/commit/46c3a0b7be4539a9f1ef71899eff3520fda17a35) | `python38Packages.google-cloud-logging: 2.6.0 -> 2.7.0`                    |
| [`0f6838b4`](https://github.com/NixOS/nixpkgs/commit/0f6838b42127bd80f0a3fbecbbf15f89438800b1) | `python38Packages.google-cloud-language: 2.3.0 -> 2.3.1`                   |
| [`5e7e5e5d`](https://github.com/NixOS/nixpkgs/commit/5e7e5e5d41cf3f140531d9957ec7c7647bca32d8) | `ccache: 4.4.2 → 4.5`                                                      |
| [`340160df`](https://github.com/NixOS/nixpkgs/commit/340160df2d58073d868db6468e3a233062887be5) | `python38Packages.google-cloud-kms: 2.10.0 -> 2.10.1`                      |
| [`b36a9512`](https://github.com/NixOS/nixpkgs/commit/b36a9512e71d8b6fc479cecba156f2dea2c9615a) | `python38Packages.google-cloud-iam: 2.5.0 -> 2.5.1`                        |
| [`80dacd9f`](https://github.com/NixOS/nixpkgs/commit/80dacd9ffa0729a541935020dce4301e1789f17e) | `python38Packages.google-cloud-error-reporting: 1.4.0 -> 1.4.1`            |
| [`8b9646c0`](https://github.com/NixOS/nixpkgs/commit/8b9646c0c23836d095e5078a8e8f9faf19dfe933) | `python38Packages.google-cloud-dlp: 3.3.0 -> 3.3.1`                        |
| [`0fcdadb8`](https://github.com/NixOS/nixpkgs/commit/0fcdadb80e3067c4ef74b87262bd81e25702db98) | `python38Packages.google-cloud-datastore: 2.2.0 -> 2.4.0`                  |
| [`f1f3d9f7`](https://github.com/NixOS/nixpkgs/commit/f1f3d9f7f827efb13fc35bdabe29be16fc824e87) | `mtr: fix JSON output format, add libjansson`                              |
| [`ee93a73b`](https://github.com/NixOS/nixpkgs/commit/ee93a73bedd2fbca00c4c7126fcbbdde12faf6e2) | `python38Packages.google-cloud-dataproc: 3.1.0 -> 3.1.1`                   |
| [`c59a5b96`](https://github.com/NixOS/nixpkgs/commit/c59a5b968ddde38a4599e1644c9c2f238fc74f16) | `python38Packages.google-cloud-datacatalog: 3.4.3 -> 3.6.0`                |
| [`cdd3c44b`](https://github.com/NixOS/nixpkgs/commit/cdd3c44bfa6746e47ec3395dd949916f27554b9b) | `cached-nix-shell: 0.1.4 -> 0.1.5`                                         |
| [`f8448067`](https://github.com/NixOS/nixpkgs/commit/f84480678d6f4ebd95deca201554bec1ce850cfe) | `makemkv: 1.16.4 -> 1.16.5`                                                |
| [`9467fee4`](https://github.com/NixOS/nixpkgs/commit/9467fee4d444f6080c167fabca5c1766b09e207e) | `python38Packages.google-cloud-container: 2.10.0 -> 2.10.1`                |
| [`a5e5e2ad`](https://github.com/NixOS/nixpkgs/commit/a5e5e2ad1be5dc125cea72ad4e017b926569c8d8) | `python38Packages.google-cloud-bigquery-datatransfer: 3.4.0 -> 3.4.1`      |
| [`5e6878cd`](https://github.com/NixOS/nixpkgs/commit/5e6878cdf56016e5733078f1a3418a2702395d4d) | `python38Packages.google-cloud-automl: 2.5.1 -> 2.5.2`                     |
| [`5440a389`](https://github.com/NixOS/nixpkgs/commit/5440a389219dfe90f57a780ac5e038c6620fae11) | `python38Packages.google-cloud-asset: 3.7.0 -> 3.7.1`                      |
| [`39f5afa2`](https://github.com/NixOS/nixpkgs/commit/39f5afa229022679454f471a41f692bb8689a387) | `xed-editor: 2.8.4 -> 3.0.2`                                               |
| [`89139c63`](https://github.com/NixOS/nixpkgs/commit/89139c637235f55636445cb3682c0458ed12c5ff) | `trilium: 0.47.8 -> 0.48.6`                                                |
| [`8010ee3f`](https://github.com/NixOS/nixpkgs/commit/8010ee3ff307381918df203fd154ff002e7012d9) | `cargo-deps: use fetchCrate`                                               |
| [`6a3d7472`](https://github.com/NixOS/nixpkgs/commit/6a3d7472a56cf1b9f996e7bbfcfb1692f21b00a7) | `python38Packages.fido2: 0.9.2 -> 0.9.3`                                   |
| [`dc768257`](https://github.com/NixOS/nixpkgs/commit/dc7682574256909976b72dd4967946eedfc91fd7) | `tree: fix build on darwin/others`                                         |
| [`bdaf941e`](https://github.com/NixOS/nixpkgs/commit/bdaf941e39921dc7ef0da9c8263c45943c850eec) | `haskellPackages.hercules-ci-*: fix eval with haskell.lib.compose`         |
| [`27bfd797`](https://github.com/NixOS/nixpkgs/commit/27bfd79741808003a7041ef3bbf62472e9ea15ee) | `moka-icon-theme: replace duplicate files with symlinks`                   |
| [`58bdfc52`](https://github.com/NixOS/nixpkgs/commit/58bdfc529b30a2e417fcc0edcbc923df23629683) | `iris: 3.4.0 -> 3.5.0; stdpp: 1.5.0 -> 1.6.0`                              |
| [`9201d388`](https://github.com/NixOS/nixpkgs/commit/9201d388edc76b87f7d28f4297a25f0f0ce2e2f3) | `moka-icon-theme: 5.4.0 -> unstable-2019-05-29`                            |
| [`e50c9981`](https://github.com/NixOS/nixpkgs/commit/e50c9981d329312fb764b7d58e17488716bf2879) | `tesseract4: apply patches to fix build on aarch64-darwin`                 |
| [`32b6a2bf`](https://github.com/NixOS/nixpkgs/commit/32b6a2bf6af21a0835ad5654912e8609bf89b96b) | `vimPlugins.nvim-lint: init at 2021-11-08`                                 |
| [`6575f966`](https://github.com/NixOS/nixpkgs/commit/6575f966481be606f7d99805ae23c5cbad737e73) | `vimPlugins.FTerm-nvim: init at 2021-11-13`                                |
| [`9e7cfee0`](https://github.com/NixOS/nixpkgs/commit/9e7cfee02b8fae83b73c3a8b65ca502252b36f7c) | `vimPlugins: update`                                                       |
| [`1e16eb5e`](https://github.com/NixOS/nixpkgs/commit/1e16eb5ea6354953ab88bcaed1a6daaab9e4f7f7) | `python38Packages.coveralls: 3.2.0 -> 3.3.1`                               |
| [`bcdb9e13`](https://github.com/NixOS/nixpkgs/commit/bcdb9e139966e95a95c392536716b17b85afd776) | `lazygit: 0.30.1 -> 0.31.3`                                                |
| [`fbbfc3ed`](https://github.com/NixOS/nixpkgs/commit/fbbfc3edfa4a90743e0f0db179abb242da4c6a4c) | `paper-icon-theme: replace duplicate files with symlinks`                  |
| [`d234c03d`](https://github.com/NixOS/nixpkgs/commit/d234c03de8e3d1851f8ca285c96847e4d6682403) | `paper-icon-theme: 2018-06-24 -> unstable-2020-03-12`                      |
| [`1977eb9d`](https://github.com/NixOS/nixpkgs/commit/1977eb9d6d790349a46a0ae1340c4070a2e1baaa) | `python38Packages.casbin: 1.9.4 -> 1.9.6`                                  |
| [`d90a4496`](https://github.com/NixOS/nixpkgs/commit/d90a4496724c6a95d00c131e11c07aeaf2018453) | `python3Packages.pywemo: 0.6.7 -> 0.6.8`                                   |
| [`f330a765`](https://github.com/NixOS/nixpkgs/commit/f330a765071ebe5e5b4766fd51553bb07944f3ad) | `python3Packages.greeclimate: 0.12.3 -> 0.12.4`                            |
| [`9c83343b`](https://github.com/NixOS/nixpkgs/commit/9c83343bb85a4ca71f84213bcd52b1393929e538) | `scrcpy: 1.19 -> 1.20`                                                     |
| [`ff52e0cb`](https://github.com/NixOS/nixpkgs/commit/ff52e0cbc2ae89833527eee2ca7e8bc3ef533da7) | `python3Packages.flux-led: 0.24.17 -> 0.24.21`                             |
| [`82ec1bce`](https://github.com/NixOS/nixpkgs/commit/82ec1bcecbdc46543a04ffa2bad887f13c34f84a) | `python3Packages.zeroconf: 0.36.12 -> 0.36.13`                             |
| [`01e481e6`](https://github.com/NixOS/nixpkgs/commit/01e481e621d4c5209a4897dbc258b398bd018706) | `python38Packages.bracex: 2.2 -> 2.2.1`                                    |
| [`b9d5df06`](https://github.com/NixOS/nixpkgs/commit/b9d5df0632008f0bafe8fd1f3355b4e4c11d0f3d) | `python3Packages.aiohttp-remotes: switch to pytestCheckHook`               |
| [`b93a0c71`](https://github.com/NixOS/nixpkgs/commit/b93a0c71f2493880eed74dfc7c4b0e8480947161) | `python3Packages.praw: 7.4.0 -> 7.5.0`                                     |
| [`7c7a25a5`](https://github.com/NixOS/nixpkgs/commit/7c7a25a5a9f0581f6a5bd638fd837a3c132e83a5) | `checkov: 2.0.568 -> 2.0.571`                                              |
| [`c03e1125`](https://github.com/NixOS/nixpkgs/commit/c03e11252f4b65da9a17cb9c3514f6e3d1f9efc3) | `python3Packages.pyezviz: 0.1.9.4 -> 0.1.9.9`                              |
| [`082ae9a4`](https://github.com/NixOS/nixpkgs/commit/082ae9a4728bdba8aed217d0d5cb89d104cd2538) | `python3Packages.minidump: 0.0.20 -> 0.0.21`                               |
| [`811fee2d`](https://github.com/NixOS/nixpkgs/commit/811fee2d6401a34bfd7d8c3b35ad9f643bd00b18) | `nodePackages: update`                                                     |
| [`05ec5f66`](https://github.com/NixOS/nixpkgs/commit/05ec5f664fade58dd0a7bd81fdb428f8bd4f8928) | `oauth2-proxy: 7.0.1 -> 7.2.0`                                             |
| [`b136a823`](https://github.com/NixOS/nixpkgs/commit/b136a8232111d2d12263c7c96d2f08a7b4361693) | `buller: 2.87 -> 3.17`                                                     |
| [`91e0710a`](https://github.com/NixOS/nixpkgs/commit/91e0710aa22aff25fa7d529ed78581a647966034) | `python38Packages.aioconsole: 0.3.2 -> 0.3.3`                              |
| [`d7575472`](https://github.com/NixOS/nixpkgs/commit/d7575472f53f94358f505b6bdffc811e29af941d) | `gitkraken: add darwin support`                                            |
| [`44582a0f`](https://github.com/NixOS/nixpkgs/commit/44582a0f0e9ae4f9b6d553bea80d4a148fed69cf) | `numberstation: 1.0.0 -> 1.0.1`                                            |
| [`2a6b6b2a`](https://github.com/NixOS/nixpkgs/commit/2a6b6b2a3c1043da60780c448caa7d37ffd4a4a1) | `osu-lazer: 2021.1105.0 -> 2021.1113.0`                                    |
| [`3067b83e`](https://github.com/NixOS/nixpkgs/commit/3067b83e14704218f8badd9f437a79aa2455d88c) | `nodejs-17_x: 17.0.1 -> 17.1.0`                                            |
| [`3f02caca`](https://github.com/NixOS/nixpkgs/commit/3f02caca7fa3b67cd105da9390c15c6d1e60051f) | `mpdevil: 1.4.0 -> 1.4.1`                                                  |
| [`1a2019bd`](https://github.com/NixOS/nixpkgs/commit/1a2019bd83de1d5eb0ce3576f1bc31ed0435e408) | `vimPlugins.coc-ultisnips: init at 1.2.3`                                  |
| [`fd50160f`](https://github.com/NixOS/nixpkgs/commit/fd50160f86d4ec38cd489ccda24abf2ef848ec94) | `python3Packages.scikitimage: fix build in darwin sandbox`                 |
| [`d9dc791f`](https://github.com/NixOS/nixpkgs/commit/d9dc791f7499699c2a9c1ef9b9c86ed7f6c40913) | `python3Packages.hangups: 0.4.14 -> 0.4.15`                                |
| [`801fe645`](https://github.com/NixOS/nixpkgs/commit/801fe64590c1cef718bfb9b51e615d485abf6a5a) | `megapixels: 1.3.0 -> 1.4.0`                                               |
| [`2dafedfd`](https://github.com/NixOS/nixpkgs/commit/2dafedfda4752387675482c1cd557276097c6be7) | `k3s: 1.22.2+k3s2 -> 1.22.3+k3s1`                                          |
| [`1e6719a7`](https://github.com/NixOS/nixpkgs/commit/1e6719a7e74584bb00199d1c1148c8ebdac328f7) | `flexget: 3.1.150 -> 3.1.152`                                              |
| [`2331190c`](https://github.com/NixOS/nixpkgs/commit/2331190cd2fe09f54515d2188c83d026a2b26757) | `rocksdb: 6.25.3 -> 6.26.0`                                                |
| [`d8e1fe38`](https://github.com/NixOS/nixpkgs/commit/d8e1fe389858be86eb3cbdb1b61f590350391f35) | `podman: 3.4.1 -> 3.4.2`                                                   |
| [`fa88683e`](https://github.com/NixOS/nixpkgs/commit/fa88683e1ed54797f7a4e838c96d34b87aa0d0a3) | `octoprint: 1.6.1 -> 1.7.2`                                                |
| [`8817170f`](https://github.com/NixOS/nixpkgs/commit/8817170fd3239a6c6131b527212a77974bc4d36b) | `octoprint.python.pkgs.octoprint-firmwarecheck: 2021.8.11 -> 2021.10.11`   |
| [`f59cf099`](https://github.com/NixOS/nixpkgs/commit/f59cf0990f1ebbbcefb37fa68747f50e0a4bda10) | `octoprint.python.pkgs.octoprint-pisupport: 2021.8.2 -> 2021.10.28`        |
| [`fe900014`](https://github.com/NixOS/nixpkgs/commit/fe9000144cf30dc015cab463d4d1d8764e6778fa) | `python3Packages.aenum: 3.1.3 -> 3.1.5`                                    |
| [`c04d246e`](https://github.com/NixOS/nixpkgs/commit/c04d246eecb201e59b147621fce45d439696a314) | `apkeep: fix darwin build`                                                 |
| [`02a4ff26`](https://github.com/NixOS/nixpkgs/commit/02a4ff26cad00dd6218f98739657ed0263f6adc7) | `python3Packages.bond-api: 0.1.14 -> 0.1.15`                               |
| [`7b25314c`](https://github.com/NixOS/nixpkgs/commit/7b25314c0aeceedd99dc96259964293754b6a2bc) | `fiji: init at 20201104-1356`                                              |
| [`58524356`](https://github.com/NixOS/nixpkgs/commit/58524356c4af59b8beeebf8d49b98147f285bed6) | `python3Packages.sanic: disable failing tests on aarch64-linux`            |
| [`f4c24b78`](https://github.com/NixOS/nixpkgs/commit/f4c24b78d337f411cd4a7fc6d40570a82a15e49f) | `hercules-ci-*, cachix: nix: 2.3 -> 2.4`                                   |
| [`2d1be9cd`](https://github.com/NixOS/nixpkgs/commit/2d1be9cd9a67f3cf7dbcf9762008d78a814dfb21) | `nix: Install nlohmann_json headers`                                       |
| [`34d9bf79`](https://github.com/NixOS/nixpkgs/commit/34d9bf79064a1a26ff39a1febad45bb4ca48759e) | `wesnoth: 1.16.0 -> 1.16.1`                                                |
| [`f2ee944c`](https://github.com/NixOS/nixpkgs/commit/f2ee944cc11b86876855adbd4f7231778683d0cd) | `python3Packages.aiocron: init at 1.7`                                     |
| [`09d3d7fe`](https://github.com/NixOS/nixpkgs/commit/09d3d7fe360f48f24e5d7543997784e39da4a642) | `mariadb: 10.6.3 -> 10.6.5`                                                |
| [`155b7f01`](https://github.com/NixOS/nixpkgs/commit/155b7f01143a91f7c0d176726b621adac691eab6) | `haskell.compiler.ghcHEAD: apply autoSignDarwinBinariesHook`               |
| [`3b9e94dc`](https://github.com/NixOS/nixpkgs/commit/3b9e94dc6c0b2ad44c885990d54fb41990fd037c) | `haskell.compiler.ghc901: fix aarch64-darwin build`                        |
| [`044e8602`](https://github.com/NixOS/nixpkgs/commit/044e86024237a48194fd2b5c9dae92e5c2c36451) | `haskell.compiler.ghc921: fix aarch64-darwin build`                        |
| [`dd4a3401`](https://github.com/NixOS/nixpkgs/commit/dd4a34019a1a6701bb92ea2fde8a9a0e3b83f24e) | `nixos/teamspeak: add openFirewall, openFirewallServerQuery`               |
| [`2f2791fa`](https://github.com/NixOS/nixpkgs/commit/2f2791faa15285fa9507222742d0758a88a1777f) | `python3Packages.intake: disable flaky darwin test`                        |
| [`f35024ee`](https://github.com/NixOS/nixpkgs/commit/f35024ee2c969c1c18a4a69b86f0cfc159edca71) | `coredns: 1.8.5 -> 1.8.6`                                                  |
| [`eb37e25c`](https://github.com/NixOS/nixpkgs/commit/eb37e25c2d334e4f3371b4b5db61134adbb88f94) | `calamares: 3.2.43 -> 3.2.44.3`                                            |
| [`a5403b9a`](https://github.com/NixOS/nixpkgs/commit/a5403b9a36f69ed5d350f889f19af576aa0f8c3f) | `scotch: 6.0.4 -> 6.1.1`                                                   |
| [`5f6bd818`](https://github.com/NixOS/nixpkgs/commit/5f6bd8187b30cbb4c6ff512b7de16348b5638479) | `bcftools: 1.13 -> 1.14`                                                   |
| [`035c7dc4`](https://github.com/NixOS/nixpkgs/commit/035c7dc4fa713a5865f38045ad86a348343f065d) | `bazarr: 0.9.9 -> 1.0.0`                                                   |
| [`1806fd63`](https://github.com/NixOS/nixpkgs/commit/1806fd639d1d0645126db045168a5412005ec808) | `rabbitmq-server: 3.9.6 -> 3.9.8`                                          |
| [`ce023d3c`](https://github.com/NixOS/nixpkgs/commit/ce023d3cc6a6caf205d7c70adfe898c8562ed266) | `saml2aws: 2.32.0 -> 2.33.0`                                               |
| [`df26a83f`](https://github.com/NixOS/nixpkgs/commit/df26a83f13ebabd49935773a7192c0fdadd2ecdd) | `sstp: 1.0.15 -> 1.0.16`                                                   |