### PR TITLE
chore(flake/nixpkgs): `5de36a04` -> `fa9d6c3d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1637340937,
-        "narHash": "sha256-cwGxNcYZLa1wk6sO94ETGLAJnpubpjLhNbStF+648+U=",
+        "lastModified": 1637384301,
+        "narHash": "sha256-ebJiY+FvwO2EX6cH995PNb2MmAX9M5iIaH+qNH5upuE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5de36a0410f17639ac7bb860781269c1791e7de6",
+        "rev": "fa9d6c3d9328e84787451c05170cf816295aa630",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                          |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`9a675cdc`](https://github.com/NixOS/nixpkgs/commit/9a675cdced37e86412e8724cc59b21a53d90f872) | `joshuto: 0.9.1 -> 0.9.2`                                               |
| [`908fc4af`](https://github.com/NixOS/nixpkgs/commit/908fc4afe847d3937b3722e7d1b0c28aa1f93bd0) | `python3Packages.alembic: 1.7.4 -> 1.7.5`                               |
| [`bcbc7c0f`](https://github.com/NixOS/nixpkgs/commit/bcbc7c0f21b2b6ec6cabf9a597e61174e87dfdd7) | `coreboot-toolchain: Add other target architectures`                    |
| [`8002a4a1`](https://github.com/NixOS/nixpkgs/commit/8002a4a1337ef874f8721eda787d2e95d13b05c6) | `coreboot-toolchain: Allow adding new architectures`                    |
| [`997d559b`](https://github.com/NixOS/nixpkgs/commit/997d559bb32b75c1673d2a8b5a4af1a5760f8820) | `PULL_REQUEST_TEMPLATE.md: fix link to nix.conf documentation`          |
| [`939caa7f`](https://github.com/NixOS/nixpkgs/commit/939caa7fb77028634d31956db72480c204752f9e) | `python3Packages.m3u8: 0.6.0 -> 0.9.0`                                  |
| [`2b84c77b`](https://github.com/NixOS/nixpkgs/commit/2b84c77b3e4f439ef4f004c1ad5cd7f12a4bfab0) | `python3Packages.m3u8: fix build on Hydra (x86_64-darwin)`              |
| [`8e4ef58a`](https://github.com/NixOS/nixpkgs/commit/8e4ef58acbadbeba439ad6030502d27f1724fd1b) | `python3Packages.m3u8: use pytestCheckHook`                             |
| [`2490c511`](https://github.com/NixOS/nixpkgs/commit/2490c511c40fcf7850c4cc0146145818fca8d26d) | `g933-utils: 2019-08-04 -> 2021-11-19, fix build`                       |
| [`2e6ae6cf`](https://github.com/NixOS/nixpkgs/commit/2e6ae6cf7ce6dad67541ac24f7c8eef18090c538) | `python3Packages.xdg: 5.0.2 -> 5.1.1`                                   |
| [`4df9292e`](https://github.com/NixOS/nixpkgs/commit/4df9292e9bb623972509a6595bf202632d905dc7) | `haskellPackages.mime-string: disable optimization for older compilers` |
| [`18e1ae0d`](https://github.com/NixOS/nixpkgs/commit/18e1ae0d99c10ff83c51a6a4214e7f70c2e17d10) | `bcompare: add darwin support (#141413)`                                |
| [`771d7823`](https://github.com/NixOS/nixpkgs/commit/771d7823a483ea08e7b9c3421cafdf0397e2e2f9) | `python3Packages.devolo-plc-api: init at 0.6.3`                         |
| [`54caa42f`](https://github.com/NixOS/nixpkgs/commit/54caa42f9e88d2b93e1367dc7952b87b1e93b655) | `catgirl: enable parallel building`                                     |
| [`de18d833`](https://github.com/NixOS/nixpkgs/commit/de18d833598fe4e30649fe248fd71f8313c48250) | `python3Packages.libversion: 1.2.3 -> 1.2.4`                            |
| [`a11b863e`](https://github.com/NixOS/nixpkgs/commit/a11b863ecef842452580db0b897e867c84767139) | `python39Packages.sanic: disable some flaky tests`                      |
| [`c8304d13`](https://github.com/NixOS/nixpkgs/commit/c8304d130f642e6ef64bf56e4851f9510e639c49) | `retroarch: 1.9.2 -> 1.9.13.2`                                          |
| [`4d8cd39b`](https://github.com/NixOS/nixpkgs/commit/4d8cd39b0bc9a24ef7a667ebe45ff301c1542f77) | `libfprint-tod: 1.90.7 -> 1.94.1`                                       |
| [`46179208`](https://github.com/NixOS/nixpkgs/commit/46179208cfe95ca627c88d4595dbc8f2fb3ebdac) | `cogl: switch to pname+version`                                         |
| [`7d51dd7d`](https://github.com/NixOS/nixpkgs/commit/7d51dd7da281fd3cb0d2b5a998daafb96451392c) | `tfsec: 0.59.0 -> 0.60.0`                                               |
| [`4d8d035c`](https://github.com/NixOS/nixpkgs/commit/4d8d035c6c89c95f2b0cffcd265181c02c8ea114) | `Removed rittelle from the maintainer list`                             |
| [`29ed2bbe`](https://github.com/NixOS/nixpkgs/commit/29ed2bbe02b55edd089d092f9a5a7bbd74c705b5) | `fricas: fix build`                                                     |
| [`cfc61a2e`](https://github.com/NixOS/nixpkgs/commit/cfc61a2eeef7fa7758aa781220d489afd8683d14) | `python3Packages.igraph: update pname`                                  |
| [`c8f84689`](https://github.com/NixOS/nixpkgs/commit/c8f846893c6c7b415864433a0d6f29790d96716a) | `openjfx11: require-big-parallel`                                       |
| [`b23e8639`](https://github.com/NixOS/nixpkgs/commit/b23e8639594a3a45b92502642ca5f364c979c8e5) | `gigedit: use old pangomm version`                                      |
| [`d6c8ed25`](https://github.com/NixOS/nixpkgs/commit/d6c8ed25be6ce9b0cb2aaa89b369bae38398f7e2) | `luabind: fix build`                                                    |
| [`f4cd131e`](https://github.com/NixOS/nixpkgs/commit/f4cd131e3841884271e9f88c7fa358d19f248249) | `roomeqwizard: init at 5.20.4`                                          |
| [`3962f856`](https://github.com/NixOS/nixpkgs/commit/3962f85607792b81511e88fb650404aa1fc4f88f) | `drush: fix build`                                                      |
| [`8aa3e1f4`](https://github.com/NixOS/nixpkgs/commit/8aa3e1f42a4b80921c979802360ae185de2e0d4e) | `mariadb-galera: 26.4.9 -> 26.4.10`                                     |
| [`1fa2e5fd`](https://github.com/NixOS/nixpkgs/commit/1fa2e5fdc98cde196b4c8fa97314254b11138e96) | `mariadb: move patches to subfolder`                                    |
| [`595511e6`](https://github.com/NixOS/nixpkgs/commit/595511e63283fb705c98c07732d63755a729bf5e) | `mariadb: cleanup build configuration`                                  |
| [`cff899a9`](https://github.com/NixOS/nixpkgs/commit/cff899a959785e507f3443211ba8d5d92c8437ba) | `mariadb: add pmem support`                                             |
| [`be52b464`](https://github.com/NixOS/nixpkgs/commit/be52b4640f72d5489407728983dcca236affba72) | `mariadb: move fix mytop to common stage`                               |
| [`7d6eb8fb`](https://github.com/NixOS/nixpkgs/commit/7d6eb8fb6676c92cf4295a72d0763bfd03f9847e) | `electron_16: 16.0.0 -> 16.0.1`                                         |
| [`b3c72ce7`](https://github.com/NixOS/nixpkgs/commit/b3c72ce7c67b388d4834ff6ae319d76136ac09b1) | `wezterm: Mark build broken for Darwin`                                 |
| [`d9a85999`](https://github.com/NixOS/nixpkgs/commit/d9a85999d0cfa300d2c5ee6d0757a133d436fb95) | `wezterm: Add perl to deps for Darwin`                                  |
| [`f0c94323`](https://github.com/NixOS/nixpkgs/commit/f0c943237a13b35cce059bcf65ae4bea864ea9ea) | `python3Packages.rapidfuzz: 1.8.2 -> 1.8.3`                             |
| [`937cf30e`](https://github.com/NixOS/nixpkgs/commit/937cf30e7e7fff70b1ec6d1e8948d21aa8b24854) | `mariadb: replace libaio with liburing`                                 |
| [`4cd015e6`](https://github.com/NixOS/nixpkgs/commit/4cd015e65e1f89d5692f00749d59258f58bcb74a) | `NixOS auto upgrade: add openssh to path`                               |
| [`6f70a225`](https://github.com/NixOS/nixpkgs/commit/6f70a225f4ca707d4f226e84df2a5ed622b87792) | `keen4: Fail script if variables are undefined`                         |
| [`8737cb2c`](https://github.com/NixOS/nixpkgs/commit/8737cb2cc4a9a36ebdfe899f04a83f084dcf3a4c) | `keen4: Add shebang line`                                               |
| [`38094397`](https://github.com/NixOS/nixpkgs/commit/38094397d704f0e5d250b305e0dca0d59b9fe132) | `keen4: Mark sourced file as unknown`                                   |
| [`f367033a`](https://github.com/NixOS/nixpkgs/commit/f367033a8784261b8317576e3a1977035ccdea63) | `keen4: Quote variable references`                                      |
| [`3a98abe8`](https://github.com/NixOS/nixpkgs/commit/3a98abe8bd8e7c3da5636c2de6e7536e22ded247) | `nixos/hercules-ci-agent: Update module`                                |
| [`70875b76`](https://github.com/NixOS/nixpkgs/commit/70875b76024bbc9fe9d2f64ed8f3f0eb817eb29e) | `hci: 0.2.3 -> 0.2.4`                                                   |
| [`562143de`](https://github.com/NixOS/nixpkgs/commit/562143de323794a0654d2fe917b2ce08f8ea71ae) | `hercules-ci-agent: 0.8.3 -> 0.8.4`                                     |
| [`2f844b00`](https://github.com/NixOS/nixpkgs/commit/2f844b004a0e6e29dd2d6c59cecef489f86009bc) | `hercules-ci-cnix-store: 0.2.1.0 -> 0.2.1.1`                            |
| [`710d4ffb`](https://github.com/NixOS/nixpkgs/commit/710d4ffbc404d31bc709aa56112a903875f7ef39) | `python3Packages.lc7001: init at 1.0.3`                                 |
| [`962f61aa`](https://github.com/NixOS/nixpkgs/commit/962f61aa056c54334805f44411b7cebf6551b7c3) | `python37Packages.ipykernel: fix build`                                 |
| [`84590bd5`](https://github.com/NixOS/nixpkgs/commit/84590bd5dad8dc59ed966730b70d2b72bc35eb3a) | `notcurses: 2.4.8 -> 2.4.9`                                             |
| [`31759dc4`](https://github.com/NixOS/nixpkgs/commit/31759dc4b74e667462b98b41e031fc2362d10428) | `nixos/networkmanager: remove redundant ipv6.ip6-privacy`               |
| [`a96a6e75`](https://github.com/NixOS/nixpkgs/commit/a96a6e751593609014b854ad40e2836c03c8a887) | `nixos/qemu-vm: fix deprecation readonly -> readonly=on`                |
| [`48a4db63`](https://github.com/NixOS/nixpkgs/commit/48a4db63e67f7d06139eb0fa53918cb07ecb6ead) | `crda: 3.18 -> 4.14`                                                    |
| [`83923f87`](https://github.com/NixOS/nixpkgs/commit/83923f87c07a8859c619022653b65bd66b320a2e) | `laminar: 1.0 -> 1.1`                                                   |
| [`4e77c7ef`](https://github.com/NixOS/nixpkgs/commit/4e77c7efc620ae9eb397ffa0f1d2aeda6fa1c6c6) | `ungoogled-chromium: 95.0.4638.69 -> 96.0.4664.45`                      |
| [`4b32a5d2`](https://github.com/NixOS/nixpkgs/commit/4b32a5d26155ce66b74930791acd38b221d3faaf) | `quark: init at 2021-02-22`                                             |
| [`83f5781d`](https://github.com/NixOS/nixpkgs/commit/83f5781dbf224758da6572e81dcd9222799ed8cc) | `qogir-theme: 2021-08-02 -> 2021-11-17`                                 |
| [`015a305a`](https://github.com/NixOS/nixpkgs/commit/015a305ab68d0fafd289d3fe9ebf446cd5ab8e28) | `google-cloud-sdk: fix completion loading`                              |
| [`64b4af52`](https://github.com/NixOS/nixpkgs/commit/64b4af529611a698c381c87f2d756f8e820f405f) | `kmod-blacklist-ubuntu: 22-1.1ubuntu1 -> 28-1ubuntu4`                   |
| [`38f51c21`](https://github.com/NixOS/nixpkgs/commit/38f51c213c83eeb4cf5bdecfe442c19be2ca8181) | `gotify-desktop: init at 1.2.0`                                         |
| [`ec238075`](https://github.com/NixOS/nixpkgs/commit/ec2380759abd61e677f2cc4a5bc1f12cc0599a47) | `rose-pine-gtk-theme: init at unstable-2021-02-22`                      |
| [`1f0d4fc2`](https://github.com/NixOS/nixpkgs/commit/1f0d4fc2fe33bc4b810c967b8a45fe91a6674a4b) | `python3Packages.pytest-subprocess: 1.1.1 -> 1.3.2`                     |
| [`8c79017a`](https://github.com/NixOS/nixpkgs/commit/8c79017ad7f680c4d30600a976ecc634f3a34f8d) | `python3Packages.graphql-subscription-manager: 0.4.0 -> 0.4.3`          |
| [`1701f4a3`](https://github.com/NixOS/nixpkgs/commit/1701f4a343db9505b2ab39d0d6ab12e989d27f9d) | `index-fm: 2.0.0 -> 2.1.0`                                              |
| [`4f9e0480`](https://github.com/NixOS/nixpkgs/commit/4f9e04807f066d69c57ce9e64ac5ac134b3dd573) | `libsForQt5.mauikit-filebrowsing: 2.0.2 -> 2.1.0`                       |
| [`a3d7a2dd`](https://github.com/NixOS/nixpkgs/commit/a3d7a2dd48788f46e3f9af1a474ffe526b72cb5a) | `libsForQt5.mauikit: 2.0.2 -> 2.1.0`                                    |
| [`86742121`](https://github.com/NixOS/nixpkgs/commit/867421210a911bf7efd1588d5b035865d08c7256) | `mpv: remove ? null from inputs, put meta last`                         |
| [`de211a38`](https://github.com/NixOS/nixpkgs/commit/de211a38e2b95f364f50e113ca42a73f9a90c412) | `.github/PULL_REQUEST_TEMPLATE: added md-to-db reminder`                |
| [`49a2d9ba`](https://github.com/NixOS/nixpkgs/commit/49a2d9ba22d78fc60917fed918c8ebc97ed458ea) | `egl-wayland: 1.1.7 -> 1.1.9`                                           |