### PR TITLE
chore(flake/inputs/nixpkgs): `51befa6c` -> `6b68d74f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1637007363,
-        "narHash": "sha256-oNLZw8/e5YCG7zbQGFBx07SA16I+hdk6d028+YowbLQ=",
+        "lastModified": 1637048323,
+        "narHash": "sha256-h2m2LuUEbV5pvNjXoWbk2rAaBAQAsf3cvJXS8DGi+Bo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "51befa6cdc7bf7d6866a6368ecbbccb1d972bb30",
+        "rev": "6b68d74f036def3d48a23969edfd0fa47f34af3e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                       |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`cd8f237c`](https://github.com/NixOS/nixpkgs/commit/cd8f237c0c4eff99b30248ab647a78347ea3f7de) | `clusterctl: init at 1.0.1`                                          |
| [`9928e040`](https://github.com/NixOS/nixpkgs/commit/9928e040e74322639fcebf87f58fb88780bd2ba4) | `seafile-client: add greizgh as maintainer due to their own request` |
| [`55bb949a`](https://github.com/NixOS/nixpkgs/commit/55bb949a2ef305ed6aff95e69a6c04036185eed0) | `seafile-client: 8.0.4 -> 8.0.5`                                     |
| [`cd58f449`](https://github.com/NixOS/nixpkgs/commit/cd58f44937a70b73447f464f1cb5a64badc78640) | `nixos/pantheon: cleanup FAQ section`                                |
| [`f1c18353`](https://github.com/NixOS/nixpkgs/commit/f1c183531161fbc5c4d0f805b88a1a51d294760a) | `fennel: 0.10.0 -> 1.0.0`                                            |
| [`d8b017f3`](https://github.com/NixOS/nixpkgs/commit/d8b017f3d876691fc8c4b951ad6cfe85bcd5cd3f) | `rivet: add a patch fix build`                                       |
| [`c3e221c6`](https://github.com/NixOS/nixpkgs/commit/c3e221c6a1846d07255f14332fd02b54c19293d0) | `Fix evaluation after #143994`                                       |
| [`e31f3929`](https://github.com/NixOS/nixpkgs/commit/e31f392946cfce8a6ded8716f438bf670b0ce0da) | `llvm_13: fix cross-compilation`                                     |
| [`badb5a1a`](https://github.com/NixOS/nixpkgs/commit/badb5a1af29cfcf0b22064c4610c7aecd69cc637) | `fhs-userenv-bubblewrap: add ca-certificates to fhs`                 |
| [`edfba44b`](https://github.com/NixOS/nixpkgs/commit/edfba44b90f62252b3086adda60d697595d7b5b8) | `gprbuild, gprbuild-boot: bump gprconfig_kb to 22.0.0`               |
| [`58cbee06`](https://github.com/NixOS/nixpkgs/commit/58cbee06b84c090cd142fc244a2038e8316c684e) | `python3Packages.python-socketio: 5.4.1 -> 5.5.0`                    |
| [`f0358795`](https://github.com/NixOS/nixpkgs/commit/f0358795ff55575c58346fde261064ddbfea1680) | `python3Packages.johnnycanencrypt: fix build with newer maturin`     |
| [`a0def2f9`](https://github.com/NixOS/nixpkgs/commit/a0def2f9cabc3ea5de43b23fb615243a61577307) | `python3Packages.pwntools: 4.6.0 -> 4.7.0`                           |
| [`81658e43`](https://github.com/NixOS/nixpkgs/commit/81658e43f3d3e3cbe5f4ae0a77951537b2e040fa) | `python3Packages.greeclimate: 0.12.4 -> 0.12.5`                      |
| [`5a41f407`](https://github.com/NixOS/nixpkgs/commit/5a41f4072ffa85c5fec5972abfee64d084aa0262) | `python3Packages.flux-led: 0.24.21 -> 0.24.24`                       |
| [`38dd8c99`](https://github.com/NixOS/nixpkgs/commit/38dd8c99b0b6b3b1e4af377e63bc201bed0b0139) | `urlwatch: 2.23 -> 2.24`                                             |
| [`b011b33e`](https://github.com/NixOS/nixpkgs/commit/b011b33e427cfedcd68d673549fb8e9f9850faf2) | `emacs.pkgs.ada-mode: use latest wisi`                               |
| [`68ba489d`](https://github.com/NixOS/nixpkgs/commit/68ba489d8e9be9587148126cb8843f840376fc09) | `gnatcoll-*: get python binary name from derivation`                 |
| [`bde7dc1f`](https://github.com/NixOS/nixpkgs/commit/bde7dc1f81fe41752af488838fd98845f8be3201) | `gnatcoll-*: 21.0.0 -> 22.0.0`                                       |
| [`7f96c6f0`](https://github.com/NixOS/nixpkgs/commit/7f96c6f0378be9c3c346f6cf3823d54be664dcac) | `gprbuild, gprbuild-boot: 21.0.0 -> 22.0.0`                          |
| [`2458ae6a`](https://github.com/NixOS/nixpkgs/commit/2458ae6a72d0bcfcc453f680c82d3ce18e646128) | `xmlada: 21.0.0 -> 22.0.0`                                           |
| [`debf4fc9`](https://github.com/NixOS/nixpkgs/commit/debf4fc929cc937562b06607c1a3d81f92ee3a77) | `gnat: 9 -> 11`                                                      |
| [`7adb11cf`](https://github.com/NixOS/nixpkgs/commit/7adb11cf580fc75faa864a640f1204e7fb874463) | `fcft: 2.4.5 -> 2.5.0`                                               |
| [`e30f006b`](https://github.com/NixOS/nixpkgs/commit/e30f006b3c6fc9cc8065d43d75b5dc2e70e01023) | `cbqn-standalone: fix installPhase on darwin`                        |
| [`a39908a7`](https://github.com/NixOS/nixpkgs/commit/a39908a7cb0e01c7d3c2f8a9199b14de6209f687) | `chromium: 95.0.4638.69 -> 96.0.4664.45`                             |
| [`d1348091`](https://github.com/NixOS/nixpkgs/commit/d13480917ae9e28b75da3d1f2de66b63d3a30d97) | `strongswan: 5.8.1 -> 5.9.4`                                         |
| [`757d9729`](https://github.com/NixOS/nixpkgs/commit/757d972916277cb3fe33643eb4dadb5eb72be0b6) | `checkov: 2.0.571 -> 2.0.574`                                        |
| [`322808de`](https://github.com/NixOS/nixpkgs/commit/322808de0fd205c64b4eec18491d7069fb94b712) | `electron_14: 14.2.0 -> 14.2.1`                                      |
| [`de1a7566`](https://github.com/NixOS/nixpkgs/commit/de1a7566119877d4cba16d184d0bbf4f1babfc7b) | `electron_15: 15.3.0 -> 15.3.1`                                      |
| [`322841df`](https://github.com/NixOS/nixpkgs/commit/322841df2c69ac87908beb61dc0481deae2cd37e) | `ledger-live-desktop: 2.34.4 -> 2.35.0`                              |
| [`75a643d9`](https://github.com/NixOS/nixpkgs/commit/75a643d9773e5416d48168d88a15689a72ed52fd) | `qownnotes: 21.10.9 -> 21.11.4`                                      |
| [`2a991224`](https://github.com/NixOS/nixpkgs/commit/2a9912242d94a2973f93322d55934caeab23e2d3) | `meslo-lgs-nf: 2020-03-22 -> 2021-09-03`                             |
| [`dcb04673`](https://github.com/NixOS/nixpkgs/commit/dcb04673070a9efe38c45ff4bbf9e3feabc24253) | `ytcc: 2.5.2 -> 2.5.3`                                               |
| [`510cbfbe`](https://github.com/NixOS/nixpkgs/commit/510cbfbec737589d63cf7a5fc9957bfb8d475747) | `typos: 1.2.0 -> 1.3.0`                                              |
| [`0aa439ba`](https://github.com/NixOS/nixpkgs/commit/0aa439baee0284e1a600a6e8cc8829ebdb7d6f1f) | `vimwiki-markdown: 0.3.3 -> 0.4.0`                                   |
| [`09906e56`](https://github.com/NixOS/nixpkgs/commit/09906e5682b7be64e2dae1a1dbd5214b3d8d1710) | `sonobuoy: 0.54.0 -> 0.55.0`                                         |
| [`83f892c5`](https://github.com/NixOS/nixpkgs/commit/83f892c511f0b647302d03af35955ba28d816073) | `nixos/lib: add /usr to pathsNeededForBoot`                          |
| [`fa9958a8`](https://github.com/NixOS/nixpkgs/commit/fa9958a86caf674e20b380619409e5ebf4871ac7) | `python3Packages.nettigo-air-monitor: 1.2.0 -> 1.2.1`                |
| [`82ae7426`](https://github.com/NixOS/nixpkgs/commit/82ae74264c446aa9a82025de0f79fcf1d276bc46) | `python3Packages.frigidaire: 0.16 -> 0.17`                           |
| [`00e6996f`](https://github.com/NixOS/nixpkgs/commit/00e6996f240221a1cbeb8b75312e0f6e4b7fe7f9) | `python3Packages.aiolookin: 0.0.3 -> 0.0.4`                          |
| [`baeb9443`](https://github.com/NixOS/nixpkgs/commit/baeb944384d19a16c9d19bbd124195ab5a0938a7) | `nixos/influxdb2: Add Hyperlink highlight for url.`                  |
| [`65b23a7a`](https://github.com/NixOS/nixpkgs/commit/65b23a7a302d18e609cf84bc5d2eb503eff154b0) | `sqls: 0.2.19 -> 0.2.20`                                             |
| [`827693be`](https://github.com/NixOS/nixpkgs/commit/827693bec4cf758b75dd35993263494cfbb9d6fa) | `python38Packages.kombu: 5.1.0 -> 5.2.1`                             |
| [`04b06658`](https://github.com/NixOS/nixpkgs/commit/04b066581453250ea66a65cd968418b385d11025) | `python38Packages.elasticsearch: 7.15.1 -> 7.15.2`                   |
| [`577451f2`](https://github.com/NixOS/nixpkgs/commit/577451f200653075f459cf90e4619fb7895f2078) | `python38Packages.dropbox: 11.22.0 -> 11.23.0`                       |
| [`0ea26215`](https://github.com/NixOS/nixpkgs/commit/0ea262154a1ed256afd153c8e1749282f2a83e69) | `python38Packages.cupy: 9.5.0 -> 9.6.0`                              |
| [`4b0e5832`](https://github.com/NixOS/nixpkgs/commit/4b0e5832671a7a27a5c969810022fc293291e7a6) | `python38Packages.clustershell: 1.8.3 -> 1.8.4`                      |
| [`ba491568`](https://github.com/NixOS/nixpkgs/commit/ba4915683fb33cb2bc247cfdc6dc1c2a0264fb9d) | `python38Packages.certbot: 1.20.0 -> 1.21.0`                         |
| [`c7703c49`](https://github.com/NixOS/nixpkgs/commit/c7703c49fe7d8214715403d8a530f6d7a8ddfc8a) | `python38Packages.braintree: 4.12.0 -> 4.13.0`                       |
| [`2ff3291e`](https://github.com/NixOS/nixpkgs/commit/2ff3291e0d74e5d2e640fe07c304fe67ca756580) | `pdfarranger: 1.7.1 -> 1.8.0`                                        |
| [`936b6280`](https://github.com/NixOS/nixpkgs/commit/936b6280180ca7b3499008fbcffaf2b968bc6e35) | `libmysofa: 1.2.0 -> 1.2.1`                                          |
| [`574a1d60`](https://github.com/NixOS/nixpkgs/commit/574a1d605a315579b7afa83c36ad2e4f1b5aa12e) | `postgresqlPackages.pg_auto_failover: 1.6.2 -> 1.6.3`                |
| [`aa32ae2e`](https://github.com/NixOS/nixpkgs/commit/aa32ae2e596ca2841a25d13562b6cb5c78c99bc2) | `apr: run tests`                                                     |
| [`4099c1ae`](https://github.com/NixOS/nixpkgs/commit/4099c1aecd683bf7e7ba99aba964f2f8e80b2755) | `apr: backport patch so we can drop iovec hack`                      |
| [`ba6411dd`](https://github.com/NixOS/nixpkgs/commit/ba6411ddcb1749e83053f320eec34f714dbbd41e) | `apr: fix cross`                                                     |
| [`c513f1ed`](https://github.com/NixOS/nixpkgs/commit/c513f1ed91dc29edf0bb0b2b8c9ac7de9f3f5eaf) | `coqPackages.smpl: init`                                             |
| [`d2fc99d7`](https://github.com/NixOS/nixpkgs/commit/d2fc99d70bb85e1f55e262eb4aece7549fd1587b) | `python3Packages.typer: disable failing tests on darwin`             |
| [`4079374c`](https://github.com/NixOS/nixpkgs/commit/4079374c60921b4b903675ad990eedc132934634) | `hpe-ltfs: fix build`                                                |
| [`a1f5a396`](https://github.com/NixOS/nixpkgs/commit/a1f5a396838fde89782d900306e6d8e1f27689c3) | `itk: vtk_7 -> vtk`                                                  |
| [`b3e79d17`](https://github.com/NixOS/nixpkgs/commit/b3e79d17887dfb82b04d7965d69556a115c470c5) | `python3Packages.pyvolumio: 0.1.4 -> 0.1.5`                          |
| [`ab721efe`](https://github.com/NixOS/nixpkgs/commit/ab721efe762fbef98bff2071b288983cf73b5f2e) | `libupnp: 1.14.10 -> 1.14.12`                                        |
| [`7fef1255`](https://github.com/NixOS/nixpkgs/commit/7fef1255d194bebbfc6d0b9adf2f62c30eea2c8f) | `libcouchbase: 3.2.1 -> 3.2.3`                                       |
| [`1595f3bc`](https://github.com/NixOS/nixpkgs/commit/1595f3bcd41f9c8ec92719a7ed0f742e9cf7b8cf) | `interactsh: 0.0.4 -> 0.0.6`                                         |
| [`a21e52fe`](https://github.com/NixOS/nixpkgs/commit/a21e52fe8be150e43b5e720ed90937a9a8a9311c) | `c3d: unstable-2020-10-05 -> unstable-2021-09-14`                    |
| [`9a0e977d`](https://github.com/NixOS/nixpkgs/commit/9a0e977ddf7b24b1276d0a5393c5d09cff5bf93e) | `python38Packages.pycm: 3.2 -> 3.3`                                  |
| [`d07cff5e`](https://github.com/NixOS/nixpkgs/commit/d07cff5e38e29d7618cab0272f972e341e1f1e73) | `python3Packages.threadpoolctl: 2.2.0 -> 3.0.0`                      |