### PR TITLE
chore(flake/inputs/sops-nix): `9a961ab9` -> `3c53d012`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1636842446,
-        "narHash": "sha256-fsA6OextnFjJkfiatKyoa/zPSEpvCTrG+zKQiaTHKwc=",
+        "lastModified": 1637050424,
+        "narHash": "sha256-8IaY0/Y5g3jJiQzPN0PflKFcFEE1C29DZZ0dF1NIJ6s=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "9a961ab91c3e1b5561725b0c833c862cf22dc76a",
+        "rev": "3c53d012ac77d4bd8428f9c847709e287c897ad9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                                 |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`9989dfc9`](https://github.com/Mic92/sops-nix/commit/9989dfc9e03f54f481c7d14eff5779e59fe583c6) | `unify ci jobs`                                |
| [`cd88d2f8`](https://github.com/Mic92/sops-nix/commit/cd88d2f8d01e760cda2c2e4d0e8abdfa0f02c8cd) | `Bump cachix/install-nix-action from 14 to 15` |