### PR TITLE
chore(flake/inputs/nixpkgs): `92377ca5` -> `42d32516`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1637170361,
-        "narHash": "sha256-t/wz7zOLxdAfyACR0R0iLWAGkAJerZP3ywEHO27HKz8=",
+        "lastModified": 1637209424,
+        "narHash": "sha256-oXw75hkCOVtoB+CEElWiTmkC1gNdL3jf0tG2GInytHA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "92377ca569ee7d09c3ff74d5bfecee63b0d7e447",
+        "rev": "42d32516400c1d821d275a5460900bbaef3d3bf1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                    |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`50bbc006`](https://github.com/NixOS/nixpkgs/commit/50bbc006ba7801c753f543774a321150b57c070d) | `svgcleaner: Remove deprecated package.`                          |
| [`5130f5df`](https://github.com/NixOS/nixpkgs/commit/5130f5df7e5c4fe67a54aff46a0b1cea6dfd0192) | `ryujinx: 1.0.7101 -> 1.0.7105`                                   |
| [`d5321ca4`](https://github.com/NixOS/nixpkgs/commit/d5321ca4ad2d56070c52c98c7b8da82d55eba0fc) | `python3Packages.trytond: 6.0.8 -> 6.2.0`                         |
| [`c6aad1b6`](https://github.com/NixOS/nixpkgs/commit/c6aad1b6d37754fa8fe1378b6d13918e6ee4e3b1) | `heisenbridge: relax mautrix constraint, enable tests`            |
| [`47f63840`](https://github.com/NixOS/nixpkgs/commit/47f638403e3d12fef9a8c259cce4f2b5f5ff2402) | `nixos/xmrig: add kernel module msr`                              |
| [`6bb5bcd6`](https://github.com/NixOS/nixpkgs/commit/6bb5bcd6f50b84a8632a0efa9c2fd6cdc4271e4b) | `mpd: disable pipewire for all but linux`                         |
| [`e0661862`](https://github.com/NixOS/nixpkgs/commit/e0661862ff2098bd018e6eb6d7b3662a5dc02d05) | `icinga2: 2.13.1 -> 2.13.2`                                       |
| [`1706b2ec`](https://github.com/NixOS/nixpkgs/commit/1706b2ec489847abe5f1f93ca831c82e522c5f6a) | `home-assistant: enable motion_blinds tests`                      |
| [`38afc80c`](https://github.com/NixOS/nixpkgs/commit/38afc80cee857402a0953459b5ebf2e72282b6f7) | `home-assistant: update component-packages`                       |
| [`0fda4083`](https://github.com/NixOS/nixpkgs/commit/0fda4083ea86e93e9d37464b6f1a4d3e1099eafd) | `python3Packages.motionblinds: init at 0.5.8.2`                   |
| [`3fa96c61`](https://github.com/NixOS/nixpkgs/commit/3fa96c615f600b979f0f65387746e8fcd661b09f) | `python3Packages.pyscard: fix tests on darwin`                    |
| [`f54808ee`](https://github.com/NixOS/nixpkgs/commit/f54808ee5925a90c575dae67459ce0c790ce5b05) | `zoneminder: 1.36.8 -> 1.36.10`                                   |
| [`98426ba3`](https://github.com/NixOS/nixpkgs/commit/98426ba308658f6ea8f9208694ab3ca11cd16da6) | `vimPlugins: update`                                              |
| [`1332cffa`](https://github.com/NixOS/nixpkgs/commit/1332cffaeb4db69f873d649ebd98281617cc3b1d) | `mpd: 0.23.2 -> 0.23.4`                                           |
| [`ebbf9313`](https://github.com/NixOS/nixpkgs/commit/ebbf93136f9ca5e4e900541b50d6154e98efcd38) | `nixos/zabbixServer: explicitely set security.wrappers ownership` |
| [`e386217d`](https://github.com/NixOS/nixpkgs/commit/e386217d72530651ada6d6ea55ec5a737a357a0a) | `matrix-synapse: 1.46.0 -> 1.47.0`                                |
| [`97102e0b`](https://github.com/NixOS/nixpkgs/commit/97102e0b78e242fd7e43c70be94eda2e965e3d1b) | `checkov: 2.0.574 -> 2.0.580`                                     |
| [`4366c6ca`](https://github.com/NixOS/nixpkgs/commit/4366c6ca9c36a6d8c204b450bd326cddd85b6782) | `python3Packages.pypinyin: 0.43.0 -> 0.44.0`                      |
| [`d421ffb4`](https://github.com/NixOS/nixpkgs/commit/d421ffb4832b176675aa82e83921e3a41b4f9700) | `electron_16: init at 16.0.0`                                     |
| [`4fdce33a`](https://github.com/NixOS/nixpkgs/commit/4fdce33af382f74026776eacb6b38ea79aeb11d5) | `electron_15: 15.3.1 -> 15.3.2`                                   |
| [`455f42bd`](https://github.com/NixOS/nixpkgs/commit/455f42bd3f449a812b4c5ee4c1105cd24634d564) | `electron_13: 13.6.1 -> 13.6.2`                                   |
| [`c96842ed`](https://github.com/NixOS/nixpkgs/commit/c96842ed019baac7003110b90b8fc2f27594f459) | `electron_12: 12.2.2 -> 12.2.3`                                   |
| [`83e069f0`](https://github.com/NixOS/nixpkgs/commit/83e069f05caae869e57dc2986dc6d744d703a998) | `deltachat-desktop: use libdeltachat 1.60.0`                      |
| [`32840493`](https://github.com/NixOS/nixpkgs/commit/328404935b1480151b7dd2ef1b15601a11c851a0) | `python3Packages.angrop: 9.0.10534 -> 9.0.10576`                  |
| [`8c9879f2`](https://github.com/NixOS/nixpkgs/commit/8c9879f2adc882dd032fc93bbf9c4ce7bcffdf36) | `python3Packages.angr: 9.0.10534 -> 9.0.10576`                    |
| [`45546f91`](https://github.com/NixOS/nixpkgs/commit/45546f91a7c07ecb78dfdb343f562d20c51a0b2d) | `python3Packages.cle: 9.0.10534 -> 9.0.10576`                     |
| [`5e2d1746`](https://github.com/NixOS/nixpkgs/commit/5e2d1746983c7b8ea92dfada9ac649c11c652e5b) | `python3Packages.claripy: 9.0.10534 -> 9.0.10576`                 |
| [`6df38df7`](https://github.com/NixOS/nixpkgs/commit/6df38df7484cd159f090edd2760d89d97eebc5d7) | `python3Packages.pyvex: 9.0.10534 -> 9.0.10576`                   |
| [`e4fb2b33`](https://github.com/NixOS/nixpkgs/commit/e4fb2b331a032a2a5f67e8f14157611f3b3f5e4a) | `python3Packages.ailment: 9.0.10534 -> 9.0.10576`                 |
| [`bb9e3fdc`](https://github.com/NixOS/nixpkgs/commit/bb9e3fdc794f15f8a7dfc54a1b727aacd66189d1) | `python3Packages.archinfo: 9.0.10534 -> 9.0.10576`                |
| [`ed97d79d`](https://github.com/NixOS/nixpkgs/commit/ed97d79de6225965e34c74c7af15bd0ab8b6345f) | `kotlin-native: 1.5.31 → 1.6.0`                                   |
| [`fadae257`](https://github.com/NixOS/nixpkgs/commit/fadae2575ba2967dcb12b6d70d52ff5a94614b3e) | `kotlin: 1.5.31 → 1.6.0`                                          |
| [`ef58bbf9`](https://github.com/NixOS/nixpkgs/commit/ef58bbf9b7ce34f1f4fcace04484b9bbea0d3ed2) | `nixos/pam: avoid extra lines in pam files`                       |
| [`660a3447`](https://github.com/NixOS/nixpkgs/commit/660a3447d20c2ec450f4b53bf966dc1cb3149fa2) | `libdeltachat: 1.64.0 -> 1.65.0`                                  |
| [`aa6463ca`](https://github.com/NixOS/nixpkgs/commit/aa6463cae65433254ebe3fca1a4727528e484230) | `python3Packages.stanza: init at 1.3.0`                           |
| [`f5b160b6`](https://github.com/NixOS/nixpkgs/commit/f5b160b66e50ee85d624d6a6fc63022a95424199) | `jackett: 0.18.925 -> 0.19.138, use buildDotnetModule`            |
| [`f692dc62`](https://github.com/NixOS/nixpkgs/commit/f692dc62c811818ad8b8366cc70d3a4dfe78c021) | `nixos/logstash: Add logstashJvmOptionsFile option`               |
| [`e8324987`](https://github.com/NixOS/nixpkgs/commit/e832498761c888dba37a8442c4458ec4db554d80) | `maintainers: add riotbib as maintainer`                          |
| [`4393bb58`](https://github.com/NixOS/nixpkgs/commit/4393bb58e9727060816c3d5008736fc5ef8c63f4) | `faudio: 21.09 -> 21.10`                                          |
| [`2dc8d067`](https://github.com/NixOS/nixpkgs/commit/2dc8d0672319973397582e332db6306dd3583741) | `gtk-theme-framework: init at 0.2.3`                              |