### PR TITLE
chore(flake/inputs/nixpkgs): `c3660247` -> `92377ca5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1637093575,
-        "narHash": "sha256-rz520P7lhCl7tU9f0KHIWBQvkRiRn6KKfvZ08ahm5OE=",
+        "lastModified": 1637170361,
+        "narHash": "sha256-t/wz7zOLxdAfyACR0R0iLWAGkAJerZP3ywEHO27HKz8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c3660247776a57e788e848a2b2f20f5d23ef9c91",
+        "rev": "92377ca569ee7d09c3ff74d5bfecee63b0d7e447",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
| [`34b47c5c`](https://github.com/NixOS/nixpkgs/commit/34b47c5c684af5a3975cf07cd063733fd47f1f32) | `dune-release: 1.5.0 -> 1.5.2`                                                                                     |
| [`a128f8d8`](https://github.com/NixOS/nixpkgs/commit/a128f8d8c13ac8ed19a65311df95a2f6a846e883) | `python3Packages.python-gammu: 3.2.3 -> 3.2.4`                                                                     |
| [`ed312a68`](https://github.com/NixOS/nixpkgs/commit/ed312a6815989da895985dce90bc20bf12f9c471) | `nixos/xmrig: add services.xmrig to module-list.nix`                                                               |
| [`f1941733`](https://github.com/NixOS/nixpkgs/commit/f1941733a97713e5a3f9b8e5ade2e79c58e0e8fd) | `emacs.pkgs.melpa-packages: 2021-11-17`                                                                            |
| [`cd75f6b2`](https://github.com/NixOS/nixpkgs/commit/cd75f6b2378fd60d69580073fd7567437bc8065e) | `mautrix*: update src`                                                                                             |
| [`cc9e0c77`](https://github.com/NixOS/nixpkgs/commit/cc9e0c77cbb7d46203a123f5a09f73cf15e63477) | `diffoscope: 190 -> 192`                                                                                           |
| [`7a5f0ec2`](https://github.com/NixOS/nixpkgs/commit/7a5f0ec2d11cd715acb05d4634e8d28c17811c75) | `R: fix build on Darwin`                                                                                           |
| [`86db5fef`](https://github.com/NixOS/nixpkgs/commit/86db5fef7bfdfaca6055b1242a7265ab4436b11f) | `mariadb: fix darwin build`                                                                                        |
| [`6253ab08`](https://github.com/NixOS/nixpkgs/commit/6253ab088a212aefd8ead666241b051e48bf2aaa) | `mariadb: revert to using fetchurl`                                                                                |
| [`bc5a610c`](https://github.com/NixOS/nixpkgs/commit/bc5a610cb7a08494d1dffd01c07e59833ce27d7b) | `nixos-rebuild: fix --install-bootloader`                                                                          |
| [`c138eff3`](https://github.com/NixOS/nixpkgs/commit/c138eff31574ff1b89ffd5132af7df30c0bfaa4a) | `unicorn: fix darwin build (#146346)`                                                                              |
| [`7eea3303`](https://github.com/NixOS/nixpkgs/commit/7eea33031892aa63f4c7b66912d486bfb97c9148) | `gildas: 20200901_a -> 20211101_a (#146224)`                                                                       |
| [`e8328148`](https://github.com/NixOS/nixpkgs/commit/e8328148cd446452b51971b796649fd88e2499a4) | `linuxKernel.kernels.linux_xanmod: 5.14.16 -> 5.15.2`                                                              |
| [`2284d771`](https://github.com/NixOS/nixpkgs/commit/2284d771dba1b1ca96059ae9d28effe2da5a13c3) | `Revert "vimPlugins: update"`                                                                                      |
| [`bbc5740d`](https://github.com/NixOS/nixpkgs/commit/bbc5740dd5feab41a5ecc6f4e2c27ccb04860d88) | `Revert "vimPlugins: update"`                                                                                      |
| [`4097dadc`](https://github.com/NixOS/nixpkgs/commit/4097dadcd928b65e0f32dd34ea17088c922d052f) | `lscolors: 0.8.0 -> 0.8.1`                                                                                         |
| [`5f757db9`](https://github.com/NixOS/nixpkgs/commit/5f757db908b32749c8ca291a728c58e9113228d3) | `python3Packages.explorerscript: fix build with renamed python-igraph`                                             |
| [`009c51b5`](https://github.com/NixOS/nixpkgs/commit/009c51b5aec69dd46e8941156f4fdf8f2dfcbb55) | `menyoki: fix darwin build`                                                                                        |
| [`89c5f3b8`](https://github.com/NixOS/nixpkgs/commit/89c5f3b8e4492fb6a54e8463f9abd469943fcbea) | `logseq: fix hash`                                                                                                 |
| [`a0d2a3ef`](https://github.com/NixOS/nixpkgs/commit/a0d2a3efbb4013894c771855d2cc4c28bf0fb168) | `nixos/locate: ignore nix logs`                                                                                    |
| [`2b46936e`](https://github.com/NixOS/nixpkgs/commit/2b46936e9c167b420f1aee7edbb24bb596e455d0) | `cbftp: fix build on darwin`                                                                                       |
| [`ef1a0dab`](https://github.com/NixOS/nixpkgs/commit/ef1a0dab00af56bf99d248143a9518826d943d80) | `cardpeek: fix build on darwin`                                                                                    |
| [`a63f9e1c`](https://github.com/NixOS/nixpkgs/commit/a63f9e1ca11bb1d795e89d3c41b0c5141f198b1a) | `vscode-extensions.update_installed_exts.sh: add function how to use the output with vscode, make shellcheck work` |
| [`12371f83`](https://github.com/NixOS/nixpkgs/commit/12371f83b1e2e8b398116d4fa4af9b33f4401ffd) | `python39Packages.tensorflow: simplify pname+version code`                                                         |
| [`eeac1c54`](https://github.com/NixOS/nixpkgs/commit/eeac1c543d398f167f8886883824fc99266aad40) | `nixos/networkd: add BatmanAdvanced options (#145963)`                                                             |
| [`ba5628c2`](https://github.com/NixOS/nixpkgs/commit/ba5628c2ab923b9f1ecbf1bc44dabd3664fad16a) | `seexpr: fmt`                                                                                                      |
| [`7c26a808`](https://github.com/NixOS/nixpkgs/commit/7c26a808993b8c47dfb638ec6110e073f42ca3d6) | `seexpr: 2.11 -> 3.0.1`                                                                                            |
| [`b8df591e`](https://github.com/NixOS/nixpkgs/commit/b8df591eb67c55e9c80fda3ba705a7d86c341c7e) | `zfs: remove myself as maintainer`                                                                                 |
| [`92266127`](https://github.com/NixOS/nixpkgs/commit/922661273c38d8fe34a8b2abf6b8d49b32d7c3ec) | `beret: remove`                                                                                                    |
| [`d9673a6e`](https://github.com/NixOS/nixpkgs/commit/d9673a6e90fec6ae772fef5f5dfad03fc9725561) | `mongodb-compass: 1.25.0 -> 1.29.4`                                                                                |
| [`28289f34`](https://github.com/NixOS/nixpkgs/commit/28289f34ece9ba0cd1524b6f3f84fff4f09e3d35) | `Revert "zfs: unlock for 5.15"`                                                                                    |
| [`f12614d4`](https://github.com/NixOS/nixpkgs/commit/f12614d43b93c95e09597620b339f991b91f3b4c) | `cargo-outdated: 0.9.18 -> 0.10.1`                                                                                 |
| [`30c56e2e`](https://github.com/NixOS/nixpkgs/commit/30c56e2e10046e255050d7b4b8c07b3b5f1f368a) | `coq-bits: 1.0.0 -> 1.1.0`                                                                                         |
| [`f5e6bb8c`](https://github.com/NixOS/nixpkgs/commit/f5e6bb8c7542ee9cdbd180ab5a566afa24b2848b) | `chromiumDev: 97.0.4692.8 -> 97.0.4692.20`                                                                         |
| [`75b64552`](https://github.com/NixOS/nixpkgs/commit/75b645529450fd4bac3b897dc1fab1701ade3465) | `zerotierone: 1.8.2 -> 1.8.3 (#146293)`                                                                            |
| [`4d5800ed`](https://github.com/NixOS/nixpkgs/commit/4d5800ed103555675b600b9688c1733df6bf1e51) | `imagemagick: 7.1.0-13 -> 7.1.0-14`                                                                                |
| [`62d48440`](https://github.com/NixOS/nixpkgs/commit/62d48440a1d4020c615c4462c3c40bde07484f71) | `python3Packages.libcloud: 3.4.0 -> 3.4.1`                                                                         |
| [`c46f9c42`](https://github.com/NixOS/nixpkgs/commit/c46f9c42b8f0508bfccd96a75e7ff4ad920d594e) | `python39Packages.tensorflow: remove ? null from inputs`                                                           |
| [`d882c575`](https://github.com/NixOS/nixpkgs/commit/d882c5751b5f0a06b60c56a468f76b54aaac04aa) | `flutter: add passthru.dart`                                                                                       |
| [`ad1d0fb7`](https://github.com/NixOS/nixpkgs/commit/ad1d0fb77219394407f81a075d4ef789538c2328) | `python3Packages.atomman: 1.3.0 -> 1.4.2`                                                                          |
| [`c408cd92`](https://github.com/NixOS/nixpkgs/commit/c408cd921f8681df1eb813a8692ed740dacfe2d4) | `nixos/nginx: fix SystemCallFilter after 1fc113f0df6e83c9dc3e5110ae7706772f21ba68`                                 |
| [`115e6e72`](https://github.com/NixOS/nixpkgs/commit/115e6e7299bd52b84fe4dc5315ef5758274b8b61) | `nixos/profiles/minimal: disable command-not-found`                                                                |
| [`e6feb740`](https://github.com/NixOS/nixpkgs/commit/e6feb74002f5ae542e4a09cf04e04a2f24d8dd89) | `python3Packages.potentials: init at 0.3.1`                                                                        |
| [`1fc113f0`](https://github.com/NixOS/nixpkgs/commit/1fc113f0df6e83c9dc3e5110ae7706772f21ba68) | `nginxStable: 1.20.1 -> 1.20.2`                                                                                    |
| [`3be80d16`](https://github.com/NixOS/nixpkgs/commit/3be80d16192b9b1a9c6853e2d2387015914c0858) | `mssql-jdbc: remove build.sh`                                                                                      |
| [`04a4175f`](https://github.com/NixOS/nixpkgs/commit/04a4175ff7e6a3802d050c8d7c1d7695863c7f87) | `tomcat-mysql-jdbc: remove build.sh`                                                                               |
| [`10e1f32e`](https://github.com/NixOS/nixpkgs/commit/10e1f32e5a3369730c7e59ce17ca70004d8eab42) | `python3Packages.cdcs: init at 0.1.5`                                                                              |
| [`bde93173`](https://github.com/NixOS/nixpkgs/commit/bde93173ddc6d213dbb52be3fdd20bb244b809b5) | `mockobjects: remove builder.sh`                                                                                   |
| [`826d4ab0`](https://github.com/NixOS/nixpkgs/commit/826d4ab03aa6e6eded3160be800bb77d9053d00c) | `smack: remove builder.sh`                                                                                         |
| [`0e9320dc`](https://github.com/NixOS/nixpkgs/commit/0e9320dc5f2cf9914711ff44f1251a4c7bd0d30b) | `cargo-deny: use buildNoDefaultFeatures`                                                                           |
| [`104fd240`](https://github.com/NixOS/nixpkgs/commit/104fd24044e93a8b6dfd908efd14851c080ed524) | `menyoki: use buildNoDefaultFeatures`                                                                              |
| [`94e7e214`](https://github.com/NixOS/nixpkgs/commit/94e7e21452ca8138f21f28a54802ca0929742477) | `lucky-commit: use buildNoDefaultFeatures`                                                                         |
| [`6189ca3a`](https://github.com/NixOS/nixpkgs/commit/6189ca3ad4bda88fbb392684f569c1b505a09de9) | `selene: use buildNoDefaultFeatures`                                                                               |
| [`b356c370`](https://github.com/NixOS/nixpkgs/commit/b356c37023a7015133fd0746f51b9b470338bc4b) | `vaultwarden: use buildFeatures`                                                                                   |
| [`84361e0a`](https://github.com/NixOS/nixpkgs/commit/84361e0a989a23acc9a80fa0ef4b66558cdba02f) | `bore: use checkFeatures`                                                                                          |
| [`478acf78`](https://github.com/NixOS/nixpkgs/commit/478acf788b629118d1272e0da21888cfe6df96fa) | `rust-analyzer: use buildFeature`                                                                                  |
| [`009c1d5b`](https://github.com/NixOS/nixpkgs/commit/009c1d5b6d8f88faded1d6962d9661dc67cee61c) | `nushell: use buildFeatures`                                                                                       |
| [`314d6b8c`](https://github.com/NixOS/nixpkgs/commit/314d6b8c35145945bf6055e43a0e73282141b381) | `rustup: use buildFeatures`                                                                                        |
| [`fdf41bea`](https://github.com/NixOS/nixpkgs/commit/fdf41beab13b969e2feb18fd29a04bfa4c4f7a5f) | `diesel-cli: use buildFeatures`                                                                                    |
| [`bd60edf4`](https://github.com/NixOS/nixpkgs/commit/bd60edf470b4a759e530778072b198ed2e3eab58) | `regenkfs: use buildFeatures`                                                                                      |
| [`b73c22c5`](https://github.com/NixOS/nixpkgs/commit/b73c22c5372c89ab0763b251aa6f3e3561df5674) | `tokei: use buildFeatures`                                                                                         |
| [`231a2134`](https://github.com/NixOS/nixpkgs/commit/231a2134c0ffb7c481c850a66418332b9231a290) | `stylua: use buildFeatures`                                                                                        |
| [`5a1b5f86`](https://github.com/NixOS/nixpkgs/commit/5a1b5f86d5814d095d8dbc5f04ebbc1f133a9ab6) | `sccache: use buildFeatures`                                                                                       |
| [`b43d7009`](https://github.com/NixOS/nixpkgs/commit/b43d700922b7257cf87235a762f4a4b9cb023e1f) | `cargo-embed: use buildFeatures`                                                                                   |
| [`64bbe7aa`](https://github.com/NixOS/nixpkgs/commit/64bbe7aa17e368f4082d85f8c721970bb194a41f) | `statix: use buildFeatures`                                                                                        |
| [`938f7302`](https://github.com/NixOS/nixpkgs/commit/938f7302c3a266ccd45173c881560523e4352f28) | `sheesy-cli: use buildFeatures`                                                                                    |
| [`da870243`](https://github.com/NixOS/nixpkgs/commit/da8702439abce2837a607a8e1cba284566b7ab52) | `cargo-audit: use buildFeatures`                                                                                   |
| [`43333d3c`](https://github.com/NixOS/nixpkgs/commit/43333d3c6e249e477ce898e6e8aa0e65cb53818e) | `wasmer: use buildFeatures and checkFeatures`                                                                      |
| [`44c0a3a6`](https://github.com/NixOS/nixpkgs/commit/44c0a3a626dfed575b23ce1795ccdc42d8b0200e) | `ouch: use buildFeatures`                                                                                          |
| [`fb3de84f`](https://github.com/NixOS/nixpkgs/commit/fb3de84fb3af6326d49a889490a9ef54f1e281fa) | `xidlehook: use buildFeatures`                                                                                     |
| [`5999944a`](https://github.com/NixOS/nixpkgs/commit/5999944ad06c8015430fddaecee700fcfdb29148) | `vector: use buildFeatures, clean up`                                                                              |
| [`1b7125db`](https://github.com/NixOS/nixpkgs/commit/1b7125db17fba70cec83289d0ef9dba6f9e27d9e) | `websocat: use buildFeatures`                                                                                      |
| [`0b95da34`](https://github.com/NixOS/nixpkgs/commit/0b95da347434d04379cd9c70138518796bd2543b) | `xxv: use buildFeatures`                                                                                           |
| [`c07e2bf5`](https://github.com/NixOS/nixpkgs/commit/c07e2bf52e04b8d5b755eed68029d0885ff053a1) | `alfis: use buildFeatures`                                                                                         |
| [`ee8e2f88`](https://github.com/NixOS/nixpkgs/commit/ee8e2f886414ee8a897fe853e8ff8c47a04cf586) | `openethereum: use buildFeatures`                                                                                  |
| [`2448ef46`](https://github.com/NixOS/nixpkgs/commit/2448ef46307a8935dbe2d217b7d093a981aa8efe) | `elan: use buildFeatures`                                                                                          |
| [`cc0e2338`](https://github.com/NixOS/nixpkgs/commit/cc0e2338013dd21ff1a30a696df8f710b82247e2) | `finalfusion-utils: use buildFeature`                                                                              |
| [`ce0da1b8`](https://github.com/NixOS/nixpkgs/commit/ce0da1b87157e4488f9d8f0c1203b54441b3022a) | `librespot: use buildFeatures`                                                                                     |
| [`9ed4b5c9`](https://github.com/NixOS/nixpkgs/commit/9ed4b5c96180ef34832c09085df16da3f3182340) | `spotifyd: use buildFeatures`                                                                                      |
| [`7303def4`](https://github.com/NixOS/nixpkgs/commit/7303def464d68215690639d9e880d1ad8b64815f) | `eww: use buildFeatures`                                                                                           |
| [`8ec1bb1b`](https://github.com/NixOS/nixpkgs/commit/8ec1bb1b463377e0bb6ee06fd14518df718daa89) | `wmfocus: use buildFeatures`                                                                                       |
| [`bb6d379d`](https://github.com/NixOS/nixpkgs/commit/bb6d379d80169c6777c015831b302a5f1b97daf0) | `i3status-rust: use buildFeatures`                                                                                 |
| [`d05ccea2`](https://github.com/NixOS/nixpkgs/commit/d05ccea21344b77c7e0dedeb3cd54023b626d8cc) | `tiny: use buildFeatures`                                                                                          |
| [`94eee0a2`](https://github.com/NixOS/nixpkgs/commit/94eee0a20b6bf04f93694cd196c8df4ebbf67812) | `vscode-extensions.vadimcn.vscode-lldb: use buildFeatures`                                                         |
| [`3d8807a2`](https://github.com/NixOS/nixpkgs/commit/3d8807a211f64a51b096b2b3e6bf20748da8bfa0) | `termplay: use buildFeatures`                                                                                      |
| [`4b8d8fc9`](https://github.com/NixOS/nixpkgs/commit/4b8d8fc923512256f83f72f9f76c1a688c0acb57) | `ripgrep: use buildFeatures`                                                                                       |
| [`59a143e2`](https://github.com/NixOS/nixpkgs/commit/59a143e206296f241556984f7070d6aee320cbc2) | `zenith: use buildFeatures`                                                                                        |
| [`08e50b55`](https://github.com/NixOS/nixpkgs/commit/08e50b55cbf966d0f254d08ddfd726f2f457c640) | `routinator: use buildFeatures`                                                                                    |
| [`eaeed592`](https://github.com/NixOS/nixpkgs/commit/eaeed5920f8ccaeddbabe6b828f32fa662531f64) | `meli: use buildFeatures`                                                                                          |
| [`2d358196`](https://github.com/NixOS/nixpkgs/commit/2d358196f06cf7cb1cfe403be2f3320dcde94931) | `todiff: use checkFeatures`                                                                                        |
| [`ebe494df`](https://github.com/NixOS/nixpkgs/commit/ebe494df9dcffe2a3ab5d8b8572af6c981bf71be) | `clipcat: use buildFeatures`                                                                                       |
| [`eb97241d`](https://github.com/NixOS/nixpkgs/commit/eb97241d7cd5c4a590b36171e0eaeff5ef63799e) | `pijul: use buildFeatures`                                                                                         |
| [`c7d9f452`](https://github.com/NixOS/nixpkgs/commit/c7d9f452b8a271dc8684bbe5dff3cd98b3191fe4) | `meshcentral: 0.8.98 -> 0.9.50`                                                                                    |
| [`cd548bdc`](https://github.com/NixOS/nixpkgs/commit/cd548bdc6a7dd1f8701bdf5350e1292445dc6396) | `meshcentral: add updateScript to expression`                                                                      |
| [`41c57447`](https://github.com/NixOS/nixpkgs/commit/41c57447daf586f843ba90743ce73c1d2b455a3a) | `python3Packages.tailscale: init at 0.1.2`                                                                         |
| [`527ebd85`](https://github.com/NixOS/nixpkgs/commit/527ebd85304e7b0bf99e54e846db7870959c8ac4) | `linuxPackages.bcc: 0.22.0 -> 0.23.0`                                                                              |
| [`21f640f9`](https://github.com/NixOS/nixpkgs/commit/21f640f93ab5d2bbdf1bd7a3ca5fa65f0f824ae8) | `gmid: fix cross-compilation`                                                                                      |
| [`5933da24`](https://github.com/NixOS/nixpkgs/commit/5933da24d2d0ea63c1dccbb70a34756045a1ad0d) | `mp3blaster: pull pending upstream inclusion fix for ncurses-6.3`                                                  |
| [`2681282a`](https://github.com/NixOS/nixpkgs/commit/2681282aa253d50c89e3ccbef193e46c1a2aa024) | `krane: 2.3.0 → 2.3.1`                                                                                             |
| [`0ea20339`](https://github.com/NixOS/nixpkgs/commit/0ea203399b1aebde7c94cde07bb4e325bc13e5c8) | `grocy: 3.1.2 -> 3.1.3`                                                                                            |
| [`6d4e3069`](https://github.com/NixOS/nixpkgs/commit/6d4e3069fc180a75e3172ccfa5a1da3b0927f724) | `la-capitaine-icon-theme: init at 0.6.2`                                                                           |
| [`6f371f47`](https://github.com/NixOS/nixpkgs/commit/6f371f473782d518a2868484ef83572fcdc4d879) | `python3Packages.aiolyric: 1.0.7 -> 1.0.8`                                                                         |
| [`ebee81f3`](https://github.com/NixOS/nixpkgs/commit/ebee81f3c7ed694a59b49cc14330a293458af9f9) | `python3Packages.python-mapnik: add erictapen as maintainer`                                                       |
| [`c98ae967`](https://github.com/NixOS/nixpkgs/commit/c98ae967d35f23d3598d0ff1399eb7d9b07545ad) | `mapnik: add erictapen as maintainer`                                                                              |
| [`2b84e72f`](https://github.com/NixOS/nixpkgs/commit/2b84e72fc646ac6d715024bc64e221d7021d5e35) | `mapnik: fix build by using proj 7`                                                                                |
| [`d9a814f4`](https://github.com/NixOS/nixpkgs/commit/d9a814f4e6842a00614f7857f57649244bae8279) | `android-studio-beta: 2021.1.1.15 → 2021.1.1.16`                                                                   |
| [`2b439432`](https://github.com/NixOS/nixpkgs/commit/2b439432294626fe676f4c0c94ea75ccc95b429c) | `gnomeExtensions.sound-output-device-chooser: 38 -> 39`                                                            |
| [`ae75e0ce`](https://github.com/NixOS/nixpkgs/commit/ae75e0ce587f97584da6bf1351a61a6fb52bc88c) | `cargo-depgraph: init at 1.2.2`                                                                                    |
| [`e8a7e2be`](https://github.com/NixOS/nixpkgs/commit/e8a7e2bebfe3960854405bbb9b9004709a811885) | `python38Packages.clize: 4.2.0 -> 4.2.1`                                                                           |
| [`0977a604`](https://github.com/NixOS/nixpkgs/commit/0977a6042f5b4c9dcaec2783d958fb71a184e979) | `python3Packages.xknx: 0.18.12 -> 0.18.13`                                                                         |
| [`cb74558d`](https://github.com/NixOS/nixpkgs/commit/cb74558d7dfd1a6e001f2fae4e876148a4dd78b4) | `logseq: 0.4.5 -> 0.4.6`                                                                                           |
| [`1d76b19d`](https://github.com/NixOS/nixpkgs/commit/1d76b19de46f6d864e36431d7a3bdead06fdc432) | `mautrix-telegram: 0.10.1 -> 0.10.2`                                                                               |
| [`97f51fea`](https://github.com/NixOS/nixpkgs/commit/97f51fea777e6d80c76f25d08ea4fcf9c3272402) | `mautrix-signal: unstable-2021-08-12 -> unstable-2021-11-12`                                                       |
| [`f1caf94f`](https://github.com/NixOS/nixpkgs/commit/f1caf94f772c45d6dae3dae570090705f869e79b) | `python3Packages.mautrix: 0.10.11 -> 0.11.3`                                                                       |
| [`63acfd56`](https://github.com/NixOS/nixpkgs/commit/63acfd5685519046dd9e4828121f11ad9b4816ce) | `python3Packages.python-igraph: rename to igraph`                                                                  |
| [`f1d204a8`](https://github.com/NixOS/nixpkgs/commit/f1d204a88011a1f8f182d38d229ff5a19c59a001) | `python3Packages.python-igraph: 0.9.6 -> 0.9.8`                                                                    |
| [`ca985cc4`](https://github.com/NixOS/nixpkgs/commit/ca985cc40fbca1dde70ead4f292f1362b75696a6) | `igraph: 0.9.4 -> 0.9.5`                                                                                           |
| [`f3866370`](https://github.com/NixOS/nixpkgs/commit/f386637083cc4e5cc3e87bc208fbc8447378ea27) | `mautrix-whatsapp: 0.1.10 -> 0.2.1`                                                                                |
| [`597e2ce5`](https://github.com/NixOS/nixpkgs/commit/597e2ce5232f57bf3305e70a826e8485b7633fa5) | `fetchgithub: fix eval when passing forceFetchGit`                                                                 |
| [`84225739`](https://github.com/NixOS/nixpkgs/commit/8422573922d12a92ac1ad7211517f194f8b5cbb0) | `i7z: 0.27.3 -> 0.27.4`                                                                                            |
| [`35e4c0d7`](https://github.com/NixOS/nixpkgs/commit/35e4c0d7503ab2f2d0e78114139b6406edda9916) | `linux: Add kernel config required for QCA6390 bluetooth (XPS 9310)`                                               |
| [`445510ed`](https://github.com/NixOS/nixpkgs/commit/445510ed6997194dac161434b1a22e9eec65c2c4) | `rust/import-cargo-lock: hopefully make nested crate test work on macos`                                           |
| [`f9a340a9`](https://github.com/NixOS/nixpkgs/commit/f9a340a91604959f484a7918b00f3ede59814f7c) | `rust/import-cargo-lock: add test git-dependency-rev-non-workspace-nested-crate`                                   |
| [`b2aa19ef`](https://github.com/NixOS/nixpkgs/commit/b2aa19efe7ffacd5ba9642354ee51f2eb6a10d07) | `rust: find nested packages in git repositories`                                                                   |
| [`c6b02470`](https://github.com/NixOS/nixpkgs/commit/c6b024706771461bbb168b6c0e575ff07764fb63) | `copyDesktopItems: fix handling of plain paths`                                                                    |
| [`4227daf9`](https://github.com/NixOS/nixpkgs/commit/4227daf9f04df6e740a9f9f6d81197ec3ca9fd74) | `python3Packages.pydeck: init at 0.7.0`                                                                            |
| [`e3ae1655`](https://github.com/NixOS/nixpkgs/commit/e3ae16550b1a49fba50fea1a225637217f8b5a35) | `python3Packages.hdfs: init at 2.5.8`                                                                              |