### PR TITLE
chore(flake/inputs/templates): `79f48a7b` -> `c99b52c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
     },
     "templates": {
       "locked": {
-        "lastModified": 1627915799,
-        "narHash": "sha256-6mmoZOq/faRYvyDHLsJbOXix5v38MvhlqSFNoHluZcc=",
+        "lastModified": 1637326938,
+        "narHash": "sha256-wHqnMeQqyFTTdcsUTThfv42KkCH38wMrIvO+gWfEIAg=",
         "owner": "NixOS",
         "repo": "templates",
-        "rev": "79f48a7b822f35c068c5e235da2e9fbd154cecee",
+        "rev": "c99b52c0c8be1fb6cdb1f484d42c32993217925d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message                              |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------- |
| [`e2e9c4a5`](https://github.com/NixOS/templates/commit/e2e9c4a5bad158c55788f3455e2667ebe5e747d2) | `c-hello: improve makefile again`           |
| [`c68ee0d5`](https://github.com/NixOS/templates/commit/c68ee0d5b1893c3f7e631269d85bea720ec2f990) | `c-hello: fix makefile for non-gcc`         |
| [`ce532e2b`](https://github.com/NixOS/templates/commit/ce532e2bb2fd7597aa18dc2b16598158c33119b6) | `typo`                                      |
| [`b5ff3ebf`](https://github.com/NixOS/templates/commit/b5ff3ebf6d0cf711c1e9c1c82fd60b942885cb58) | `correct spelling numer -> number`          |
| [`a4ed779e`](https://github.com/NixOS/templates/commit/a4ed779e1313b7ad8fb3c3885c14af11f9cf5446) | `fix a wrong comment`                       |
| [`7de14d98`](https://github.com/NixOS/templates/commit/7de14d986b28fb5f724cbc3d96b9995485b30f33) | `funnier message`                           |
| [`4b03bea6`](https://github.com/NixOS/templates/commit/4b03bea60a4281840481a2f8110edd64ec440d6c) | `add a check and add enable Hoogle`         |
| [`efbf526e`](https://github.com/NixOS/templates/commit/efbf526eefd992bef7891f4d39466a8ba6df6dde) | `remove unused mtl dependency`              |
| [`35118ebc`](https://github.com/NixOS/templates/commit/35118ebc58bf575da364400601d05557aa959d2b) | `Add a haskell-hello template`              |
| [`44245170`](https://github.com/NixOS/templates/commit/44245170e227aa71cfb489c13c1c950b2fac8242) | `Support aarch64-{linux,darwin} by default` |
| [`d6cdadfd`](https://github.com/NixOS/templates/commit/d6cdadfd6d91656fa46dec0be888f238d599ef15) | `η-reduction in forAllSystems`              |
| [`a34b491a`](https://github.com/NixOS/templates/commit/a34b491aea538d141a4136c62230ba594aed657b) | `added rust and python templates`           |