### PR TITLE
chore(flake/inputs/nixpkgs): `42d32516` -> `d9e8a587`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1637209424,
-        "narHash": "sha256-oXw75hkCOVtoB+CEElWiTmkC1gNdL3jf0tG2GInytHA=",
+        "lastModified": 1637289634,
+        "narHash": "sha256-JEbbn6ARkzJX39VEvKwScJxqJgO3wMcZpjY94AOR6ME=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "42d32516400c1d821d275a5460900bbaef3d3bf1",
+        "rev": "d9e8a587e143aa8d3f1594004d63b5c785b416fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                                                                                             |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| [`5c7006d5`](https://github.com/NixOS/nixpkgs/commit/5c7006d513767e2729db59ed919cd80fb0c3bd3f) | `metasploit: 6.1.14 -> 6.1.15`                                                                                                                                             |
| [`57b974d9`](https://github.com/NixOS/nixpkgs/commit/57b974d907f84cd293c74258712dc105a361e1cc) | `sogo: 5.2.0 -> 5.3.0`                                                                                                                                                     |
| [`433e000f`](https://github.com/NixOS/nixpkgs/commit/433e000ff7f7643e9ee8bdfb3ea4b51d55e1c100) | `sope: 5.2.0 -> 5.3.0`                                                                                                                                                     |
| [`66ed8b22`](https://github.com/NixOS/nixpkgs/commit/66ed8b2212bd77edf40d7cd11f84dbf9d3c1ca50) | `exploitdb: 2021-11-16 -> 2021-11-18`                                                                                                                                      |
| [`709bfda3`](https://github.com/NixOS/nixpkgs/commit/709bfda3295b182110dd913e746f358dce2dd0c5) | `python3Packages.casbin: 1.9.6 -> 1.9.7`                                                                                                                                   |
| [`95b8513b`](https://github.com/NixOS/nixpkgs/commit/95b8513b39b311d45bf2624a8a3b925e2f3d5ee4) | `mumsi/mumlib: Drop`                                                                                                                                                       |
| [`be6b1ae5`](https://github.com/NixOS/nixpkgs/commit/be6b1ae5f6e00aae0aa491f0cc54d4c9f97a8eff) | `devserver: fix build on darwin (#146530)`                                                                                                                                 |
| [`6f423785`](https://github.com/NixOS/nixpkgs/commit/6f4237850f86ce7b10fed8b1b994104261f79eae) | `python3Packages.pysmartapp: 0.3.3 -> 0.3.4`                                                                                                                               |
| [`516570d9`](https://github.com/NixOS/nixpkgs/commit/516570d972f63cac6c5c72327c159a698e40ff47) | `ulauncher: fix loading svg icons`                                                                                                                                         |
| [`d70f70dc`](https://github.com/NixOS/nixpkgs/commit/d70f70dc68c7a6e49d6512319e72de3f7e174c82) | `checkov: 2.0.582 -> 2.0.587`                                                                                                                                              |
| [`eaab9909`](https://github.com/NixOS/nixpkgs/commit/eaab9909ca70e9ef67703cfa8e72086996810692) | `icinga2: Enable LTO and tests + cleanup doc`                                                                                                                              |
| [`c425bda9`](https://github.com/NixOS/nixpkgs/commit/c425bda9ffe7e3f951f2c6a0b72304739f75b116) | `python3Packages.identify: 2.3.6 -> 2.3.7`                                                                                                                                 |
| [`036dbf4f`](https://github.com/NixOS/nixpkgs/commit/036dbf4f85015d7736b34d35b8439056da2bdc84) | `python3Packages.qcs-api-client: 0.16.0 -> 0.18.0`                                                                                                                         |
| [`ab3a1ce5`](https://github.com/NixOS/nixpkgs/commit/ab3a1ce57d6c95925b7e653dbe440a74159dd4ce) | `purple-googlechat: init at unstable-2020-10-18 (#145224)`                                                                                                                 |
| [`9c177f0a`](https://github.com/NixOS/nixpkgs/commit/9c177f0a1f15894cbf3cb799a646c1f9b91bdbca) | `pax: fix build on darwin`                                                                                                                                                 |
| [`ecf388e9`](https://github.com/NixOS/nixpkgs/commit/ecf388e90b68e1437e124a02a4a7c44f71eaf342) | `vmTools: Make msize larger to silence warning`                                                                                                                            |
| [`9584a89e`](https://github.com/NixOS/nixpkgs/commit/9584a89e690c70184216ad4b06fc5bf9c88d7190) | `convbin: fix build on darwin`                                                                                                                                             |
| [`410bafef`](https://github.com/NixOS/nixpkgs/commit/410bafefdeb12c7cf85e96a597406c7993f5359d) | `gpxsee: 9.11 → 9.12`                                                                                                                                                      |
| [`866f134d`](https://github.com/NixOS/nixpkgs/commit/866f134dbdcca18128969f9b65bcf6eae1c3fb9f) | `erlang: 24.1.5 -> 24.1.6 (#146496)`                                                                                                                                       |
| [`5a56e021`](https://github.com/NixOS/nixpkgs/commit/5a56e02125ecf013e7d97fd7af7ef251e67265e0) | `python3Packages.rtoml: fix build on darwin`                                                                                                                               |
| [`4535a9dd`](https://github.com/NixOS/nixpkgs/commit/4535a9ddb4e9370a0275df1b74a1e3caae453f32) | `haskellPackages: mark builds failing on hydra as broken`                                                                                                                  |
| [`8bc4944f`](https://github.com/NixOS/nixpkgs/commit/8bc4944f274d6a872fad2c31e7ff75d7ad7534a2) | `python39Packages.weasyprint: remove extra pytest, remove linting only tests, format to standard pythonPackages layout, clarify test comment which is also true for linux` |
| [`412899fe`](https://github.com/NixOS/nixpkgs/commit/412899feae7c1fd8d54857207fc59e0e10589295) | `python39Packages.pydyf: remove extra pytest, remove linting only tests, format to standard pythonPackages layout`                                                         |
| [`47971592`](https://github.com/NixOS/nixpkgs/commit/479715923b1fde5b4abfd7851f88f1bf04f2e0db) | `ibus-theme-tools: init at 4.2.0 (#146361)`                                                                                                                                |
| [`b7879b34`](https://github.com/NixOS/nixpkgs/commit/b7879b343a63745c00cb8f53b4a9369d1d4afdc9) | `clightning: improve build setup`                                                                                                                                          |
| [`db8278e2`](https://github.com/NixOS/nixpkgs/commit/db8278e29576b222a3020f09bccbb8dc69a2a232) | `rates: fix build on darwin`                                                                                                                                               |
| [`b3966997`](https://github.com/NixOS/nixpkgs/commit/b3966997730b31b5d969527436b8e158705872f6) | `python3Packages.bimmer-connected: 0.7.22 -> 0.8.0`                                                                                                                        |
| [`58ce4b5a`](https://github.com/NixOS/nixpkgs/commit/58ce4b5a2832aecca581bec3da6d5e220f5705d9) | `heisenbridge: 1.6.0 -> 1.7.0`                                                                                                                                             |
| [`e5537e4d`](https://github.com/NixOS/nixpkgs/commit/e5537e4de773cc63a7246acb93751c105cb07c25) | `synology-drive: init at 3.0.1-12674 (#141977)`                                                                                                                            |
| [`2ec2ad06`](https://github.com/NixOS/nixpkgs/commit/2ec2ad064bed3f47434babecf6fed96710b8fe1e) | `androidenv: fix emulator build on Linux`                                                                                                                                  |
| [`a6abef6e`](https://github.com/NixOS/nixpkgs/commit/a6abef6ed259cf2090b06470a6ad3d139e52417d) | `tgswitch: init at 0.5.378`                                                                                                                                                |
| [`53fd52dc`](https://github.com/NixOS/nixpkgs/commit/53fd52dca90798b0fae2bb5381e3f4e3bcb73a57) | `stxxl: fix build on darwin`                                                                                                                                               |
| [`586ec1fb`](https://github.com/NixOS/nixpkgs/commit/586ec1fbe4c1a5c24d5a5b57a9eb8557c8550c00) | `mhost: fix build on darwin`                                                                                                                                               |
| [`0031a11e`](https://github.com/NixOS/nixpkgs/commit/0031a11ec45fd614428415d2eebf9a21ceabe621) | `cargo-crev: 0.20.1 -> 0.21.3`                                                                                                                                             |
| [`d2290e85`](https://github.com/NixOS/nixpkgs/commit/d2290e85bb7a946b13e7344a3d6af0a253fbbf62) | `haskellPackages.lucid-{alpine,htmx}: pin to 0.1.0.2 for stackage compat`                                                                                                  |
| [`8ea3df51`](https://github.com/NixOS/nixpkgs/commit/8ea3df51cd106cbde64692a7a54783758288e6db) | `erlang: 24.1.4 -> 24.1.5 (#145530)`                                                                                                                                       |
| [`d4795c8e`](https://github.com/NixOS/nixpkgs/commit/d4795c8efc9220cdf91fd0521ea452dc0cf5127d) | `haskellPackages.hasql-interpolate: disable tests (need running postgres)`                                                                                                 |
| [`bb52b0e1`](https://github.com/NixOS/nixpkgs/commit/bb52b0e13e2af4ea8c8750069a388d630f5f239a) | `haskellPackages.synthesizer-alsa: re-enabled`                                                                                                                             |
| [`531c9c19`](https://github.com/NixOS/nixpkgs/commit/531c9c19e3f711b9718bd36e3fdcaf84a51a92ed) | `proj: fix build on Hydra`                                                                                                                                                 |
| [`c919b174`](https://github.com/NixOS/nixpkgs/commit/c919b17438c87f58c66d2b5adb89fdc652ec71ec) | `haskellPackages.llvm-ffi-tools, llvm-pkg-config: re-enabled`                                                                                                              |
| [`ed3fe4c6`](https://github.com/NixOS/nixpkgs/commit/ed3fe4c6c4b6f5bc8a370db3b74e0d19262cd2e4) | `haskellPackages.lapack: disable tests because they do not run reliably`                                                                                                   |
| [`1b2ef27e`](https://github.com/NixOS/nixpkgs/commit/1b2ef27ea200466640a096238014b2cec2c26ad5) | `haskellPackages: update list of transitively broken packages`                                                                                                             |
| [`c3908b01`](https://github.com/NixOS/nixpkgs/commit/c3908b0110a288cbf2f69bc384f019e06219f229) | `mjolnir: 1.2.0 -> 1.2.1`                                                                                                                                                  |
| [`94186e43`](https://github.com/NixOS/nixpkgs/commit/94186e430b3697a0a2e15752c69c5bb562dc5fe2) | `iqueue: init at 0.1.0 (#139064)`                                                                                                                                          |
| [`dee196ab`](https://github.com/NixOS/nixpkgs/commit/dee196abef9740e95a602c72508fb91e6ed570e5) | `lychee: 0.7.0 -> 0.8.1`                                                                                                                                                   |
| [`3a4f6472`](https://github.com/NixOS/nixpkgs/commit/3a4f647269672b7efb0f377cc9ab4aaa84a07396) | `pkgsMusl.liburing: fix build`                                                                                                                                             |
| [`74c99a1c`](https://github.com/NixOS/nixpkgs/commit/74c99a1c825a4fddb9cb4fb17a3a88649f4b4238) | `streamlink: 2.4.0 -> 3.0.1`                                                                                                                                               |
| [`3eaa93c7`](https://github.com/NixOS/nixpkgs/commit/3eaa93c722a67f0d1674b763467a655e78e456ad) | `gistyc: init at 1.3`                                                                                                                                                      |
| [`57407fed`](https://github.com/NixOS/nixpkgs/commit/57407fed58509a8d731d525f39842ea5ab696237) | `kio-fuse: init at 5.0.1 (#138492)`                                                                                                                                        |
| [`473ac28b`](https://github.com/NixOS/nixpkgs/commit/473ac28b806b1e9c11cc71f6c388a1ccd3bcf961) | `pacvim: pull pending upstream inclusion fix for ncurses-6.3`                                                                                                              |
| [`cb22860d`](https://github.com/NixOS/nixpkgs/commit/cb22860dfb7981399b1d6fe754d88815372911b2) | `ncdc: pull upstream ncurses-6.3 fix`                                                                                                                                      |
| [`abbba8eb`](https://github.com/NixOS/nixpkgs/commit/abbba8eb4c2181aeeeb8c807f82bd566a5c35e56) | `python3Packages.weasyprint: 52 -> 54.3`                                                                                                                                   |
| [`e9511873`](https://github.com/NixOS/nixpkgs/commit/e9511873045ea0b4d38b0f2670d911863bbb5cca) | `python3Packages.pydyf: init at 1.0.2`                                                                                                                                     |
| [`83b41751`](https://github.com/NixOS/nixpkgs/commit/83b4175120fff50f77dda3a023090fb2b50e878e) | `maintainers: add rprecenth`                                                                                                                                               |
| [`521cecb9`](https://github.com/NixOS/nixpkgs/commit/521cecb93dbeb707d0df7c40f16d0100f083abfb) | `ion3: fix src url`                                                                                                                                                        |
| [`1384c851`](https://github.com/NixOS/nixpkgs/commit/1384c851de19cbf733cfc39ea375627d83083104) | `linuxPackages_5_15.ddcci-driver: fix build`                                                                                                                               |
| [`12157af2`](https://github.com/NixOS/nixpkgs/commit/12157af2ecb46383c0c6c0f8c3d7dceaaf9aa664) | `ccextractor: fix build on x86_64-darwin`                                                                                                                                  |
| [`cb5f41a0`](https://github.com/NixOS/nixpkgs/commit/cb5f41a0678b1dd628148cdd281c698e238ae635) | `nixos/hbase: add settings option for hbase-site.xml`                                                                                                                      |
| [`2f5fc999`](https://github.com/NixOS/nixpkgs/commit/2f5fc999894f26129b8f7cfef33ed3c042dc70df) | `cloak: fix build on darwin`                                                                                                                                               |
| [`e068dbd9`](https://github.com/NixOS/nixpkgs/commit/e068dbd97702ec6d0b3da6c45b273fbb9c336889) | `libyaml-cpp: Fix wrong paths in pkg-config .pc file.`                                                                                                                     |
| [`62db7503`](https://github.com/NixOS/nixpkgs/commit/62db7503eb74c9c6d3c6a52ab5e225e522f3ea84) | `topicctl: 1.1.1 -> 1.2.0`                                                                                                                                                 |
| [`0196fd79`](https://github.com/NixOS/nixpkgs/commit/0196fd79b767e4d4b08f8edfed00660c6eef5ed3) | `nextcloud22: 22.2.2 -> 22.2.3`                                                                                                                                            |
| [`5d56c78f`](https://github.com/NixOS/nixpkgs/commit/5d56c78f3736fc6a64fa52388d51f594df58ce0a) | `python3Packages.ledgerwallet: fix build`                                                                                                                                  |
| [`1bf3720f`](https://github.com/NixOS/nixpkgs/commit/1bf3720f78f06c7a7db90bce5fd2c4774ced8ddd) | `libretro.play: fix build`                                                                                                                                                 |
| [`6a43259f`](https://github.com/NixOS/nixpkgs/commit/6a43259fa8c244ea3059dbd8cbaac41902ddce1f) | `tidy-viewer: 1.4.2 -> 1.4.3`                                                                                                                                              |
| [`8e63563f`](https://github.com/NixOS/nixpkgs/commit/8e63563f6399210981ddc6300c7d4afc3a0bd303) | `python3Packages.pywizlight: 0.4.10 -> 0.4.13`                                                                                                                             |
| [`c2542026`](https://github.com/NixOS/nixpkgs/commit/c2542026ca5437e3f6e0911cfd0b75df144b8eef) | `python3Packages.qiskit-aer: disable failing test`                                                                                                                         |
| [`1b953802`](https://github.com/NixOS/nixpkgs/commit/1b953802caf7d494fa650e54d77c4bd32e5923ed) | `python3Packages.cvxpy: 1.1.13 -> 1.1.17`                                                                                                                                  |
| [`8b96a43b`](https://github.com/NixOS/nixpkgs/commit/8b96a43bcbd4491c6ec6e792258cce5bd4229e40) | `python3Packages.scs: 2.1.1 -> 3.0.0`                                                                                                                                      |
| [`6c6080dd`](https://github.com/NixOS/nixpkgs/commit/6c6080dd3b5db3f5da8390c6da4116f92f9ded77) | `scs: 2.1.1 -> 3.0.0`                                                                                                                                                      |
| [`123ba3ac`](https://github.com/NixOS/nixpkgs/commit/123ba3ac62535d3ee75d4b86b2ac5b01915f2f3f) | `checkov: 2.0.580 -> 2.0.582`                                                                                                                                              |
| [`0894568a`](https://github.com/NixOS/nixpkgs/commit/0894568aee97eeade591369772046c0d519f95dc) | `nixos/cadvisor: add zfs to path when zfs enabled`                                                                                                                         |
| [`e9f73120`](https://github.com/NixOS/nixpkgs/commit/e9f73120f6db96d821411053058053cdcb38853b) | `ledger-live-desktop: 2.35.0 -> 2.35.1`                                                                                                                                    |
| [`927e6859`](https://github.com/NixOS/nixpkgs/commit/927e685929abafc694edb045756e433c492f4af9) | `Mark as broken on Darwin`                                                                                                                                                 |
| [`78b9e125`](https://github.com/NixOS/nixpkgs/commit/78b9e1252d9d6f89973d804646c3979838ddaf94) | `retroarch,libretro: add myself as maintainer`                                                                                                                             |
| [`5fc7933a`](https://github.com/NixOS/nixpkgs/commit/5fc7933ab893fc4c6b973d39aef6685450ab626e) | `retroarch: update license`                                                                                                                                                |
| [`5ffd52d0`](https://github.com/NixOS/nixpkgs/commit/5ffd52d09fe8ee234ac0aec8d0937fa412f38163) | `ookla-speedtest: 1.0.0 -> 1.1.0`                                                                                                                                          |
| [`e9bbcb7f`](https://github.com/NixOS/nixpkgs/commit/e9bbcb7f1623b63465adc246b8e7d965c4b3b663) | `libretro: update core licenses`                                                                                                                                           |
| [`bbf12f11`](https://github.com/NixOS/nixpkgs/commit/bbf12f11ca9d45049ead289975c8bc702b826677) | `libretro: clean-up`                                                                                                                                                       |
| [`db9cb2dc`](https://github.com/NixOS/nixpkgs/commit/db9cb2dc1059daa53ac8d15461dbc2358c13cb37) | `libretro: name -> pname+version`                                                                                                                                          |
| [`75e1954f`](https://github.com/NixOS/nixpkgs/commit/75e1954f63ee8d89051fc2ffe6bf2b2e40949ced) | `retroarch: 1.9.13.2 -> 1.9.2`                                                                                                                                             |
| [`bf93ad6b`](https://github.com/NixOS/nixpkgs/commit/bf93ad6b391adebe3ab25be54d3b70e0f14fe0f7) | `retroarch: fix editorconfig error on hashes.json`                                                                                                                         |
| [`71fb8595`](https://github.com/NixOS/nixpkgs/commit/71fb85952dbbcb5829a504acadeadbc049811bab) | `libretro.citra: fix compilation`                                                                                                                                          |
| [`c03e4f14`](https://github.com/NixOS/nixpkgs/commit/c03e4f141a4b8aebbf2cb8c397992704f6e68aab) | `libretro: 2020-03-06 -> unstable-2021-11-16`                                                                                                                              |
| [`8b122f95`](https://github.com/NixOS/nixpkgs/commit/8b122f950c1d48b1d0ba500f48ba20a4c52f6370) | `libretro: add update.py script`                                                                                                                                           |
| [`14b2e99b`](https://github.com/NixOS/nixpkgs/commit/14b2e99b33e31d0d366a9150c94dd43ce256ba96) | `retroarch: 1.8.5 -> 1.9.13.2`                                                                                                                                             |
| [`4cba739c`](https://github.com/NixOS/nixpkgs/commit/4cba739c57296710e3e0523a723ed81d4e86bdf8) | `ion3: explicitly disable parallel builds`                                                                                                                                 |
| [`76c1bb81`](https://github.com/NixOS/nixpkgs/commit/76c1bb81060673f9c2e6991a95f85aa0840758e3) | `hyperscan: fix build`                                                                                                                                                     |
| [`98e19d03`](https://github.com/NixOS/nixpkgs/commit/98e19d03331e311516e5800a0c4776e88faa656a) | `gau: 1.2.0 -> 2.0.6`                                                                                                                                                      |
| [`8549cee7`](https://github.com/NixOS/nixpkgs/commit/8549cee791ba09705125e1e5d8799c098eba43a5) | `python3Packages.git-filter-repo: 2.33.0 -> 2.34.0`                                                                                                                        |
| [`4a6db133`](https://github.com/NixOS/nixpkgs/commit/4a6db1339ebaf1557f1443608d1e1c0dc8da8442) | `python3Packages.identify: 2.3.5 -> 2.3.6`                                                                                                                                 |
| [`7e0d7e40`](https://github.com/NixOS/nixpkgs/commit/7e0d7e407525b0b0d8c903842582f469d53808ad) | `python3Packages.rdflib-jsonld: remove as deprecated`                                                                                                                      |
| [`df371add`](https://github.com/NixOS/nixpkgs/commit/df371addaf8ebfbec1be049940d1bfad465d244f) | `python3Packages.schema-salad: fix for rdflib 6`                                                                                                                           |
| [`c66aeafd`](https://github.com/NixOS/nixpkgs/commit/c66aeafde960efb5d275a7485c2e99763b378f07) | `python3Packages.velbus-aio: 2021.11.6 -> 2021.11.7`                                                                                                                       |
| [`e8c3838f`](https://github.com/NixOS/nixpkgs/commit/e8c3838f9d4da4569dd1f18fab71510bad65be78) | `python3Packages.pylitterbot: 2021.10.1 -> 2021.11.0`                                                                                                                      |
| [`e342685f`](https://github.com/NixOS/nixpkgs/commit/e342685f43eb98650ed836c2cf3cde8c1e3d05f0) | `python3Packages.motioneye-client: 0.3.11 -> 0.3.12`                                                                                                                       |
| [`5aa715b6`](https://github.com/NixOS/nixpkgs/commit/5aa715b64ccdb934efa951a055ff6f41815cd1fc) | `python3Packages.librouteros: 3.1.0 -> 3.2.0`                                                                                                                              |
| [`b46e9fe6`](https://github.com/NixOS/nixpkgs/commit/b46e9fe6f3622c0ff924528b511d2cf250298bde) | `home-assistant: update component-packages`                                                                                                                                |
| [`4a2d7d38`](https://github.com/NixOS/nixpkgs/commit/4a2d7d38ce6695b11aa2fdb1dae3c1d999aadbc9) | `python3Packages.niko-home-control: init at 0.2.2`                                                                                                                         |
| [`4c138f6b`](https://github.com/NixOS/nixpkgs/commit/4c138f6bd65228d2a1f11d53079d0c110fcb90d3) | `nixos/locate: exclude by default version control systems and .cache`                                                                                                      |
| [`9c233088`](https://github.com/NixOS/nixpkgs/commit/9c2330881331ed5ab722f580a7227a6ec2ba13a6) | `terraform-providers.nomad: 1.4.5 -> 1.4.15`                                                                                                                               |
| [`a9e43d8a`](https://github.com/NixOS/nixpkgs/commit/a9e43d8a0785ce3c4e530bc6776f162a779f2f26) | `terraform-providers.github: 3.1.0 -> 4.18.0`                                                                                                                              |
| [`9dc45adf`](https://github.com/NixOS/nixpkgs/commit/9dc45adfb67675f98bb9e3e15a305f417cec2c5e) | `terraform-providers.consul: 2.8.0 -> 2.14.0`                                                                                                                              |
| [`700768fa`](https://github.com/NixOS/nixpkgs/commit/700768faa2107acb34250124650de19dbce3a1e7) | `terraform-providers: format`                                                                                                                                              |
| [`751887b1`](https://github.com/NixOS/nixpkgs/commit/751887b1f6044031baa5cf732f00db74ce9ceb64) | `terraform-providers: update nix command for nix 2.4`                                                                                                                      |
| [`84432ac3`](https://github.com/NixOS/nixpkgs/commit/84432ac34bd0d824cef9746b8a85810cfbcd7e22) | `sqlite: remove error prone ? null inputs, set meta.mainProgram`                                                                                                           |
| [`17b1055d`](https://github.com/NixOS/nixpkgs/commit/17b1055d652f6ffe6b41516c2b667e09ab024b66) | `plan9port: quick&dirty breakage fix`                                                                                                                                      |
| [`3f339f3c`](https://github.com/NixOS/nixpkgs/commit/3f339f3cf44d090e2cc624f89df81fdb29810a0a) | `profiles/base: add mtools`                                                                                                                                                |
| [`c9e8bf89`](https://github.com/NixOS/nixpkgs/commit/c9e8bf891414c807dba5e6da9e0f7144b47bcbca) | `gparted: add mtools, dosfstools`                                                                                                                                          |
| [`82a58da6`](https://github.com/NixOS/nixpkgs/commit/82a58da60babeaac51b0e65b523f0588130175ee) | `python3Packages.oocsi: init at 0.4.2`                                                                                                                                     |
| [`ea81ce6f`](https://github.com/NixOS/nixpkgs/commit/ea81ce6ff5f700f77c0f2d08e375a0301583d118) | `python3Packages.uptime-kuma-monitor: init at 1.0.0`                                                                                                                       |
| [`27988f4e`](https://github.com/NixOS/nixpkgs/commit/27988f4e845be7668424b69680082c44febca1b4) | `python3Packages.pyevilgenius: init at 1.0.0`                                                                                                                              |
| [`33cf9951`](https://github.com/NixOS/nixpkgs/commit/33cf9951348ca65fe66d31d30e0e66525be71ec4) | `truffleHog: 2.1.11 -> 2.2.1`                                                                                                                                              |
| [`62cec070`](https://github.com/NixOS/nixpkgs/commit/62cec07035a95e8763dcb9399300e2bf395c91ed) | `nixos/mjolnir: set rawHomeserverUrl in config`                                                                                                                            |
| [`4be0baff`](https://github.com/NixOS/nixpkgs/commit/4be0baff3cd03ab6095d4afd1721553987597b66) | `mjolnir: 1.1.20 -> 1.2.0`                                                                                                                                                 |
| [`63b4b861`](https://github.com/NixOS/nixpkgs/commit/63b4b8616b69dd1ee0be4b3d2098d9332ceee357) | `nixos/libinput: add module tests`                                                                                                                                         |
| [`e8f9f6ef`](https://github.com/NixOS/nixpkgs/commit/e8f9f6efb6d0c1692918ff3e260744201d2c84ca) | `haskell.compiler.ghcjs: fix evaluation regression`                                                                                                                        |
| [`607dd149`](https://github.com/NixOS/nixpkgs/commit/607dd14964ff962d3359d37c76489cd236e66b09) | `haskell.compiler.ghcHEAD: bootstrap using 8.10.7 binary`                                                                                                                  |
| [`c28ddd3f`](https://github.com/NixOS/nixpkgs/commit/c28ddd3fd5f538cdb0a6bca53da2a4390cc19d0a) | `haskell.compiler.ghcHEAD: 9.3.20210913 -> 9.3.20211111`                                                                                                                   |
| [`65d105da`](https://github.com/NixOS/nixpkgs/commit/65d105da1e6a4275495666cf939405c59b4b4845) | `hyper-haskell: remove broken flag`                                                                                                                                        |
| [`1b7f9b01`](https://github.com/NixOS/nixpkgs/commit/1b7f9b01fbefa5d3c31469357d33bd1d9be787ab) | `thunderbird-unwrapped: 91.3.0 -> 91.3.1`                                                                                                                                  |
| [`497cc96f`](https://github.com/NixOS/nixpkgs/commit/497cc96f323f15f0e7ad82b645396dc2bd273757) | `python3Packages.ihatemoney: unbreak with flask-wtf 1.0.0`                                                                                                                 |
| [`c7a180ab`](https://github.com/NixOS/nixpkgs/commit/c7a180ab0ce358f032755f536e8208fa206e5e64) | `nixos/libinput: improve docs`                                                                                                                                             |
| [`6e931423`](https://github.com/NixOS/nixpkgs/commit/6e9314230a09832e3e4320bbbc4949e7c7bdc4af) | `haskellPackages.git-annex: fix build with git-lfs 1.2.0`                                                                                                                  |
| [`7d3dbec3`](https://github.com/NixOS/nixpkgs/commit/7d3dbec3cc7f68313fa3d1d05a7f066a786e166e) | `haskellPackages.git-annex: move input overrides to configuration-nix`                                                                                                     |
| [`3266c514`](https://github.com/NixOS/nixpkgs/commit/3266c5142167d531bd723eca3a940c54cc4b65a3) | `haskellPackages.git-annex: refactor configuration-nix.nix overrides`                                                                                                      |
| [`01340b1e`](https://github.com/NixOS/nixpkgs/commit/01340b1e7c7e8fa243d6295bec9f636d2d589c7e) | `python38Packages.flask_wtf: 0.15.1 -> 1.0.0`                                                                                                                              |
| [`6327d72c`](https://github.com/NixOS/nixpkgs/commit/6327d72c55a701e9d5b552b74873c2f9216be4bd) | `haskellPackages.ghcide: allow newer implicit-hie-cradle`                                                                                                                  |
| [`0b7c86fd`](https://github.com/NixOS/nixpkgs/commit/0b7c86fded796e074f64dd991163a7512974c0a3) | `haskell.packages.ghc921.hashable-time: 0.2.1 -> 0.3`                                                                                                                      |
| [`5debbba1`](https://github.com/NixOS/nixpkgs/commit/5debbba1f6e7408206c62089c5cb4c62114a0289) | `haskell.packages.ghc921.cereal: drop now obsolete patch`                                                                                                                  |
| [`ac15a841`](https://github.com/NixOS/nixpkgs/commit/ac15a841cd4e151ae6ac2003d011f03d38323a53) | `haskellPackages.nix-tree: Build with a supported brick version`                                                                                                           |
| [`097602fa`](https://github.com/NixOS/nixpkgs/commit/097602fa2ea72abd600d2b3a22ea503ffc67246a) | `osmscout-server: Remove optional dependency mapnik`                                                                                                                       |
| [`1c2f36ac`](https://github.com/NixOS/nixpkgs/commit/1c2f36ac024bb9f72b0af9349957f2afa2b62bef) | `haskellPackages: regenerate package set based on current config`                                                                                                          |
| [`7748bd20`](https://github.com/NixOS/nixpkgs/commit/7748bd20a38e6adb51aac3727749b955e4a70341) | `haskellPackages.hadolint: overrideScope for correct dependency versions`                                                                                                  |
| [`f618f8ba`](https://github.com/NixOS/nixpkgs/commit/f618f8ba385527b09fb5ba4e914de9667ddc55cf) | `haskellPackages: adjust overrides for hspec update`                                                                                                                       |
| [`51eed17d`](https://github.com/NixOS/nixpkgs/commit/51eed17da007939b6991df38c348005684bc3dbe) | `haskellPackages: adjust overrides for doctest update`                                                                                                                     |
| [`8b92aabf`](https://github.com/NixOS/nixpkgs/commit/8b92aabf52e1d77df22ec368d5a8f3ebff9ffae0) | `haskellPackages: regenerate package set based on current config`                                                                                                          |
| [`9568b05c`](https://github.com/NixOS/nixpkgs/commit/9568b05c769f2b5da0f9432fc476609266a72314) | `all-cabal-hashes: 2021-11-05T06:34:09Z -> 2021-11-12T03:22:57Z`                                                                                                           |
| [`b1120b2a`](https://github.com/NixOS/nixpkgs/commit/b1120b2a0621a92c8f959f426d54c221d28a0b68) | `haskellPackages: stackage-lts 18.15 -> 18.16`                                                                                                                             |
| [`5d389f21`](https://github.com/NixOS/nixpkgs/commit/5d389f21e1744c0131e6be31994978c4062a5412) | `chia: 1.2.10 -> 1.2.11`                                                                                                                                                   |
| [`29791cd7`](https://github.com/NixOS/nixpkgs/commit/29791cd7aa0deddca087836a18da1e8cf94180e3) | `python3Packages.chiapos: 1.0.4 -> 1.0.6`                                                                                                                                  |
| [`8ac53921`](https://github.com/NixOS/nixpkgs/commit/8ac539219d5c71657d27ee45c92eda24a758f826) | `python3Packages.clvm-rs: 0.1.14 -> 0.1.15`                                                                                                                                |
| [`516f2db6`](https://github.com/NixOS/nixpkgs/commit/516f2db69849ae66956f634c466f741afa451a8c) | `python3Packages.dnspythonchia: init at 2.2.0`                                                                                                                             |
| [`3109dcbf`](https://github.com/NixOS/nixpkgs/commit/3109dcbfb9e98dc3c25b679abe883ed457e9dedd) | `aliyun-cli: init at 3.0.94`                                                                                                                                               |
| [`1de5c1d8`](https://github.com/NixOS/nixpkgs/commit/1de5c1d803f8c33eed5eb6d79d0568026053c65e) | `maintainers: add ornxka`                                                                                                                                                  |
| [`833cad6a`](https://github.com/NixOS/nixpkgs/commit/833cad6a35f5ae3cc3f7ffa5b5735455e0d1f065) | `earthly: 0.5.22 → 0.5.24`                                                                                                                                                 |
| [`edfd0b67`](https://github.com/NixOS/nixpkgs/commit/edfd0b67c38bbbe5db707a2937afac051f938dfa) | `lite-xl: init at 2.0.1`                                                                                                                                                   |
| [`837957f9`](https://github.com/NixOS/nixpkgs/commit/837957f919ed27b98511d10a20f61efac4097ee9) | `electron-mail: 4.12.2 -> 4.12.7`                                                                                                                                          |
| [`ba489ce3`](https://github.com/NixOS/nixpkgs/commit/ba489ce3183a840d96cb3e8e1a431a63eb6c2f79) | `agg: enable build on darwin`                                                                                                                                              |
| [`9b6319ed`](https://github.com/NixOS/nixpkgs/commit/9b6319edee1fa384bf6b8662d4e7732d611cb582) | `maintainers: add boppyt`                                                                                                                                                  |
| [`b681ad32`](https://github.com/NixOS/nixpkgs/commit/b681ad32540c5bcb93d3cb98dfd25f22f2eb5503) | `buildFHSUserEnv: Allow having custom /opt in the FHS environment`                                                                                                         |