### PR TITLE
chore(flake/inputs/home-manager): `2452979e` -> `8230decb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -62,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1637249535,
-        "narHash": "sha256-RCatEYQ+uqsZOZpN4ZOtSoO7CJTiQpHNdPjUA0jtejw=",
+        "lastModified": 1637362702,
+        "narHash": "sha256-WFGEXrh2wWHi5DLdUX1qM5T3P5TgmVE6AyM+bVuOaNs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2452979efe92128b03e3c27567267066c2825fab",
+        "rev": "8230decb3f0cb3408607accc93e5d0951ebf3963",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                          |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`8230decb`](https://github.com/nix-community/home-manager/commit/8230decb3f0cb3408607accc93e5d0951ebf3963) | `home-environment: make `home.profileDirectory` public` |
| [`398c0b36`](https://github.com/nix-community/home-manager/commit/398c0b36a3d8f7285db938468f46e82cf1a3d746) | `home-manager: properly forward exit codes`             |