### PR TITLE
chore(flake/inputs/nixpkgs): `935f133a` -> `51befa6c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1636963175,
-        "narHash": "sha256-PC4jXUTAOHC5rrQKecPrTuJLqVFZj99BPIqvD5ylsOQ=",
+        "lastModified": 1637007363,
+        "narHash": "sha256-oNLZw8/e5YCG7zbQGFBx07SA16I+hdk6d028+YowbLQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "935f133a7b58ef2910fb72b1b5b9546b2d90b7e9",
+        "rev": "51befa6cdc7bf7d6866a6368ecbbccb1d972bb30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                  |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`702b5f6d`](https://github.com/NixOS/nixpkgs/commit/702b5f6dc9d9e411406a59ccd3d5274d9ea29e68) | `gtk4: 4.4.0 -> 4.4.1`                                                          |
| [`d25def1a`](https://github.com/NixOS/nixpkgs/commit/d25def1a8472f315030a3bc113c6b9f5be8f76a4) | `broot: 1.6.6 -> 1.7.1`                                                         |
| [`9e7f498e`](https://github.com/NixOS/nixpkgs/commit/9e7f498eafc0469b68fdf8dde8d9412c830def5c) | `jupyter_server: Patch unicode test for Darwin (#145993)`                       |
| [`5153a6cf`](https://github.com/NixOS/nixpkgs/commit/5153a6cf192bf840538b969da19af30a4a96e869) | `gradle: Clean up`                                                              |
| [`e7b09202`](https://github.com/NixOS/nixpkgs/commit/e7b0920211addd5ff840cfd5a8399859731acaac) | `reveal-md: init at 5.2.0`                                                      |
| [`b0657ddc`](https://github.com/NixOS/nixpkgs/commit/b0657ddc91101c625d2cba64b6b3d22350062f39) | `flex-ndax: 0.1-20210714.0 -> 0.2-20211111.0`                                   |
| [`aeaafd15`](https://github.com/NixOS/nixpkgs/commit/aeaafd1502d562a12c57f780a460307629543e00) | `doc: Explain daemon(IO)NiceLevel removal in release note`                      |
| [`ee8e993f`](https://github.com/NixOS/nixpkgs/commit/ee8e993fd430ed80b1ea58b1b9b396270ade09a1) | `modules/nix-daemon: Replace daemon(IO)NiceLevel options`                       |
| [`d635496f`](https://github.com/NixOS/nixpkgs/commit/d635496f3a3fe33e290bed733a6579aadf611d00) | `grafana: 8.2.3 -> 8.2.4, fix CVE-2021-41244 (#146164)`                         |
| [`62110935`](https://github.com/NixOS/nixpkgs/commit/621109350df973691eec50ba7ad5b022f56c0aab) | `hck: 0.6.6 -> 0.6.7`                                                           |
| [`f8bbc587`](https://github.com/NixOS/nixpkgs/commit/f8bbc587eb2dbd1e7168b59cd0bb0d5aef89d2da) | `elan: wrap embedded linker`                                                    |
| [`4bfbd0af`](https://github.com/NixOS/nixpkgs/commit/4bfbd0af14c20ca48eb6a01ed2689103945970f0) | `python3.pkgs.nbclient: remove entry point`                                     |
| [`4e7dda04`](https://github.com/NixOS/nixpkgs/commit/4e7dda04ccc1e93658abcfafcd4a911bc093336e) | `vala_0_52: 0.52.6 -> 0.52.7`                                                   |
| [`f8a8ed3a`](https://github.com/NixOS/nixpkgs/commit/f8a8ed3a2bf2f0b6011e75bdad5098c96658397e) | `python3Packages.total-connect-client: 2021.11.2 -> 2021.11.4`                  |
| [`b608867a`](https://github.com/NixOS/nixpkgs/commit/b608867a248c62f4ba6b9ef402ac33784bf3b418) | `xterm: 369 -> 370`                                                             |
| [`44be59af`](https://github.com/NixOS/nixpkgs/commit/44be59afb9d8732c3d73690400bbd3f80ec03fc0) | `netplan: remove default value from fetchFromGitHub, cleanup substituteInPlace` |
| [`241c93fa`](https://github.com/NixOS/nixpkgs/commit/241c93fabe43e1220ce8aebb0b4219ffbb2b9b81) | `nextcloud-client: remove caugner from maintainers`                             |
| [`79497a97`](https://github.com/NixOS/nixpkgs/commit/79497a972a98f953b939fd8f21f61d6a92c533c7) | `lunatic: mark broken on darwin`                                                |
| [`ce6665dc`](https://github.com/NixOS/nixpkgs/commit/ce6665dceef9873d1166afa2178b32a947591bf2) | `lunatic: fix build`                                                            |
| [`16769bde`](https://github.com/NixOS/nixpkgs/commit/16769bdede14bd5efab799e0985645a9a458ef24) | `python3Packages.slugid: init 2.0.0 (#141409)`                                  |
| [`4862b748`](https://github.com/NixOS/nixpkgs/commit/4862b748db650c02c00b59b364301de906431c23) | `stylua: 0.11.1 -> 0.11.2`                                                      |
| [`d8caf2d2`](https://github.com/NixOS/nixpkgs/commit/d8caf2d2e7ddcfe56441b4eea51963f607b0f5ee) | `qbe: unstable-2021-10-28 -> unstable-2021-11-10`                               |
| [`9283fc53`](https://github.com/NixOS/nixpkgs/commit/9283fc5384d862b21a26a19e7284e3390c7e1127) | `python38Packages.youtube-transcript-api: 0.4.1 -> 0.4.2`                       |
| [`23fc0c34`](https://github.com/NixOS/nixpkgs/commit/23fc0c348d2934851dd75e9c23c66055d78f67aa) | `python38Packages.youtube-search-python: 1.4.9 -> 1.5.1`                        |
| [`e7d14125`](https://github.com/NixOS/nixpkgs/commit/e7d14125641c938f31bb7cad191edcb7f3bcb6df) | `downonspot: init at unstable-2021-10-11 (#141494)`                             |
| [`930f8daa`](https://github.com/NixOS/nixpkgs/commit/930f8daa6530161913af24fedb20b50f0b7087ac) | `ceres-solver: 2.0.0 split outputs, build dynamic, default with blas (#139268)` |
| [`ab79b9c9`](https://github.com/NixOS/nixpkgs/commit/ab79b9c94f6296e835450b1e807596d3924fa981) | `python38Packages.yfinance: 0.1.64 -> 0.1.66`                                   |
| [`0bef0c38`](https://github.com/NixOS/nixpkgs/commit/0bef0c38f74372ca1794e800b8709b90558efba2) | `lib.modules: add mkDerivedConfig`                                              |
| [`931ab058`](https://github.com/NixOS/nixpkgs/commit/931ab058daa7e4cd539533963f95e2bb0dbd41e6) | `miniserve: 0.17.0 -> 0.18.0`                                                   |
| [`cfbf3b4d`](https://github.com/NixOS/nixpkgs/commit/cfbf3b4da68631672f6734b02d4802f4278a514b) | `python38Packages.west: 0.11.1 -> 0.12.0`                                       |
| [`4f0724e0`](https://github.com/NixOS/nixpkgs/commit/4f0724e090826dcb67984feabce23b3d122d73d4) | `python38Packages.wcmatch: 8.2 -> 8.3`                                          |
| [`25244353`](https://github.com/NixOS/nixpkgs/commit/25244353eab7b820a7326d85bf78043db4e01fdb) | `python38Packages.traits: 6.3.0 -> 6.3.2`                                       |
| [`2f9a30b5`](https://github.com/NixOS/nixpkgs/commit/2f9a30b53a74d09116f5a5c6ec8cab05b1abd23d) | `python38Packages.torchvision: 0.10.1 -> 0.11.1`                                |
| [`695241f2`](https://github.com/NixOS/nixpkgs/commit/695241f2bc4d634ab03c1355e30e1f36e6b4c585) | `cpuid: 20211031 -> 20211114`                                                   |
| [`2813d619`](https://github.com/NixOS/nixpkgs/commit/2813d6194b512b9d5aabdf586b96019863318085) | `ocamlPackages.bistro: unstable-2021-07-13 -> unstable-2021-11-13`              |
| [`deafbbf3`](https://github.com/NixOS/nixpkgs/commit/deafbbf343ae621fa5a15b39d97ceb3a8a9723fd) | `python38Packages.tempest: 29.0.0 -> 29.2.0`                                    |
| [`5a626715`](https://github.com/NixOS/nixpkgs/commit/5a6267150e6bd8ac6d514753b6efd298be43f526) | `python38Packages.sunpy: 3.1.0 -> 3.1.1`                                        |
| [`fc960d3c`](https://github.com/NixOS/nixpkgs/commit/fc960d3c0f4f2fade9a50faf08afaffbe313ef88) | `python38Packages.striprtf: 0.0.15 -> 0.0.16`                                   |
| [`0603b945`](https://github.com/NixOS/nixpkgs/commit/0603b9459f315163cb203e5227bafbfa0c517f05) | `python38Packages.stripe: 2.61.0 -> 2.62.0`                                     |
| [`e682fd7c`](https://github.com/NixOS/nixpkgs/commit/e682fd7c83d16c35de979ecd419115c98a260601) | `steam: 1.0.0.72 -> 1.0.0.73`                                                   |
| [`7ccb24d9`](https://github.com/NixOS/nixpkgs/commit/7ccb24d9a4fdc1dbba396196f7b34014b195f1a2) | `python38Packages.sopel: 7.1.5 -> 7.1.6`                                        |
| [`af5e7e66`](https://github.com/NixOS/nixpkgs/commit/af5e7e66625adf15e2a0bf4150a4068acb70dd61) | `python3Packages.ha-philipsjs: 2.7.5 -> 2.7.6`                                  |
| [`baa566f5`](https://github.com/NixOS/nixpkgs/commit/baa566f5a5827a280dbdb590603ae3e202132ad6) | `cri-o: 1.22.0 -> 1.22.1`                                                       |
| [`fe6e74ea`](https://github.com/NixOS/nixpkgs/commit/fe6e74ead973beb3fc508385bbd25ce2142405a1) | `gvproxy: 0.2.0 -> 0.3.0`                                                       |
| [`261f2073`](https://github.com/NixOS/nixpkgs/commit/261f2073d8481ed799e06549a9228b6a71fbc489) | `dbeaver: 21.2.4 -> 21.2.5`                                                     |
| [`45b87c0c`](https://github.com/NixOS/nixpkgs/commit/45b87c0cc214298a6063f85a8dd95a17dabb87ee) | `python38Packages.samsungtvws: 1.6.0 -> 1.7.0`                                  |
| [`6997347f`](https://github.com/NixOS/nixpkgs/commit/6997347f4542417bc03eab9a0dbe83498b9e07ac) | `python3Packages.environs: 9.3.4 -> 9.3.5`                                      |
| [`d4fbff9d`](https://github.com/NixOS/nixpkgs/commit/d4fbff9d649a45ae847ff4016cae62d4a21c5d3a) | `pngcheck: take ownership`                                                      |
| [`75322a38`](https://github.com/NixOS/nixpkgs/commit/75322a3817a66dec05c677768b4b47b9359e1d71) | `pngcheck: enable building on darwin`                                           |
| [`12faa4aa`](https://github.com/NixOS/nixpkgs/commit/12faa4aaf680b3618dc0ae8bb6aa75938a49dc6e) | `visidata: 2.6.1 -> 2.7`                                                        |
| [`5ee42fa3`](https://github.com/NixOS/nixpkgs/commit/5ee42fa3f010c39e0f4c4115ccce87480451b8b0) | `apkeep: fix aarch64 build`                                                     |
| [`04b69e48`](https://github.com/NixOS/nixpkgs/commit/04b69e480eb09ce75c0b41fcdc955dce93ed6b7a) | `python38Packages.pytelegrambotapi: 4.1.1 -> 4.2.0`                             |
| [`4a0e5951`](https://github.com/NixOS/nixpkgs/commit/4a0e59511deff2d295a640920599009918500e55) | `python38Packages.pycollada: 0.7.1 -> 0.7.2`                                    |
| [`e9e3b968`](https://github.com/NixOS/nixpkgs/commit/e9e3b968873f83002128831b60d632203622c086) | `python38Packages.py3status: 3.39 -> 3.40`                                      |
| [`db746798`](https://github.com/NixOS/nixpkgs/commit/db746798a8f7590f5e0588443f3dffcbf19d5985) | `python38Packages.plaid-python: 8.5.0 -> 8.6.0`                                 |
| [`c77b50b9`](https://github.com/NixOS/nixpkgs/commit/c77b50b90824af9546749cce6bd6c78ff508499b) | `python38Packages.pex: 2.1.54 -> 2.1.55`                                        |
| [`3f772a5f`](https://github.com/NixOS/nixpkgs/commit/3f772a5f2baff61a263895c213fd7bf9819f0265) | `qemu: add support for io_uring`                                                |
| [`0e590c91`](https://github.com/NixOS/nixpkgs/commit/0e590c91d20efb1be7978347a2d45940a1d2fc2e) | `etc module: make `.text` and `.source` the same priority`                      |
| [`5badc25f`](https://github.com/NixOS/nixpkgs/commit/5badc25f5839346bfaa9983855850891d7346fc8) | `pcl: fix build on aarch64`                                                     |
| [`e632b0ac`](https://github.com/NixOS/nixpkgs/commit/e632b0acccb71a804b4bce09531b55b1754ec6c4) | `less: 590 -> 596`                                                              |
| [`968d1804`](https://github.com/NixOS/nixpkgs/commit/968d18045263799811c2ff9e238214bd1f6a2329) | `php: Implement overrideAttrs that composes with buildEnv/withExtensions`       |
| [`962807bf`](https://github.com/NixOS/nixpkgs/commit/962807bf9e66d89107b09d328d774b45e8169983) | `kodi.packages.libretro-mgba: init at 0.9.2.31`                                 |
| [`f82b8909`](https://github.com/NixOS/nixpkgs/commit/f82b8909cbc0c4613d2e7232732ef5898e5cf241) | `texlab: 3.3.0 → 3.3.1`                                                         |
| [`603254ba`](https://github.com/NixOS/nixpkgs/commit/603254bab2c8ca31fafef44dd879792510fac335) | `zsh-fast-syntax-highlighting: new upstream url`                                |
| [`0fd0f7db`](https://github.com/NixOS/nixpkgs/commit/0fd0f7db54332e4bddae2b156cbb213fabfe7f20) | `python3Packages.pymysensors: 0.22.0 -> 0.22.1`                                 |
| [`30e1b0bd`](https://github.com/NixOS/nixpkgs/commit/30e1b0bd69e43bb9ad9fba81c3ecbb4fd5d5be21) | `Revert "metrics: drop requiredSystemFeatures; /cc #76776"`                     |
| [`881d3fae`](https://github.com/NixOS/nixpkgs/commit/881d3fae720f51142cc0f0f5f9bc533b6e83af23) | `wrapFirefox: fix icon linking for Thunderbird`                                 |
| [`2110942b`](https://github.com/NixOS/nixpkgs/commit/2110942bca27ab12d264980f713e3c45c0f53e2a) | `bluetooth_battery: 1.2.0 -> 1.3.1`                                             |
| [`af9b2fc0`](https://github.com/NixOS/nixpkgs/commit/af9b2fc0ae447acc539fa6d9261023384c327bfc) | `electrs: use rocksdb_6_23`                                                     |
| [`06651404`](https://github.com/NixOS/nixpkgs/commit/06651404a6cce0227f2d7a0489ceadc64781fdaf) | `electrs: bring back rocksdb dynamic linking`                                   |
| [`31cf0a39`](https://github.com/NixOS/nixpkgs/commit/31cf0a39137fdb06c19bdb0102cbe0239d730948) | `blockbook: use rocksdb_6_23`                                                   |
| [`434676aa`](https://github.com/NixOS/nixpkgs/commit/434676aa05044fc157156f1e503d5ef1b1316068) | `blockbook: 0.3.4 -> 0.3.6`                                                     |
| [`214b3913`](https://github.com/NixOS/nixpkgs/commit/214b39133eef93734c984ea3a06caa4affcfb9cb) | `rocksdb: reintroduce rocksdb 6.23.3 as rocksdb_6_23`                           |
| [`2774c726`](https://github.com/NixOS/nixpkgs/commit/2774c726b4d8a922de19add521ae904673b07ebb) | `firefox: add a patch fixing deadlock`                                          |
| [`f857492a`](https://github.com/NixOS/nixpkgs/commit/f857492a193ead51cc40d2f453fde94168bf3ddc) | `firefox: use rustc.llvmPackages.stdenv with bintools`                          |
| [`b3fd89bb`](https://github.com/NixOS/nixpkgs/commit/b3fd89bb20a53b83447910030dd64fd9982fa108) | `libreoffice*: skip test to fix build with icu70`                               |
| [`084da134`](https://github.com/NixOS/nixpkgs/commit/084da134e9b1bb9130eb7da660d58ee63e3ea419) | `libreoffice-still: 7.1.6.2 -> 7.1.7.2`                                         |
| [`24c9cd84`](https://github.com/NixOS/nixpkgs/commit/24c9cd84c2e5d244b88b805b85b20512af37325d) | `slock: fix cross-compilation`                                                  |
| [`b1c58be1`](https://github.com/NixOS/nixpkgs/commit/b1c58be1ac6ed732c4b0ef7d4781ab52d7a6a09b) | `farbfeld: fix cross-compilation`                                               |
| [`8d88d514`](https://github.com/NixOS/nixpkgs/commit/8d88d5144ac9425fe884cd114f956cbe4f2c1452) | `sic: fix cross-compilation`                                                    |
| [`396b3fc0`](https://github.com/NixOS/nixpkgs/commit/396b3fc00b1b5b60c695fda01456a950a8c4d02a) | `ii: fix cross-compilation`                                                     |
| [`72dbc900`](https://github.com/NixOS/nixpkgs/commit/72dbc9005ec54e47d05860122ff52c4d69b4d754) | `wmname: fix cross-compilation`                                                 |
| [`d2972cac`](https://github.com/NixOS/nixpkgs/commit/d2972cac853a7f8367f2840a8c291cc1e7f8240e) | `slstatus: fix cross-compilation`                                               |
| [`7754c041`](https://github.com/NixOS/nixpkgs/commit/7754c0417cb9f343a98036ebee91e013c9220fc5) | `libxlsxwriter: 1.1.3 -> 1.1.4`                                                 |
| [`06ddf344`](https://github.com/NixOS/nixpkgs/commit/06ddf344d8b2a8f3b2ddd356028115f84bd4987a) | `lnd: 0.13.3-beta -> 0.13.4-beta`                                               |
| [`8165ee70`](https://github.com/NixOS/nixpkgs/commit/8165ee70ca98ed062f40de8590f32264a15ebaf2) | `cloud-sql-proxy: 1.26.0 -> 1.27.0`                                             |
| [`322ae11b`](https://github.com/NixOS/nixpkgs/commit/322ae11b186b5fed38fecccb927143cee64f39a2) | `zellij: 0.20.0 -> 0.20.1`                                                      |
| [`90197ce7`](https://github.com/NixOS/nixpkgs/commit/90197ce7ada61136032b5e85933e583c2b0d2c73) | `python3Packages.pyflunearyou: 2.0.2 -> 2021.10.0`                              |
| [`30a48de7`](https://github.com/NixOS/nixpkgs/commit/30a48de7db53ceb6d270e394eac3ef323d5af919) | `starship: 0.58.0 -> 1.0.0`                                                     |
| [`e6548105`](https://github.com/NixOS/nixpkgs/commit/e6548105b7ffbcb20d0a091be358165a21b510e2) | `rnix-lsp: use nix (2.4)`                                                       |
| [`f55e76a5`](https://github.com/NixOS/nixpkgs/commit/f55e76a50251b2017c3896627162dc3e26c14ade) | `helix: 0.4.1 -> 0.5.0`                                                         |
| [`108b850b`](https://github.com/NixOS/nixpkgs/commit/108b850b8e030b431646d1a8ad41000f40317c7c) | `zellij: 0.19.0 -> 0.20.0`                                                      |
| [`5e2b2752`](https://github.com/NixOS/nixpkgs/commit/5e2b2752dad4b893d05fdf8e1b9fe836c2ca486e) | `diffoscope: drop upstreamed fix-uimage-on-file-5.41.patch patch`               |
| [`f3de6494`](https://github.com/NixOS/nixpkgs/commit/f3de64943da6e67f6d00e36a0a97f057065c2fb6) | `snappy: fix build on x86_64-darwin`                                            |
| [`a8d1f24a`](https://github.com/NixOS/nixpkgs/commit/a8d1f24ac291f5a0bc0c3f0b965d6360d6ea47d3) | `synth: fix darwin build`                                                       |
| [`efe4c017`](https://github.com/NixOS/nixpkgs/commit/efe4c017498c6ccd00bf551f9eae5323cdebecba) | `python3Packages.pyefergy: 0.1.3 -> 0.1.4`                                      |
| [`df9f3896`](https://github.com/NixOS/nixpkgs/commit/df9f3896e798f2698274eb181ad076ba27cff644) | `kexec-tools: 2.0.22 → 2.0.23`                                                  |
| [`b427f9a5`](https://github.com/NixOS/nixpkgs/commit/b427f9a5bf48e69c7b21704be2b0429c7855e798) | `kmon: 1.5.5 -> 1.6.0, clarify license`                                         |
| [`6a584e15`](https://github.com/NixOS/nixpkgs/commit/6a584e15fb0de8397568322ccd14286848f8cc58) | `khard: fix eval, add import check`                                             |
| [`555aa761`](https://github.com/NixOS/nixpkgs/commit/555aa76120a4ebb5139704276ee7dd0b8c3cd520) | `linux: enable TCP_CONG_ADVANCED`                                               |
| [`eef72d8f`](https://github.com/NixOS/nixpkgs/commit/eef72d8f9c0f311234db01e0edd9a45e9fd34642) | `pkgsMusl.cups: enable systemd support`                                         |
| [`a2e92ff6`](https://github.com/NixOS/nixpkgs/commit/a2e92ff6ad2c0040ccfbd712e2088fc4010c53eb) | `pkgsMusl.redis: enable systemd support`                                        |
| [`eae534c5`](https://github.com/NixOS/nixpkgs/commit/eae534c584ac21a613702e3f53259dfceb993ed7) | `pkgsMusl.dbus: enable systemd support`                                         |
| [`8e5abca4`](https://github.com/NixOS/nixpkgs/commit/8e5abca4058999d118da146884ec496cafebaa88) | `python3Packages.click: 8.0.2 -> 8.0.3`                                         |
| [`b5cfd8dd`](https://github.com/NixOS/nixpkgs/commit/b5cfd8dd69a7fe789aa5d253ce452c5cb13256a3) | `treewide: remove python39Packages.ruamel_yaml aliases`                         |
| [`10d3b3c3`](https://github.com/NixOS/nixpkgs/commit/10d3b3c3fa78a999423b65d01ab44f79bc8f39a8) | `cargo-about: 0.3.0 -> 0.4.1`                                                   |
| [`4cb7820a`](https://github.com/NixOS/nixpkgs/commit/4cb7820ac9d46ffa20024350a208c66344958c7c) | `elan: 1.3.0 -> 1.3.1`                                                          |