### PR TITLE
chore(flake/inputs/home-manager): `cbcb2976` -> `a7c5b00d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -62,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1636978996,
-        "narHash": "sha256-5t5ZNRtlLpOta0jVyjpqENG2DmISyD90ZuanRIiTSu0=",
+        "lastModified": 1637010045,
+        "narHash": "sha256-EzA+Iu2c8N1i3K8jouZSuyMOOeR1glFZSW9ZgqmPH54=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cbcb2976b69a4054a8cb2a4c26101ca337191999",
+        "rev": "a7c5b00d44f65efd1e8ace2c02243f179e72283a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                        |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`a7c5b00d`](https://github.com/nix-community/home-manager/commit/a7c5b00d44f65efd1e8ace2c02243f179e72283a) | `polybar: use recursive config type (#2235)`          |
| [`2dcd9eb0`](https://github.com/nix-community/home-manager/commit/2dcd9eb021bab3ac51995099aec16b7354851c9c) | `docs: minor rewording in usage documentation`        |
| [`c855cdde`](https://github.com/nix-community/home-manager/commit/c855cdde20f3d00c421aeae59546d22430ba86ae) | `docs: make README refer to installation chapter`     |
| [`e785e679`](https://github.com/nix-community/home-manager/commit/e785e6797786d4c08a74039a2b4afd4c8d90ba21) | `docs: make text more specific about Nix 2.4 support` |