### PR TITLE
chore(flake/home-manager): `8230decb` -> `c82bc787`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -62,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1637362702,
-        "narHash": "sha256-WFGEXrh2wWHi5DLdUX1qM5T3P5TgmVE6AyM+bVuOaNs=",
+        "lastModified": 1637398047,
+        "narHash": "sha256-H6yh2VvABMhrkjYrPccc0Buak4L9jtFzsb98FsNDM2Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8230decb3f0cb3408607accc93e5d0951ebf3963",
+        "rev": "c82bc787b8990c89f2f7d57df652ce2424129b92",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                 |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`c82bc787`](https://github.com/nix-community/home-manager/commit/c82bc787b8990c89f2f7d57df652ce2424129b92) | `xdg: fix typo and add test`                   |
| [`a19f40d3`](https://github.com/nix-community/home-manager/commit/a19f40d39dfedb9158c29566169f49c6b80a8865) | `firefox: fix test case`                       |
| [`8a16d62e`](https://github.com/nix-community/home-manager/commit/8a16d62e953a3bd16f1c5c9538bb9099c52de1e6) | `flameshot: extend module with package-option` |