### PR TITLE
chore(flake/inputs/nixos-hardware): `abf18e3a` -> `5a7e6137`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -77,11 +77,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1637217942,
-        "narHash": "sha256-tqcvsA1th9p80Fll+8bkMz2GCnLh1++KCyuvNSd7sx4=",
+        "lastModified": 1637242070,
+        "narHash": "sha256-/XCFGOriSpAgo0lPxVK12vFBpta567kwfHZr5tNNHyE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "abf18e3afe2f94d1c896292b1c433c88bec80662",
+        "rev": "5a7e613703ea349fd46b3fa2f3dfe3bd5444d591",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                              |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`0492dd82`](https://github.com/NixOS/nixos-hardware/commit/0492dd8216377dad6cafe52ec7275fede993e45f) | `Add a config for the 9th generation of Lenovo Thinkpad X1` |