### PR TITLE
chore(flake/inputs/home-manager): `a7c5b00d` -> `42915b78`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -62,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1637010045,
-        "narHash": "sha256-EzA+Iu2c8N1i3K8jouZSuyMOOeR1glFZSW9ZgqmPH54=",
+        "lastModified": 1637084316,
+        "narHash": "sha256-CXkhRX+Lh8gwkDVQWXOUtEvx4ELJWu3vru2QmsR+OeM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a7c5b00d44f65efd1e8ace2c02243f179e72283a",
+        "rev": "42915b78af4a6c9e07a3ae412ff3a494a1fc98d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                     |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`42915b78`](https://github.com/nix-community/home-manager/commit/42915b78af4a6c9e07a3ae412ff3a494a1fc98d5) | `lieer: use configured package in service (#2480)` |
| [`05a31160`](https://github.com/nix-community/home-manager/commit/05a31160913d2ae91b7e71d5ced12416d2049d24) | `offlineimap: Fix for OfflineIMAP 8 (#2479)`       |