### PR TITLE
chore(flake/inputs/nixpkgs): `6b68d74f` -> `c3660247`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1637048323,
-        "narHash": "sha256-h2m2LuUEbV5pvNjXoWbk2rAaBAQAsf3cvJXS8DGi+Bo=",
+        "lastModified": 1637093575,
+        "narHash": "sha256-rz520P7lhCl7tU9f0KHIWBQvkRiRn6KKfvZ08ahm5OE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6b68d74f036def3d48a23969edfd0fa47f34af3e",
+        "rev": "c3660247776a57e788e848a2b2f20f5d23ef9c91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                     |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`a7ea834b`](https://github.com/NixOS/nixpkgs/commit/a7ea834b1782c0931b47a58db65e3cb6b337a2ad) | `nixos/plex: replace literalExample with literalExpression`                        |
| [`19b22191`](https://github.com/NixOS/nixpkgs/commit/19b22191f7de3d172562f2fdcf1e9be21df23fef) | `vim-utils: better error message if duplicates`                                    |
| [`47a69c64`](https://github.com/NixOS/nixpkgs/commit/47a69c646f8e82658177f21d9d2342a4045456a1) | `qtile: fix qtile check command`                                                   |
| [`194628e4`](https://github.com/NixOS/nixpkgs/commit/194628e4040a59fd7afbbab14074e3f4f74be957) | `zoom-us: 5.8.3.145 -> 5.8.4.210`                                                  |
| [`dbfd2672`](https://github.com/NixOS/nixpkgs/commit/dbfd26724defe3f8a63431e0fe1bf6955cc2f44f) | `doc: add ocaml end user doc to nixpkgs manual (#145100)`                          |
| [`ab054f8f`](https://github.com/NixOS/nixpkgs/commit/ab054f8fdb3258d5b97edf3c5ca699b5d71714cd) | `steamPackages: make customisable`                                                 |
| [`e1bfb41f`](https://github.com/NixOS/nixpkgs/commit/e1bfb41f6ced583f73a3242226a739385a47fa8e) | `corectrl: 1.1.4 -> 1.2.2`                                                         |
| [`6c2f6a21`](https://github.com/NixOS/nixpkgs/commit/6c2f6a21ed354628adffae407340472fa245ef2d) | `commitizen: 4.2.1 -> 4.2.4`                                                       |
| [`37fa1e7c`](https://github.com/NixOS/nixpkgs/commit/37fa1e7c1d412b26152fc30e087c038685b32756) | `treewide: pass and inherit writeShellScript in node2nix packages`                 |
| [`5913fdbd`](https://github.com/NixOS/nixpkgs/commit/5913fdbd0bf1a77811f262df1af3f3dc1b6e44df) | `github-runner: Update dependencies`                                               |
| [`9a1ee525`](https://github.com/NixOS/nixpkgs/commit/9a1ee5250a8360eed7c70cfb9aac2844db48a41e) | `alttpr-opentracker: Update dependencies`                                          |
| [`80cf9cd7`](https://github.com/NixOS/nixpkgs/commit/80cf9cd7eebe29b8ff6edc6ba3f92d0a926b2050) | `eventstore: Fix create-deps.sh script and update dependencies`                    |
| [`be738c15`](https://github.com/NixOS/nixpkgs/commit/be738c1590c44dfd5b7ade05384126fc69884ef0) | `python-language-server: Update dependencies`                                      |
| [`8f256170`](https://github.com/NixOS/nixpkgs/commit/8f256170e4fc9688d6cf7a1bbceb547344a3bba0) | `wasabibackend: Update dependencies`                                               |
| [`caea8212`](https://github.com/NixOS/nixpkgs/commit/caea8212dacf8f670a945f45576227d05847139e) | `wasabibackend: Use nixpkgs-fmt instead of nixfmt`                                 |
| [`b3d87e4b`](https://github.com/NixOS/nixpkgs/commit/b3d87e4b17ac98917383232d1885f5f6ab2599fa) | `discordchatexporter-cli: Update dependencies`                                     |
| [`f201ba1b`](https://github.com/NixOS/nixpkgs/commit/f201ba1bbd57e84adda87477173181624fae3f5c) | `osu-lazer: Update dependencies`                                                   |
| [`57ed744c`](https://github.com/NixOS/nixpkgs/commit/57ed744c0597e408f5ad8661dd06b8e436009511) | `roslyn: Update dependencies`                                                      |
| [`79dc6a56`](https://github.com/NixOS/nixpkgs/commit/79dc6a56292eb20676a07980528969ffcffcf340) | `nixos/hbase: use jre8 instead of latest.`                                         |
| [`1b2a061c`](https://github.com/NixOS/nixpkgs/commit/1b2a061c87fd079f57a05c5390a42dcc777498f0) | `gnome.gedit: fix typelib path`                                                    |
| [`b464f057`](https://github.com/NixOS/nixpkgs/commit/b464f0573e4e67978ed00a4bbab567a9bd08fc3c) | `ocamlPackages.sodium: build on later OCaml versions`                              |
| [`916b2543`](https://github.com/NixOS/nixpkgs/commit/916b25435fb22be405f25b20b793f1b2ac57a390) | `docopts: 0.6.3 -> 0.6.4`                                                          |
| [`88355320`](https://github.com/NixOS/nixpkgs/commit/883553209927dcc88158e810e9adc3dfeb0195bd) | `exploitdb: 2021-11-13 -> 2021-11-16`                                              |
| [`c0066eb9`](https://github.com/NixOS/nixpkgs/commit/c0066eb9cd2bdd3acbaba230b20d936ccb82918b) | `python3Packages.pyp: add pythonImportsCheck`                                      |
| [`659392fe`](https://github.com/NixOS/nixpkgs/commit/659392fe20a5582cc118b0072099a95a7f0689c6) | `python3Packages.ntc-templates: switch to use pythonOlder`                         |
| [`714665cf`](https://github.com/NixOS/nixpkgs/commit/714665cf9548bfb4f4dfcf3baa274ea78e6d7138) | `ocamlPackages.pythonlib: init at 0.14.0`                                          |
| [`f27f14bd`](https://github.com/NixOS/nixpkgs/commit/f27f14bd7a42e6e38ca14a81be52094d8cf23c6d) | `ocamlPackages.ppx_python: init at 0.14.0`                                         |
| [`6abc7cd9`](https://github.com/NixOS/nixpkgs/commit/6abc7cd907ea06424e7963e949cf554a6b3914c2) | `bluez: 5.61 -> 5.62`                                                              |
| [`708666dc`](https://github.com/NixOS/nixpkgs/commit/708666dcb6a5339a02c9e9fb5c78ae350b3b54bb) | `nodePackages: update package set`                                                 |
| [`86d5dd09`](https://github.com/NixOS/nixpkgs/commit/86d5dd09f1ba96f82bf4f3a1eb4cd7881520a025) | `ryujinx: Update dependencies`                                                     |
| [`c94cfb48`](https://github.com/NixOS/nixpkgs/commit/c94cfb48dfae36f447a2334e0e5aa1d21a684adb) | `dotnetCorePackages.*_5*: 5.0.10 -> 5.0.12`                                        |
| [`a018a794`](https://github.com/NixOS/nixpkgs/commit/a018a794deff4ae9cd4b2e0a21433bd57b0b3eb2) | `dotnetCorePackages:*_3_1: 3.1.19 -> 3.1.21`                                       |
| [`0f7a65dc`](https://github.com/NixOS/nixpkgs/commit/0f7a65dcbe9878d93ab1407ce6cf58d00c5c41bb) | `python3Packages.zfec: add pythonImportsCheck`                                     |
| [`0d3fcab2`](https://github.com/NixOS/nixpkgs/commit/0d3fcab2a0611ec88ee69e9702c85ef37bc5a923) | `blocksat-cli: 0.4.0 -> 0.4.1`                                                     |
| [`d8b840f9`](https://github.com/NixOS/nixpkgs/commit/d8b840f9544227513666b38db7f3abf0b4220a2e) | `visidata: 2.7 -> 2.7.1`                                                           |
| [`867e614f`](https://github.com/NixOS/nixpkgs/commit/867e614f97623ed7d75857fc9e4cfde19b206e89) | `nodePackages.node2nix: backport patch to reduce derivation size`                  |
| [`09cab632`](https://github.com/NixOS/nixpkgs/commit/09cab6323b5de0f06344e8cad03e4ccc2a869059) | `home-assistant: 2021.11.3 -> 2021.11.4`                                           |
| [`a153ef57`](https://github.com/NixOS/nixpkgs/commit/a153ef57e0a36f5fc908ab0e7d65f0fb4ac667d4) | `vaultwarden: fix the build for rustc 1.56`                                        |
| [`6ece9b66`](https://github.com/NixOS/nixpkgs/commit/6ece9b660d50afcd03bc251007655f72601351b4) | `python3Packages.pytibber: 0.20.0 -> 0.21.0`                                       |
| [`79c28d61`](https://github.com/NixOS/nixpkgs/commit/79c28d614deabbb49d3a9fa5fa3b20c19bde6c4a) | `roon-server: add alsa-lib to LD_LIBRARY_PATH`                                     |
| [`e0c6f91e`](https://github.com/NixOS/nixpkgs/commit/e0c6f91e6d855b49df94892ff4c831ea9bd67884) | `bpb: fix build on darwin`                                                         |
| [`519f1c78`](https://github.com/NixOS/nixpkgs/commit/519f1c78ace5156288eb09a35acd3da8cbbb31d0) | `mongodb-tools: add bryanasdev000 as maintainer`                                   |
| [`19badcf7`](https://github.com/NixOS/nixpkgs/commit/19badcf76fab26e58fcaf856a3e5b78516a309a6) | `mongodb-tools: 4.2.0 -> 100.5.1`                                                  |
| [`f726b6c4`](https://github.com/NixOS/nixpkgs/commit/f726b6c47689da09e664c173557a53e4467963c9) | `linux-rt_5_11: remove`                                                            |
| [`c783c8d8`](https://github.com/NixOS/nixpkgs/commit/c783c8d8594ad43402f4a9a4bacf148381d0baa7) | `linux/hardened/patches/5.15: init at 5.15.2-hardened1`                            |
| [`db13d848`](https://github.com/NixOS/nixpkgs/commit/db13d848fcd2e4f74a00c2de1f1cd8178cc25e33) | `linux/hardened/patches/5.4: 5.4.158-hardened1 -> 5.4.159-hardened1`               |
| [`b868e782`](https://github.com/NixOS/nixpkgs/commit/b868e782821ca7419ca2e27928faecb2501c7433) | `linux/hardened/patches/5.14: 5.14.17-hardened1 -> 5.14.18-hardened1`              |
| [`57d9fd17`](https://github.com/NixOS/nixpkgs/commit/57d9fd1791d6f053e8e5e28732807642fc6b07d6) | `linux/hardened/patches/4.19: 4.19.216-hardened1 -> 4.19.217-hardened1`            |
| [`9b6fb581`](https://github.com/NixOS/nixpkgs/commit/9b6fb581af5d352889b2cdccfe896fd7504cff2c) | `linux/hardened/patches/4.14: 4.14.254-hardened1 -> 4.14.255-hardened1`            |
| [`38d1f15f`](https://github.com/NixOS/nixpkgs/commit/38d1f15fe4d31d4da045b0bc89fadf89a8ecf17e) | `linux-rt_5_10: 5.10.73-rt54 -> 5.10.78-rt55`                                      |
| [`f74c838d`](https://github.com/NixOS/nixpkgs/commit/f74c838dbff7c8e508513af86c6e640aaa481eb0) | `ceph-client: install sbin binaries into bin, link sbin to bin`                    |
| [`54523e57`](https://github.com/NixOS/nixpkgs/commit/54523e57b4a20f6fc814469eb29d7dd8343cb043) | `you-get: install completions`                                                     |
| [`42f9ae29`](https://github.com/NixOS/nixpkgs/commit/42f9ae293426c44a4a58f528670b1d92c3028c2b) | `you-get: 0.4.1545 -> 0.4.1555`                                                    |
| [`383cef41`](https://github.com/NixOS/nixpkgs/commit/383cef41ed7fa97078e06c390c2abce0b5673313) | `tea: 0.7.1 -> 0.8.0`                                                              |
| [`e5139adb`](https://github.com/NixOS/nixpkgs/commit/e5139adbdfc0a7053130521c30b84002955fe59b) | `todoman: enable on darwin`                                                        |
| [`4bb0051f`](https://github.com/NixOS/nixpkgs/commit/4bb0051feac526096a390d3ae5679043b0a37441) | `todoman: 4.0.0 -> 4.0.1`                                                          |
| [`f95c6d61`](https://github.com/NixOS/nixpkgs/commit/f95c6d611200153e73bac4a4b4c91fa2d45b3709) | `ceph-client: fix copy of python modules`                                          |
| [`acdc53e9`](https://github.com/NixOS/nixpkgs/commit/acdc53e9f62a82fccff541ba12ab0916a44dd942) | `python38Packages.statsmodels: 0.13.0 -> 0.13.1`                                   |
| [`d30e64af`](https://github.com/NixOS/nixpkgs/commit/d30e64af0203999b7d4a2f2d7ea5ebdc324bf6eb) | `python38Packages.rebulk: 3.0.1 -> 3.1.0`                                          |
| [`5971d296`](https://github.com/NixOS/nixpkgs/commit/5971d29609aef0fdaac9753b05c929d711dc03ad) | `terraform-providers.cloudflare: 2.23.0 -> 3.4.0`                                  |
| [`94b137c8`](https://github.com/NixOS/nixpkgs/commit/94b137c851ba7b26d159d6b6f78c9849014739c8) | `python38Packages.pypresence: 4.2.0 -> 4.2.1`                                      |
| [`fee52c1b`](https://github.com/NixOS/nixpkgs/commit/fee52c1bec3fef9b6d16f46afead438212885d01) | `python38Packages.pyp: 0.3.4 -> 1.0.0`                                             |
| [`15b7fa76`](https://github.com/NixOS/nixpkgs/commit/15b7fa76711e138058fb77206b3c718e0631c16b) | `python39Packages.normality: 2.1.3 -> 2.2.5`                                       |
| [`6b23ea33`](https://github.com/NixOS/nixpkgs/commit/6b23ea33ec800e54659715f7ec5ab3235b1cbdd2) | `gemget: init at 1.8.0`                                                            |
| [`cd05ebec`](https://github.com/NixOS/nixpkgs/commit/cd05ebecfbd1baf4ce4796dc6fb9e9ad6e820008) | `maintainers: add amfl`                                                            |
| [`d73349bf`](https://github.com/NixOS/nixpkgs/commit/d73349bff0767392af829eedd85c6de3cbd4b498) | `python38Packages.pdfkit: 0.6.1 -> 1.0.0`                                          |
| [`b004c68f`](https://github.com/NixOS/nixpkgs/commit/b004c68f5698fc255a6f1df3d2fd76d24c432ed6) | `python38Packages.ntc-templates: 2.3.2 -> 3.0.0`                                   |
| [`7cca1778`](https://github.com/NixOS/nixpkgs/commit/7cca177876ea4e9668e64dfe192b000ea303c727) | `python38Packages.multitasking: 0.0.9 -> 0.0.10`                                   |
| [`a53521b5`](https://github.com/NixOS/nixpkgs/commit/a53521b536daa74fe4f52549d65eb8715ff843b7) | `python38Packages.mne-python: 0.23.4 -> 0.24.0`                                    |
| [`bf78db4e`](https://github.com/NixOS/nixpkgs/commit/bf78db4e39853cbcc7391a3258d144d6bae50c9a) | `python38Packages.libcloud: 3.3.1 -> 3.4.0`                                        |
| [`eb7e0ba2`](https://github.com/NixOS/nixpkgs/commit/eb7e0ba2578eb94622ecffe5b6142edcc9a8bfc0) | `python38Packages.ibm-cloud-sdk-core: 3.12.0 -> 3.13.0`                            |
| [`2df1f026`](https://github.com/NixOS/nixpkgs/commit/2df1f0268bac7e7da859d1c01db902736f2cd975) | `python3Packages.django: remove lsix from maintainers`                             |
| [`c870679a`](https://github.com/NixOS/nixpkgs/commit/c870679a00963a48daf27821c96753f642284ff8) | `python38Packages.cogapp: 3.1.0 -> 3.2.0`                                          |
| [`a2a7a3eb`](https://github.com/NixOS/nixpkgs/commit/a2a7a3eba7d4390650c99594577e208c8faef995) | `python3Packages.vehicle: init at 0.2.0`                                           |
| [`a00663e7`](https://github.com/NixOS/nixpkgs/commit/a00663e737e861bcc719127adcf4c28a7edb3027) | `python38Packages.asyncssh: 2.8.0 -> 2.8.1`                                        |
| [`6a6cd8cb`](https://github.com/NixOS/nixpkgs/commit/6a6cd8cb50723d17a9d710923443f03dd8932468) | `zncModules.clientbuffer: 2020-04-24 -> 2021-05-30`                                |
| [`5c8408f4`](https://github.com/NixOS/nixpkgs/commit/5c8408f4ae4254c668fc3b4426603f6df6882258) | `python3Packages.colorlog: 6.5.0 -> 6.6.0`                                         |
| [`4d8d026e`](https://github.com/NixOS/nixpkgs/commit/4d8d026e15e2aec296bc4e16b853116dbad78301) | `python3Packages.torchaudio-bin: init at 0.10.0`                                   |
| [`2b77566c`](https://github.com/NixOS/nixpkgs/commit/2b77566cb6eb29bbdc6c37fc8072b8457b2148e1) | `crystal: 1.2.1 → 1.2.2`                                                           |
| [`17c61e97`](https://github.com/NixOS/nixpkgs/commit/17c61e97723ef2b10b60fd497b0e4eebe3b8655c) | `nixos/swap: remove fallocate and use dd as the main swap creation method`         |
| [`51e95616`](https://github.com/NixOS/nixpkgs/commit/51e95616d729f46221728c8a8bce250d08968884) | `selinux-python: fix cross; strict deps`                                           |
| [`86e057aa`](https://github.com/NixOS/nixpkgs/commit/86e057aa5b6b44aa20b65ed194ec359e897bd89d) | `zfs: unlock for 5.15`                                                             |
| [`8f5073b5`](https://github.com/NixOS/nixpkgs/commit/8f5073b59e731e8fbb2fa363f674669b714e222f) | `update formatting`                                                                |
| [`bd084e9b`](https://github.com/NixOS/nixpkgs/commit/bd084e9b2a40e654c5303740ff7735405349f5be) | `godot: 3.3.4 -> 3.4`                                                              |
| [`c28ad410`](https://github.com/NixOS/nixpkgs/commit/c28ad410499b1a6f3c1d4267103f470c875cdd91) | `godot: 3.3.3 -> 3.3.4`                                                            |
| [`6599cb61`](https://github.com/NixOS/nixpkgs/commit/6599cb61aaa00e4b97c2ffcae0898821995f6460) | `python3Packages.manticore: 0.3.5 -> 0.3.6`                                        |
| [`d03e760c`](https://github.com/NixOS/nixpkgs/commit/d03e760ce9d58ffe90645aef3860e643689afe30) | `python3Packages.torchvision-bin: 0.10.1 -> 0.11.1`                                |
| [`207b16af`](https://github.com/NixOS/nixpkgs/commit/207b16af90cda99f640a75f64a6e16b755a44062) | `python3Packages.pytorch-bin: 1.9.1 -> 1.10.0`                                     |
| [`14c30c85`](https://github.com/NixOS/nixpkgs/commit/14c30c8521a8c39a751a84e6df7075537dedfbb0) | `libtorch-bin: 1.9.0 -> 1.10.0`                                                    |
| [`cb737c9e`](https://github.com/NixOS/nixpkgs/commit/cb737c9edb4082bab9606c360e90835f205184d9) | `python3Packages.qiling: 1.3.0 -> 1.4.0`                                           |
| [`a402f9c9`](https://github.com/NixOS/nixpkgs/commit/a402f9c9ea1f9c57bc6a8f2177a450b2fb767bf7) | `unicorn: 1.0.3 -> 2.0.0-rc4`                                                      |
| [`1802e188`](https://github.com/NixOS/nixpkgs/commit/1802e1888ba7b12a0d7554775bcc7d5fecb50742) | `python3Packages.unicorn: add pythonImportsCheck`                                  |
| [`1070be5f`](https://github.com/NixOS/nixpkgs/commit/1070be5fe43fdda1b185c55f51457a7710bd7337) | `python3Packages.multiprocess: 0.10.9 -> 0.70.12.2`                                |
| [`15db0902`](https://github.com/NixOS/nixpkgs/commit/15db090295ab8f7fa147eddd955ef1172fc4c694) | `dotnet: make SDK 6.0 default`                                                     |
| [`2bcc4707`](https://github.com/NixOS/nixpkgs/commit/2bcc4707e86f791167f78784e5ecba218a99218d) | `dotnet: introduce print-hashes script`                                            |
| [`985f9def`](https://github.com/NixOS/nixpkgs/commit/985f9deff25f1706371c8088af98842699266661) | `python38Packages.PyICU: update meta`                                              |
| [`a49ccd5d`](https://github.com/NixOS/nixpkgs/commit/a49ccd5da64e21c9e6a6cc65345dc369619a3c4c) | `python38Packages.PyICU: unpin icu`                                                |
| [`5eb14c27`](https://github.com/NixOS/nixpkgs/commit/5eb14c27a6cb58d5985d0ec97ccde0e1588b7406) | `python38Packages.PyICU: 2.7.4 -> 2.8`                                             |
| [`83fa3d7c`](https://github.com/NixOS/nixpkgs/commit/83fa3d7c121a31168be07652b32a633380fd0ef6) | `openseachest: init at 21.06.21`                                                   |
| [`05f41aed`](https://github.com/NixOS/nixpkgs/commit/05f41aedbbd9586c54587b5b67c5b5660f370944) | `pounce: 2.5 -> 3.0`                                                               |
| [`096c956e`](https://github.com/NixOS/nixpkgs/commit/096c956ef7325a2f86207bae9ddf0d190fecbcf5) | `q4wine: init at 1.3.13`                                                           |
| [`20515812`](https://github.com/NixOS/nixpkgs/commit/205158124a6227cbe2dcc72065e31370af0bfaf9) | `python3Packages.hidapi: 0.10.1 -> 0.11.0.post2`                                   |
| [`a28064c9`](https://github.com/NixOS/nixpkgs/commit/a28064c96ca867c36e8710293362937ce8a9832f) | `fossil: 2.16 -> 2.17`                                                             |
| [`ac117c51`](https://github.com/NixOS/nixpkgs/commit/ac117c51694b41972226572be41bdee7c27882cf) | `awslimitchecker: init at 12.0.0`                                                  |
| [`5d9bd045`](https://github.com/NixOS/nixpkgs/commit/5d9bd0452fa643f6d1879eb9f231d46f350fbbd4) | `init: libbde at 20210605`                                                         |
| [`a2c05368`](https://github.com/NixOS/nixpkgs/commit/a2c053689474ee80198f07b5b4f29106dd44a408) | `apacheHttpd: add proxy and php nixos tests to passthru.tests`                     |
| [`01a85ce4`](https://github.com/NixOS/nixpkgs/commit/01a85ce48b156973cb0aa9f5a898a6975d20b1cf) | `kcat(previously kafkacat): 1.6.0 -> 1.7.0`                                        |
| [`b649af00`](https://github.com/NixOS/nixpkgs/commit/b649af00fb983698c999c49236f81b25093eee64) | `cmark: 0.30.1 -> 0.30.2`                                                          |
| [`4de6574f`](https://github.com/NixOS/nixpkgs/commit/4de6574fb8d6289dc4960272e1e03482267995e0) | `kissat: init at 2.0.1`                                                            |
| [`ef9b3aea`](https://github.com/NixOS/nixpkgs/commit/ef9b3aea0836de44f26f8ece966d13a006fda1f0) | ` plex: add support for custom scanners`                                           |
| [`fda25f88`](https://github.com/NixOS/nixpkgs/commit/fda25f88d238899ecdc2b195e00855db24b761b7) | `vimpager: supply runtimeShell to Makefile`                                        |
| [`e7996ab6`](https://github.com/NixOS/nixpkgs/commit/e7996ab6cef26b3885ee0d337bcbd7de75c2988f) | `nixos/modules/hardware/video/nvidia: Fix incorrect reference to 'nvidiaSettings'` |