### PR TITLE
chore(flake/inputs/nixos-hardware): `4045d5f4` -> `ad0b7c5a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -77,11 +77,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1636877509,
-        "narHash": "sha256-0c2fnIlpNqcgxg8JK6Qa3iY4r93MFn2TQ4/3y9W5B7g=",
+        "lastModified": 1637170060,
+        "narHash": "sha256-He3CaRefpj9VctY9NMqyYc8blkrJK7AIj7z8YBxohq4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "4045d5f43aff4440661d8912fc6e373188d15b5b",
+        "rev": "ad0b7c5a9585f1b622560ab1a90b562a6ac45e18",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                              |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`5190a9b4`](https://github.com/NixOS/nixos-hardware/commit/5190a9b4f21f4de28a396c1a214c1fef92c4d256) | `fix(intel): add opengl packages for 32bit` |