### PR TITLE
chore(flake/inputs/nixpkgs): `d9e8a587` -> `5de36a04`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1637289634,
-        "narHash": "sha256-JEbbn6ARkzJX39VEvKwScJxqJgO3wMcZpjY94AOR6ME=",
+        "lastModified": 1637340937,
+        "narHash": "sha256-cwGxNcYZLa1wk6sO94ETGLAJnpubpjLhNbStF+648+U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d9e8a587e143aa8d3f1594004d63b5c785b416fb",
+        "rev": "5de36a0410f17639ac7bb860781269c1791e7de6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                        |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`7cb6bb06`](https://github.com/NixOS/nixpkgs/commit/7cb6bb064a3250922f3916cabad2f185331d9f68) | `synology-drive-client: init at 3.0.2 (#144706)`                      |
| [`e7e34805`](https://github.com/NixOS/nixpkgs/commit/e7e3480530b34a9fe8cb52963ec2cf66e6707e15) | `zsh-vi-mode: init at v0.8.5`                                         |
| [`2e75b280`](https://github.com/NixOS/nixpkgs/commit/2e75b280a7aac9b490249efb7a78a7fd836787a9) | `prometheus-nginx-exporter: boolean conversion to string`             |
| [`307e6576`](https://github.com/NixOS/nixpkgs/commit/307e65762109d577edc187b9d8a1fbfd200e0ac8) | `matrix-corporal: 2.1.0 -> 2.2.0`                                     |
| [`af4b47ec`](https://github.com/NixOS/nixpkgs/commit/af4b47ecd7e7cc83d240bd9264f4b4704764f860) | `libvirt: fix build on aarch64-darwin`                                |
| [`852a72a7`](https://github.com/NixOS/nixpkgs/commit/852a72a70b0e0805d5a4a03a412cd1b63393c7e3) | `gimx: refactor`                                                      |
| [`f3ece9f2`](https://github.com/NixOS/nixpkgs/commit/f3ece9f26cb1ddd4f31359d6151852fa86818648) | `nixosTests.aseprite: init`                                           |
| [`6ac64dc1`](https://github.com/NixOS/nixpkgs/commit/6ac64dc1c403ce6fce6c00a59a46dedfe0b12160) | `libresprite: init at 1.0`                                            |
| [`2ff27bbc`](https://github.com/NixOS/nixpkgs/commit/2ff27bbc8e46c2c602474f76da322c9bef14307c) | `deno: run deno fmt on update script`                                 |
| [`c5ab7812`](https://github.com/NixOS/nixpkgs/commit/c5ab781203b224d53f1c4d2ea12b24cd8cf1e05f) | `deno: 1.15.3 -> 1.16.2`                                              |
| [`cb86d674`](https://github.com/NixOS/nixpkgs/commit/cb86d6749cfdccebff3c5f7bac52ec9b669aed8c) | `python3Packages.qcs-api-client: 0.18.0 -> 0.19.0`                    |
| [`c4f57b94`](https://github.com/NixOS/nixpkgs/commit/c4f57b9489400f52bc7add26574bbc6051c35634) | `vscodium: add bobby285271 as maintainer`                             |
| [`d4482218`](https://github.com/NixOS/nixpkgs/commit/d448221824bdfcafbaabb687447a696e1926f959) | `e16: 1.0.23 -> 1.0.24`                                               |
| [`e9b7f556`](https://github.com/NixOS/nixpkgs/commit/e9b7f5564a257a5e3ad83399b023f3f060aaddf6) | `vscode: add bobby285271 as maintainer`                               |
| [`b246e289`](https://github.com/NixOS/nixpkgs/commit/b246e2890277249cb5db6877c5e0203950a5ceee) | `icinga2: Fix infinite loop regression`                               |
| [`02548607`](https://github.com/NixOS/nixpkgs/commit/02548607661d360f71066bda1e84917a6095ede1) | `imagej: fix crash with opening dialogs (#142841)`                    |
| [`fb1a99cd`](https://github.com/NixOS/nixpkgs/commit/fb1a99cd6c9f43c366c92e3bdd2b8158d80febf1) | `xfce.xfce4-sensors-plugin: 1.4.1 -> 1.4.2`                           |
| [`f880bff2`](https://github.com/NixOS/nixpkgs/commit/f880bff2e6a63d68809269d76f032e4fe7e0556f) | `xfce.xfce4-whiskermenu-plugin: 2.6.1 -> 2.6.2`                       |
| [`02b78277`](https://github.com/NixOS/nixpkgs/commit/02b7827778413ec41d54b95f28bb670632e7a71e) | `vscodium: 1.62.2 -> 1.62.3`                                          |
| [`020bfe27`](https://github.com/NixOS/nixpkgs/commit/020bfe27994ccff45a64b6e4bc23f865132a07ac) | `xfce.thunar-media-tags-plugin: odd numbered minor version is stable` |
| [`cc7a0816`](https://github.com/NixOS/nixpkgs/commit/cc7a0816fa5530d46142f90e7a3e1f355f02d866) | `nheko: 0.8.2 -> 0.9.0`                                               |
| [`d49cad9b`](https://github.com/NixOS/nixpkgs/commit/d49cad9badd6310b2b150fbc688c49c6986c0e57) | `kitsas: 3.0 → 3.1.1, enable on darwin`                               |
| [`52188a4c`](https://github.com/NixOS/nixpkgs/commit/52188a4cbf2e5bbc09c0d7c8a8a328a0c1a74a0f) | `icinga2: Fix path to icinga2 binary`                                 |
| [`c6023821`](https://github.com/NixOS/nixpkgs/commit/c60238215c2f2c3e3b9e56cd4a9acd5596245bd6) | `mtxclient: 0.5.1 -> 0.6.0`                                           |
| [`27b1450a`](https://github.com/NixOS/nixpkgs/commit/27b1450afa4823b79487ae2c3298bc014755a89e) | `coeurl: init at 0.1.0`                                               |
| [`1331b3d2`](https://github.com/NixOS/nixpkgs/commit/1331b3d252e92c78087b82afc44d912c28f1c5c4) | `nixos/getty: remove serialSpeed`                                     |
| [`ca0fd306`](https://github.com/NixOS/nixpkgs/commit/ca0fd306e22b7d093cb96bcb34dbe05629789994) | `python3Packages.pyqtgraph: skip tests failing on non-x86`            |
| [`01fd2714`](https://github.com/NixOS/nixpkgs/commit/01fd2714c6f4521316575057fe5f4ed56037966d) | `pn: unstable-2021-01-28 -> 0.9.0`                                    |
| [`ffad12ae`](https://github.com/NixOS/nixpkgs/commit/ffad12aea1f43a90d7600a54e2236926ec5e49fe) | `libphonenumber: 8.11.3 -> 8.12.37`                                   |
| [`93dccfb6`](https://github.com/NixOS/nixpkgs/commit/93dccfb659e6eb827d07842e338433ae60ed1d11) | `flexget: 3.1.152 -> 3.1.153`                                         |
| [`4d28812e`](https://github.com/NixOS/nixpkgs/commit/4d28812ef41cdfe0e957da03af8357ee7d0b34ba) | `qalculate-gtk: 3.20.1 -> 3.21.0`                                     |
| [`f4e78560`](https://github.com/NixOS/nixpkgs/commit/f4e7856085d5eaa920885bfd6a94169dd5999a16) | `python3Packages.python-language-server: mark as broken`              |
| [`8df86556`](https://github.com/NixOS/nixpkgs/commit/8df865561fbc53922f1e801c3deeb53c12ce8c4f) | `python3Packages.pdftotext: fix build on darwin`                      |
| [`181f7a78`](https://github.com/NixOS/nixpkgs/commit/181f7a78306944818a695035e0c22cf7f04c2888) | `bullet: fix build on darwin`                                         |
| [`c1f20006`](https://github.com/NixOS/nixpkgs/commit/c1f200061dd1418ec373886e1833f06bb2948e68) | `libcryptui: use gtk3-x11 on darwin`                                  |
| [`e1361b69`](https://github.com/NixOS/nixpkgs/commit/e1361b69d9e45d5d877386b918f70b7e6c3ff6b0) | `l2md: unstable-2020-07-31 -> unstable-2021-10-27`                    |
| [`3b8e3619`](https://github.com/NixOS/nixpkgs/commit/3b8e361939b1db7b5194dca2f10e66622c56ae59) | `pantheon.wingpanel-indicator-sound: 6.0.0 -> 6.0.1`                  |
| [`669740ba`](https://github.com/NixOS/nixpkgs/commit/669740ba937fb7f821a9528e9b6f5e1a6c5d4ab6) | `vscode: 1.62.2 -> 1.62.3`                                            |
| [`7bb21fc6`](https://github.com/NixOS/nixpkgs/commit/7bb21fc6e65911efae2f4bd22743085f25efa4b0) | `sngrep: pull upstream fix for ncurses-6.3`                           |
| [`58aae575`](https://github.com/NixOS/nixpkgs/commit/58aae5758e58e80da9cfc9def64d0022f818c39d) | `profanity: pull upstream fixes for ncurses-6.3`                      |
| [`bdb11339`](https://github.com/NixOS/nixpkgs/commit/bdb113393585e0e8d675d1ebba1416c432584c17) | `sakura: 3.8.3 -> 3.8.4`                                              |
| [`2b310dd3`](https://github.com/NixOS/nixpkgs/commit/2b310dd32bf4dd984a5a0b9e6e026ac6a6c282c5) | `wxSVG: 1.5.22 -> 1.5.23`                                             |
| [`440af742`](https://github.com/NixOS/nixpkgs/commit/440af7420e01b8d7f72638a643f89a0e87cd2991) | `lnd: 0.13.4-beta -> 0.14.0-beta`                                     |
| [`e40599d4`](https://github.com/NixOS/nixpkgs/commit/e40599d46b5e99f58ac473258474791fe04f22cc) | `kristal: add missing wrapQtAppsHook  argument`                       |
| [`8d904c69`](https://github.com/NixOS/nixpkgs/commit/8d904c69010c556b86531e23c0bf762f8c378bc3) | `kristal: add wrapQtAppsHook`                                         |
| [`4d01b4ac`](https://github.com/NixOS/nixpkgs/commit/4d01b4ac9bfc6202ef7874fbb1897cec1b37953c) | `kristall: don't use libsForQt5.mkDerivation`                         |
| [`6d4e19be`](https://github.com/NixOS/nixpkgs/commit/6d4e19beb6eb541a1010118033799a369f1fc9ec) | `python3Packages.pyezviz: 0.1.9.9 -> 0.2.0.0`                         |
| [`170255c3`](https://github.com/NixOS/nixpkgs/commit/170255c3a335db242970aebfaf277b7cefeb2c35) | `linux/hardened/patches/5.4: 5.4.159-hardened1 -> 5.4.160-hardened1`  |
| [`63833276`](https://github.com/NixOS/nixpkgs/commit/6383327644ff133c8a8f841e9563e3f153520d1e) | `linux/hardened/patches/5.15: 5.15.2-hardened1 -> 5.15.3-hardened1`   |
| [`cc0a7581`](https://github.com/NixOS/nixpkgs/commit/cc0a75815db600e6ae58be19c2faf42819f6d5b7) | `linux/hardened/patches/5.14: 5.14.18-hardened1 -> 5.14.20-hardened1` |
| [`51bd34b7`](https://github.com/NixOS/nixpkgs/commit/51bd34b742c1971baedf14697e6e70871f7029d0) | `linux/hardened/patches/5.10: 5.10.78-hardened1 -> 5.10.80-hardened1` |
| [`c871adc7`](https://github.com/NixOS/nixpkgs/commit/c871adc77c189683716ff67c199ad5a21140fa47) | `linux_latest-libre: 18452 -> 18473`                                  |
| [`83c1df75`](https://github.com/NixOS/nixpkgs/commit/83c1df7574c9fc93776ea798349113d6b1c7c08b) | `linux: 5.4.159 -> 5.4.160`                                           |
| [`be5a54e9`](https://github.com/NixOS/nixpkgs/commit/be5a54e9526743d3b5e860048eb483ab434c9811) | `linux: 5.15.2 -> 5.15.3`                                             |
| [`654052ab`](https://github.com/NixOS/nixpkgs/commit/654052abbbf849197a892495db941e57f6d2314d) | `linux: 5.14.18 -> 5.14.20`                                           |
| [`8cf6618d`](https://github.com/NixOS/nixpkgs/commit/8cf6618d0ca429709ed0c64f5c3bacbcc7fc1546) | `linux: 5.10.79 -> 5.10.80`                                           |
| [`0d38cca7`](https://github.com/NixOS/nixpkgs/commit/0d38cca78a576417f3fbcdb5921d28443399b2e8) | `stella: 6.5.3 -> 6.6`                                                |
| [`7f084162`](https://github.com/NixOS/nixpkgs/commit/7f08416298a8a601b2f949cc1a0b63b68568f264) | `tcsh: 6.22.04 -> 6.23.00`                                            |
| [`1b323e03`](https://github.com/NixOS/nixpkgs/commit/1b323e036ce3bd0816e79c1cdef02eb1ba063f57) | `babashka: 0.6.4 -> 0.6.5`                                            |
| [`71f6dcfc`](https://github.com/NixOS/nixpkgs/commit/71f6dcfcc234ef35f9b16b9a3acc747a679755a4) | `vnote: 3.8.1 -> 3.10.1`                                              |
| [`c3da3ce7`](https://github.com/NixOS/nixpkgs/commit/c3da3ce7390bbd7933d50090e668439baf050b2e) | `kristall: fix build on darwin`                                       |
| [`5f8dc66f`](https://github.com/NixOS/nixpkgs/commit/5f8dc66f42f3ea33aac9a48087d3f9ada10733b3) | `cmigemo: fix Darwin build`                                           |
| [`443bb334`](https://github.com/NixOS/nixpkgs/commit/443bb33421dc33ff8723b1de3a394f0553a71eb9) | `skk-dicts: fix Darwin build`                                         |
| [`f5f12888`](https://github.com/NixOS/nixpkgs/commit/f5f128881010c17f86e0c1d79e1bb51f7d752913) | `hydrus: 461 -> 462`                                                  |
| [`f0fe254d`](https://github.com/NixOS/nixpkgs/commit/f0fe254d5f623f9a11d66a0819cbf866a8140245) | `python39Packages.grpcio-tools: 1.41.0 -> 1.42.0`                     |
| [`deb8e275`](https://github.com/NixOS/nixpkgs/commit/deb8e275eac9606c4387d2fb24ec5c82cdac6b73) | `grpc: 1.41.0 -> 1.42.0`                                              |
| [`a54392ef`](https://github.com/NixOS/nixpkgs/commit/a54392efdaa1506549eb567958144002241b081a) | `wg-friendly-peer-names: init at unstable-2021-11-08`                 |
| [`cfc583dd`](https://github.com/NixOS/nixpkgs/commit/cfc583ddcd48182824dc1550144f8e25f1fea6d2) | `alfis: 0.6.5 -> 0.6.9`                                               |
| [`397efc26`](https://github.com/NixOS/nixpkgs/commit/397efc26cb4bc609adb95fc79031e6d2b6f0f7cd) | `blocksat-cli: use disabledTestPaths`                                 |
| [`670f5474`](https://github.com/NixOS/nixpkgs/commit/670f5474b955ae020ee0d794a5a688a2918c6c47) | `nixos/{startx,xserver,sx}: make it possible to use both a gui dm`    |
| [`1e498cb0`](https://github.com/NixOS/nixpkgs/commit/1e498cb0286ca624d161c7607e363182962dc57c) | `jboss-mysql-jdbc: remove build.sh`                                   |
| [`f93a7f8b`](https://github.com/NixOS/nixpkgs/commit/f93a7f8b56adcd8e19ed759de576e39e64576ecf) | `nixos-generate-config: automatically enable microcode updates`       |
| [`7b6a800b`](https://github.com/NixOS/nixpkgs/commit/7b6a800bd2adb86afa3eab0b133ec71615b3d389) | `python38Packages.python-openstackclient: 5.6.0 -> 5.7.0`             |
| [`5c18e504`](https://github.com/NixOS/nixpkgs/commit/5c18e50477a2b4f48510329b460b902cc95a4166) | `ktlint: 0.42.1 -> 0.43.0`                                            |
| [`e9d77861`](https://github.com/NixOS/nixpkgs/commit/e9d77861bb1fca63388851436890c74583eed8e4) | `moonraker: unstable-2021-10-24 -> unstable-2021-11-13`               |
| [`40e650fa`](https://github.com/NixOS/nixpkgs/commit/40e650fa3d1e20cf8bd734558cc7abb6fc2e4963) | `marktext: 0.16.2 -> 0.16.3`                                          |
| [`0996886c`](https://github.com/NixOS/nixpkgs/commit/0996886c85dd50c91ae9e0f143d14cecf9c224a6) | `radare2: Add darwin support`                                         |
| [`4d25878c`](https://github.com/NixOS/nixpkgs/commit/4d25878cd2dd60edf4a819d578d5a6381eae1fa3) | `libewf: Add bzip2 dependency for darwin`                             |
| [`ac1f1bbc`](https://github.com/NixOS/nixpkgs/commit/ac1f1bbcf987474bb701a628d0dc6d35f7340273) | `dasel: 1.21.2 -> 1.22.1`                                             |
| [`5609f84d`](https://github.com/NixOS/nixpkgs/commit/5609f84d1b7720d7d9f15df3d58dcf37d9248807) | `nixos/webdav: init`                                                  |
| [`028d78ea`](https://github.com/NixOS/nixpkgs/commit/028d78ea58c426a72cad7241ff2ba4bb66b160b5) | `proxysql: init at 2.3.2`                                             |
| [`ab844b2c`](https://github.com/NixOS/nixpkgs/commit/ab844b2cf3c1fa3e7ca5e5f44ad171dc22d02afa) | `webdav: init at 4.1.1`                                               |
| [`a76d49ea`](https://github.com/NixOS/nixpkgs/commit/a76d49eaf8e4ebac1d32e124e3171dd03d96c12f) | `gitstats: switch to fetchFromGitHub`                                 |
| [`e4726e19`](https://github.com/NixOS/nixpkgs/commit/e4726e19e70808a27947fa7e828640da2a7feca1) | `gitinspector: switch to fetchFromGitHub`                             |
| [`7dfb8534`](https://github.com/NixOS/nixpkgs/commit/7dfb853434b5a1124c664d3fdb6f28274e640956) | `svn2git: switch to fetchFromGitHub`                                  |
| [`3a2808ea`](https://github.com/NixOS/nixpkgs/commit/3a2808eab1c3f9bc0d954464f3b3e32f59bf1caa) | `mytetra: switch to fetchFromGitHub`                                  |
| [`58993fbd`](https://github.com/NixOS/nixpkgs/commit/58993fbd4da683d5d0d25a78e340a94f6bc48543) | `ib/controller: switch to fetchFromGitHub`                            |
| [`51d7d762`](https://github.com/NixOS/nixpkgs/commit/51d7d762066085cf79bb4c69017eaa000b8f187d) | `scudcloud: switch to fetchFromGitHub`                                |
| [`7849d376`](https://github.com/NixOS/nixpkgs/commit/7849d37611f343f439cea7c3a527b9364163497c) | `ricochet: switch to fetchFromGitHub`                                 |
| [`a1cea09c`](https://github.com/NixOS/nixpkgs/commit/a1cea09cd57f7f0a6733bed3f2759449e6ca607e) | `fme: switch to fetchFromGitHub`                                      |
| [`2a8a50b4`](https://github.com/NixOS/nixpkgs/commit/2a8a50b45731921aa9c1c60bb6d461ec18354626) | `particl-core: switch to fetchFromGitHub`                             |
| [`2e74d854`](https://github.com/NixOS/nixpkgs/commit/2e74d854f3749c2dd8f72fba76d656791ae7dd35) | `swh-lv2: switch to fetchFromGitHub`                                  |
| [`fb1cc88a`](https://github.com/NixOS/nixpkgs/commit/fb1cc88a084a1c1e4dcf12116ec9dfe4030ca827) | `ladspa-plugins: switch to fetchFromGitHub`                           |
| [`221ec72f`](https://github.com/NixOS/nixpkgs/commit/221ec72f0ed9a12dc035a9e8137b8abd456ef1eb) | `hydrogen0: switch to fetchFromGitHub`                                |
| [`82bb0302`](https://github.com/NixOS/nixpkgs/commit/82bb0302ca8203bbf947a4ec8ea66140f1e6a1e4) | `hybridreverb2: switch to fetchFromGitHub`                            |
| [`aeb416bb`](https://github.com/NixOS/nixpkgs/commit/aeb416bb22b32b4fbb23001956417202be9e0259) | `cadence: switch to fetchFromGitHub`                                  |
| [`282f7608`](https://github.com/NixOS/nixpkgs/commit/282f76086fc555a85c4583a5bea70585b7bb0863) | `octavePackages.tsa: 4.6.2 -> 4.6.3`                                  |
| [`7b8dd951`](https://github.com/NixOS/nixpkgs/commit/7b8dd9515e3aed98b9ef8cf02df3179647f2ec54) | `octavePackages.nan: 3.5.3 -> 3.6.0`                                  |
| [`1203df18`](https://github.com/NixOS/nixpkgs/commit/1203df184ac5e6f10410dbee9578a7938b50b400) | `octavePackages.zeromq: 1.5.2 -> 1.5.3`                               |
| [`637ddb77`](https://github.com/NixOS/nixpkgs/commit/637ddb776c6bca487573bc6ea62d9edc66ba7f22) | `octavePackages.sparsersb: 1.0.8 -> 1.0.9`                            |
| [`098b0a2d`](https://github.com/NixOS/nixpkgs/commit/098b0a2df383de31c6621a213a61887d64f90bc5) | `octavePackages.control: 3.3.0 -> 3.3.1`                              |
| [`4a2a66bb`](https://github.com/NixOS/nixpkgs/commit/4a2a66bb6d0379a5dcc724dd1eb9d3cfb038e6a2) | `octavePackages.audio: 2.0.2 -> 2.0.3`                                |
| [`e80c50b4`](https://github.com/NixOS/nixpkgs/commit/e80c50b44d362e7facce8fc93564c844d0b624cc) | `octavePackages: buildOctavePackage respects user-provided hooks`     |
| [`879d7ee0`](https://github.com/NixOS/nixpkgs/commit/879d7ee0c19f1f2e3e775f318a1ea316f72b3414) | `step-ca: 0.17.4 -> 0.17.6`                                           |
| [`e4f37d28`](https://github.com/NixOS/nixpkgs/commit/e4f37d28eedbf1e566a526aa516d5ac308d8f622) | `ikiwiki: Use python with pygments package`                           |
| [`4007e03a`](https://github.com/NixOS/nixpkgs/commit/4007e03a20086b4b02f65336055c85fe55ffb97c) | `ikiwiki: Patch shebangs in plugins`                                  |
| [`a2e7a452`](https://github.com/NixOS/nixpkgs/commit/a2e7a452be8b5bbd63985de3f1f54d74e28e348b) | `ikiwiki: Apply upstream fix for highlight-4.0 compatibility`         |
| [`d38e03f3`](https://github.com/NixOS/nixpkgs/commit/d38e03f307d1a8d4229b38d3e330d8d1af7e6626) | `ikiwiki: Make myself a maintainer`                                   |
| [`1259ad6c`](https://github.com/NixOS/nixpkgs/commit/1259ad6cb09e92290f11e300830a3e198c65dec1) | `x11docker: 6.9.0 -> 6.10.0`                                          |
| [`c0cf3d69`](https://github.com/NixOS/nixpkgs/commit/c0cf3d69d0b71b781cfa9963db65131b538286cc) | `ocserv: 0.12.6 -> 1.1.2`                                             |