### PR TITLE
chore(flake/nixpkgs): `fa9d6c3d` -> `296032dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1637384301,
-        "narHash": "sha256-ebJiY+FvwO2EX6cH995PNb2MmAX9M5iIaH+qNH5upuE=",
+        "lastModified": 1637469704,
+        "narHash": "sha256-tNbrZZDHCLBw5/3REe8Dm/WMYiAXgXy7n5GuhRn5lI0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fa9d6c3d9328e84787451c05170cf816295aa630",
+        "rev": "296032dd5ff5e4c266782e73f9c00ee044f19c70",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`255c2849`](https://github.com/NixOS/nixpkgs/commit/255c2849248e331d7f0e56a041b80e0014a19177) | `czkawka: 0.3.2 -> 0.3.3 (#146757)`                                       |
| [`3a98364c`](https://github.com/NixOS/nixpkgs/commit/3a98364c4b8741ca40e0af5597f44e6e12e9922b) | `purenix: add to top-level packages`                                      |
| [`e9de71cc`](https://github.com/NixOS/nixpkgs/commit/e9de71cc5d0f6755987c93705cf21e69197540bb) | `darwin: stop using gccStdenv when stdenv works fine`                     |
| [`24aacf38`](https://github.com/NixOS/nixpkgs/commit/24aacf38082fac4de98d4bc2275ae3db38d273aa) | `nilfs-utils: fix hardcoded paths`                                        |
| [`8afc4e54`](https://github.com/NixOS/nixpkgs/commit/8afc4e543663ca0a6a4f496262cd05233737e732) | `pythonPackages.termplotlib: fix build`                                   |
| [`42133e84`](https://github.com/NixOS/nixpkgs/commit/42133e84517a8aef0de2788160055494284a0447) | `python3Packages.python-crontab: skip test test_03_usage`                 |
| [`34a7ce11`](https://github.com/NixOS/nixpkgs/commit/34a7ce11562b146b57bf68083f322c370a06c1b1) | `python3Packages.libasyncns: add pythonImportsCheck`                      |
| [`15f425ae`](https://github.com/NixOS/nixpkgs/commit/15f425ae9c25aacea6dfd3754e9a0f7e803524ac) | `python3Packages.libasyncns: fix build for darwin`                        |
| [`2077956e`](https://github.com/NixOS/nixpkgs/commit/2077956e7813fcc57f45d07a4b46715d0cd592ce) | `nixos/network-interfaces: add a warning for underscores in hostname`     |
| [`a907da6e`](https://github.com/NixOS/nixpkgs/commit/a907da6e638c8654bface8a4f5aeec2776668c8c) | `libasyncns: fix build for darwin`                                        |
| [`08b402b7`](https://github.com/NixOS/nixpkgs/commit/08b402b70e3d84d089f3de7221423790afd6a06a) | `libretro: enableParalellBuilding, except for older MAMEs`                |
| [`31b38fd9`](https://github.com/NixOS/nixpkgs/commit/31b38fd938038c63e0623dba0d6a7eccc7bd39ed) | `cdpr: fix build on darwin`                                               |
| [`d1c3a49f`](https://github.com/NixOS/nixpkgs/commit/d1c3a49fdd110aee082467af8e9ae8213613971e) | `vmTools: set msize to 16KiB temporarily`                                 |
| [`1ee4cb8d`](https://github.com/NixOS/nixpkgs/commit/1ee4cb8d9341d52d36e0fb954f69e7669d1f8e8c) | `sage: patch test so that new pari warning doesn't cause failures (#4)`   |
| [`8886aa29`](https://github.com/NixOS/nixpkgs/commit/8886aa29fa0c359964d8644ab572509921725263) | `oil: 0.9.3 -> 0.9.4`                                                     |
| [`09b01aa4`](https://github.com/NixOS/nixpkgs/commit/09b01aa435a5214376d71a787717c07bed60ed4c) | `vector: 0.17.3 -> 0.18.0 (#146523)`                                      |
| [`60c52309`](https://github.com/NixOS/nixpkgs/commit/60c52309689d7a9260035b66e7a7f29f2b92880e) | `nixosTests.installer: increase the VM memory`                            |
| [`a66592d7`](https://github.com/NixOS/nixpkgs/commit/a66592d763bff6da755495e18d1f1dc68508c44e) | `gimpPlugins.fourier: fix build on clang`                                 |
| [`a88446e3`](https://github.com/NixOS/nixpkgs/commit/a88446e324ce48d244a9e2866325b00ab0729b11) | `zynaddsubfx: fix aarch64-linux build`                                    |
| [`a94464d5`](https://github.com/NixOS/nixpkgs/commit/a94464d58554aa02dc144431fcface13829cd039) | `intel-gmmlib: 21.3.2 -> 21.3.3`                                          |
| [`70e9780f`](https://github.com/NixOS/nixpkgs/commit/70e9780f978a80fd5f9d041ad3172b2525f788f7) | `wine{Unstable,Staging}: 6.21 -> 6.22`                                    |
| [`b054a859`](https://github.com/NixOS/nixpkgs/commit/b054a8594a1f5136e4ae7aa5f4e76bea95d7aab9) | `chromium: update.py: Download files from the main repository`            |
| [`39d1d189`](https://github.com/NixOS/nixpkgs/commit/39d1d1893bbdb4af6119efd65331980ed7aa86f6) | `gotify-desktop: add maintainer genofire (me)`                            |
| [`110930ee`](https://github.com/NixOS/nixpkgs/commit/110930ee32c8572cedd46eebeb26e643e1e4c179) | `maintainers: add genofire (me)`                                          |
| [`96d27b27`](https://github.com/NixOS/nixpkgs/commit/96d27b27c5d50e08b44adf5a2bd81f8dcf5200c6) | `home-assistant: enable vlc_telnet tests`                                 |
| [`2bfbd302`](https://github.com/NixOS/nixpkgs/commit/2bfbd302b229dacbb16e868a1f77623b53beb4c3) | `home-assistant: update component-packages`                               |
| [`24cfd348`](https://github.com/NixOS/nixpkgs/commit/24cfd348b1b2cadc81080f72ed7aad55730c2a82) | `python3Packages.aiovlc: init at 0.1.0`                                   |
| [`471183f2`](https://github.com/NixOS/nixpkgs/commit/471183f245c3dd85221f5821d570d4fb84c52d5a) | `nixos/tests/hibernate: set memorySize to 2G`                             |
| [`9387303e`](https://github.com/NixOS/nixpkgs/commit/9387303e393e4da1e4f38caa51fc6f77a74e2edc) | `broot: 1.7.1 -> 1.7.3`                                                   |
| [`ff7045f0`](https://github.com/NixOS/nixpkgs/commit/ff7045f01839bb299311bcb463e732f4f52888b3) | `vscode-extensions.haskell.haskell: 1.6.1 -> 1.7.1 (#146528)`             |
| [`42a83770`](https://github.com/NixOS/nixpkgs/commit/42a83770be09b3ac21b18da6d03c95c8a3398ecd) | `python3Packages.envisage: format default.nix`                            |
| [`e19fe85e`](https://github.com/NixOS/nixpkgs/commit/e19fe85e84db636ab12a86f11571370825872360) | `python3Packages.envisage: disable tests of broken optional feature`      |
| [`d1277658`](https://github.com/NixOS/nixpkgs/commit/d127765898cf783e083e277a9abae4f909263956) | `wine{Unstable,Staging}: 6.20 -> 6.21`                                    |
| [`e2ab6321`](https://github.com/NixOS/nixpkgs/commit/e2ab6321ed156e0bc9479c118c80db691bff935a) | `vmTools: set msize to 128KiB`                                            |
| [`30632db5`](https://github.com/NixOS/nixpkgs/commit/30632db50a85e51088d3465ae77315b1215b76d7) | `f3d: 1.1.0 -> 1.1.1`                                                     |
| [`454a8706`](https://github.com/NixOS/nixpkgs/commit/454a8706ca6aadb820890a0b8126d307a89d85c6) | `pythonPackages.dogpile-core: remove`                                     |
| [`3c20fe4f`](https://github.com/NixOS/nixpkgs/commit/3c20fe4ffc93096dc389cd93c2f59a8c6d161e4f) | `signal-desktop: 5.23.1 -> 5.24.0`                                        |
| [`be2bc44d`](https://github.com/NixOS/nixpkgs/commit/be2bc44d0e12d0fbb5f89fe410fa6c3baa64ef3c) | `Partially revert "chromiumDev: 97.0.4692.20 -> 98.0.4710.4"`             |
| [`67c0df93`](https://github.com/NixOS/nixpkgs/commit/67c0df93ead69f20418853fdbd1356671e869ed6) | `gimp: fix build on darwin`                                               |
| [`72da520e`](https://github.com/NixOS/nixpkgs/commit/72da520e40dd0c767ebe0e689f396191de25effe) | `home-assistant: enable nightscout tests`                                 |
| [`23b94ff0`](https://github.com/NixOS/nixpkgs/commit/23b94ff04dd6535f75647f9bd3a10cde02f3e99d) | `home-assistant: update component-packages`                               |
| [`48e70f34`](https://github.com/NixOS/nixpkgs/commit/48e70f34bf47d0651b0e1b718507b1e368e8c079) | `python3Packages.py-nightscout: init at 1.3.2`                            |
| [`241c1452`](https://github.com/NixOS/nixpkgs/commit/241c145226ce031543c4580acfa7feef993d7463) | `chromiumDev: 97.0.4692.20 -> 98.0.4710.4`                                |
| [`f3ae4d9c`](https://github.com/NixOS/nixpkgs/commit/f3ae4d9cc3e537b03a21fd8c8575af43a2377b8e) | `python3Packages.restrictedpython: 5.1 -> 5.2`                            |
| [`62b54145`](https://github.com/NixOS/nixpkgs/commit/62b541455d2cef0f43defcf6ce8ce72561797be8) | `ccache: 4.5 → 4.5.1`                                                     |
| [`f435d7d6`](https://github.com/NixOS/nixpkgs/commit/f435d7d6310cd55af254518eb2f69d0d866a4cec) | `retroarch: fix build on macOS, mark as broken`                           |
| [`36f6fd1f`](https://github.com/NixOS/nixpkgs/commit/36f6fd1f410a797d021234ef8245ca68c53de440) | `nixos/doc: add release notes about retroarch changes`                    |
| [`03e35cfb`](https://github.com/NixOS/nixpkgs/commit/03e35cfb6579745cecd0d629403438b90022e324) | `retroarch: use fixed paths on "libretro_info_path"`                      |
| [`cbcd3d6c`](https://github.com/NixOS/nixpkgs/commit/cbcd3d6c858885d04198b5b66621d561d01086a5) | `retroarchFull: init`                                                     |
| [`24095a99`](https://github.com/NixOS/nixpkgs/commit/24095a994c847ae3754b631eeceda8c4687ecad1) | `retroArchCores: remove`                                                  |
| [`8afdfa98`](https://github.com/NixOS/nixpkgs/commit/8afdfa9896e29e1775059adba824ef395f70d78b) | `foo2zjs: add hbpl1 printers support`                                     |
| [`a6eeab7a`](https://github.com/NixOS/nixpkgs/commit/a6eeab7ab7f97ddb592e85b612b029619f309e56) | `super-slicer-staging: 2.3.57.0 -> 2.3.57.6`                              |
| [`6ba4962a`](https://github.com/NixOS/nixpkgs/commit/6ba4962a152132e41e8ae13c0e334f8a799ca5a8) | `python3Packages.nessclient: enable tests`                                |
| [`5da59495`](https://github.com/NixOS/nixpkgs/commit/5da59495a3ad49de926f789207ed0087596e5cf1) | `afterstep: fix build on upcoming binutils-2.36`                          |
| [`6b997794`](https://github.com/NixOS/nixpkgs/commit/6b9977942adb40518d74eead610d5e92b7067863) | `nixosTests.vscodium: add comments`                                       |
| [`51556957`](https://github.com/NixOS/nixpkgs/commit/51556957bfc4ea84bc837143c13e9e45e55d82fb) | `pywlroots: 0.14.9 -> 0.14.11`                                            |
| [`32fda5d1`](https://github.com/NixOS/nixpkgs/commit/32fda5d1664de1ceaacd553e5ec07f808f26e4f0) | `python3Packages.elementpath: update ordering`                            |
| [`747436de`](https://github.com/NixOS/nixpkgs/commit/747436dee19d6d7dfbb716627fe0a7e7aee4d57a) | `nilfs-utils: explicitly enable libmount`                                 |
| [`15111f8a`](https://github.com/NixOS/nixpkgs/commit/15111f8a9ad423d300886b537647691c2faa28cd) | `ndk-bundle: fix build`                                                   |
| [`35ec2452`](https://github.com/NixOS/nixpkgs/commit/35ec24523b71f4a79409b3b3ded4e4f9c2c39046) | `nixos/hbase: Fix missing top-level in hbase-site.xml`                    |
| [`72bdd5b7`](https://github.com/NixOS/nixpkgs/commit/72bdd5b7570183cd5768c3fbf1fd22ef4c15e7af) | `Revert "libfprint-tod: 1.90.7 -> 1.94.1"`                                |
| [`5afe6d96`](https://github.com/NixOS/nixpkgs/commit/5afe6d962c2c84fa3dc7baf6e5465265d11e9623) | `plan9port: tighten up `broken``                                          |
| [`7769bdce`](https://github.com/NixOS/nixpkgs/commit/7769bdce1376315f9085fb87bbc065eb64c78bf0) | `python3Packages.ludios_wpull: use updated URLs`                          |
| [`b5e87f5f`](https://github.com/NixOS/nixpkgs/commit/b5e87f5f2e40ab84dd1977348e0ea44f36a749df) | `grab-site: 2.2.0 -> 2.2.2; pythonPackages.ludios_wpull: 3.0.7 -> 3.0.9`  |
| [`e1990cfa`](https://github.com/NixOS/nixpkgs/commit/e1990cfa2b9a51af9b3ed33a8dc023d86551edc5) | `python3Packages.sanic: skip tests on all archs`                          |
| [`5e253e04`](https://github.com/NixOS/nixpkgs/commit/5e253e043dd91ec75112723e9f0b8b923fab5487) | `creduce: 2.9.0 -> 2.10.0`                                                |
| [`df03e376`](https://github.com/NixOS/nixpkgs/commit/df03e376fb24fc81b01863920803ace0eadc0469) | `grpc: fix build on aarch64`                                              |
| [`21d4d1bf`](https://github.com/NixOS/nixpkgs/commit/21d4d1bfdae4221013996cf6062ef493e6632e03) | `apache-airflow: fix build on darwin`                                     |
| [`1334a625`](https://github.com/NixOS/nixpkgs/commit/1334a62539d86d9bcf43c286568c20227615ce90) | `test-driver.py: directly import pathlib.Path`                            |
| [`ec05219e`](https://github.com/NixOS/nixpkgs/commit/ec05219e4092d03f335da1ac5794801d88350eab) | `apache-airflow: use pytestCheckHook`                                     |
| [`5c35e918`](https://github.com/NixOS/nixpkgs/commit/5c35e9184db774816bbd2de4a996f74a6583153b) | `lrzip: enable asm on x86 and fix build on darwin`                        |
| [`dc2cad81`](https://github.com/NixOS/nixpkgs/commit/dc2cad8150551fe842ddc87a1d704b0de2267b9a) | `gp2c: cosmetical changes`                                                |
| [`3845245d`](https://github.com/NixOS/nixpkgs/commit/3845245d713cb985231258ba73b9fd9407762760) | `pari: 2.13.1 -> 2.13.3`                                                  |
| [`4bd364da`](https://github.com/NixOS/nixpkgs/commit/4bd364da6e9e0eeb266a3ebca9c520090f52ec29) | `python3Packages.xmlschema: 1.8.1 -> 1.8.2`                               |
| [`3b6fd94f`](https://github.com/NixOS/nixpkgs/commit/3b6fd94fd636cdb3e26898962593924a10937ab2) | `python3Packages.tweepy: 4.3.0 -> 4.4.0`                                  |
| [`eef64da3`](https://github.com/NixOS/nixpkgs/commit/eef64da3dbf88251c103cd25afe598334c2cfbdd) | `ookla-speedtest: fix syntax error when evaling on unsupported platforms` |
| [`637b57eb`](https://github.com/NixOS/nixpkgs/commit/637b57eb37944649a7a83742365d675215dfb3d5) | `python3Packages.pyupgrade: 2.29.0 -> 2.29.1`                             |
| [`2cd54662`](https://github.com/NixOS/nixpkgs/commit/2cd546626a5b99cdbb1b99bb04dcc7a34e29129f) | `python3Packages.pyatmo: 6.1.0 -> 6.2.0`                                  |
| [`7201052d`](https://github.com/NixOS/nixpkgs/commit/7201052de20144b11c4ef1eec7c29cb562257cb3) | `nixosTests.vscodium: wait for different text`                            |
| [`2a04ae8b`](https://github.com/NixOS/nixpkgs/commit/2a04ae8b125285ed980722614e75e220ee9847c8) | `nixosTests.vscodium: rename machines`                                    |
| [`9e71014e`](https://github.com/NixOS/nixpkgs/commit/9e71014edecba9d9c78531ebc2861e28c931ff6f) | `test-driver.py: always export single machine as 'machine'`               |
| [`a8f693ed`](https://github.com/NixOS/nixpkgs/commit/a8f693ed48e64fd5d4b6ae2304962e387227bbd4) | `test-driver.py: fix weird non-pythonism`                                 |
| [`ef4ab06b`](https://github.com/NixOS/nixpkgs/commit/ef4ab06ba5b0c2faffdd5cde41c15c6eb704b186) | `python3Packages.identify: 2.3.7 -> 2.4.0`                                |
| [`e2128023`](https://github.com/NixOS/nixpkgs/commit/e21280234bac95ddd6412e987133c01cccfb63e9) | `python3Packages.ukkonen: init at 1.0.1`                                  |
| [`ce224d86`](https://github.com/NixOS/nixpkgs/commit/ce224d8643012dcbf9cf4f3b1e1bb4f549bb7c74) | `chromiumBeta: 96.0.4664.45 -> 97.0.4692.20`                              |
| [`c91c0296`](https://github.com/NixOS/nixpkgs/commit/c91c0296dd3d48fb0225d2b518296abd7a7d5a2e) | `home-assistant: 2021.11.4 -> 2021.11.5`                                  |
| [`6a71aba5`](https://github.com/NixOS/nixpkgs/commit/6a71aba55cc40a464f46e7ea4a1191f8fa46c62e) | `python3Packages.faraday-plugins: 1.5.6 -> 1.5.7`                         |
| [`ffbba7b5`](https://github.com/NixOS/nixpkgs/commit/ffbba7b5325ab6b208ae7431b25d4a43f9afb22c) | `checkov: 2.0.587 -> 2.0.591`                                             |
| [`7ed2f6e5`](https://github.com/NixOS/nixpkgs/commit/7ed2f6e55d9b145169b9e2c020daceb15996c3a2) | `nixos/tests/vscodium{,-wayland}: merge tests`                            |
| [`6ecb9a35`](https://github.com/NixOS/nixpkgs/commit/6ecb9a352f046013b8d81053678017705a150559) | `nixos/tests/vscodium-wayland: init`                                      |
| [`53fa9753`](https://github.com/NixOS/nixpkgs/commit/53fa9753b7d7722e619142c1d3d83109828bae3b) | `masscan: fix build on darwin`                                            |
| [`b663e1b4`](https://github.com/NixOS/nixpkgs/commit/b663e1b4d3b996457b9915d3156a41e3649f16f6) | `lrzip: refactor derivation`                                              |
| [`e371ffc4`](https://github.com/NixOS/nixpkgs/commit/e371ffc4a7670e23fcd2f7c8a29a9b0d8b4d26ef) | `souffle: pull pending upstream inclusion fix for ncurses-6.3`            |
| [`3e913ac6`](https://github.com/NixOS/nixpkgs/commit/3e913ac64c178b83e17068513c8d4d2d08b22aec) | `viber: 13.3.1.22 -> 16.1.0.37`                                           |
| [`b7dfc54d`](https://github.com/NixOS/nixpkgs/commit/b7dfc54d735e3a13c0c7fe2bb1b686e0c65d389a) | `python3Packages.aiohwenergy: init at 0.4.0`                              |
| [`12647a0a`](https://github.com/NixOS/nixpkgs/commit/12647a0a977d14d131a7d58204a9d2ab3d0ddeac) | `python3Packages.luxtronik: init at 0.3.9`                                |
| [`7d1a6e10`](https://github.com/NixOS/nixpkgs/commit/7d1a6e100f7359b0fda3c00c1cacd82ee6406e69) | `python3Packages.pyebus: init at 1.2.4`                                   |
| [`476e37de`](https://github.com/NixOS/nixpkgs/commit/476e37de3f54a194f6afce3d2132824f189af8a9) | `python3Packages.vulcan-api: init at 2.0.3`                               |
| [`f76bc9cc`](https://github.com/NixOS/nixpkgs/commit/f76bc9cc95479816685bcc87c83c1658b5abe0cd) | `python3Packages.related: init at 0.7.2`                                  |
| [`83b3fb14`](https://github.com/NixOS/nixpkgs/commit/83b3fb146300b5ad1f7492068f342b106f860656) | `python3Packages.uonet-request-signer-hebe: init at 0.1.1`                |
| [`17c12a8c`](https://github.com/NixOS/nixpkgs/commit/17c12a8cd2005da09e7378a3d38f78f481c18c11) | `kail: 0.8.0 -> 0.15.0 switch to buildGoModule`                           |
| [`b524bea3`](https://github.com/NixOS/nixpkgs/commit/b524bea334ed9a88850c4312481708902c7dcf42) | `vimpc: pull pending upstream inclusion fix for ncurses-6.3`              |
| [`2ea5321f`](https://github.com/NixOS/nixpkgs/commit/2ea5321fb97433503844e40aa96b7d4d5ca9f5b6) | `trafficserver: pull upstream fix for ncurses-6.3`                        |
| [`eafed17e`](https://github.com/NixOS/nixpkgs/commit/eafed17eff28c28683f14edd96b5830429385f9a) | `tiptop: pull upstream patch for ncurses-6.3 support`                     |
| [`552868e1`](https://github.com/NixOS/nixpkgs/commit/552868e18d832ef9f97d0115bb9501155f08f479) | `python3Packages.roombapy: 1.6.3 -> 1.6.4`                                |
| [`23599fea`](https://github.com/NixOS/nixpkgs/commit/23599fea9ae9fc516fbab18a79e8455ec6a9ee16) | `python3Packages.millheater: 0.8.1 -> 0.9.0`                              |
| [`bd600302`](https://github.com/NixOS/nixpkgs/commit/bd600302cd0fe66f3d99a874b04cf3095d85aa77) | `navidrome: 0.45.1 -> 0.47.0`                                             |
| [`068a885d`](https://github.com/NixOS/nixpkgs/commit/068a885d9c6434c4fac0b6098d7b157a0a69245b) | `adns: fix static compilation`                                            |
| [`3a2f6a79`](https://github.com/NixOS/nixpkgs/commit/3a2f6a79e044dcd075414ef9f3558487430cdccd) | `gistyc: add tests`                                                       |
| [`37d5c0e5`](https://github.com/NixOS/nixpkgs/commit/37d5c0e51e10effa26a9d25c064094c3e656a0cd) | `mate.mate-screensaver: 1.26.0 -> 1.26.1`                                 |
| [`a8f57f2c`](https://github.com/NixOS/nixpkgs/commit/a8f57f2c40bf0f8064b478afa60ac84efb7bff2c) | `trivy: 0.20.2 -> 0.21.0`                                                 |
| [`51b4f7ae`](https://github.com/NixOS/nixpkgs/commit/51b4f7aebc2c1eebb12b2a2ecffa680a44d98b31) | `powertop: pull upstream fix for ncurses-6.3`                             |
| [`1678743f`](https://github.com/NixOS/nixpkgs/commit/1678743f015b152565870e652d467714545bb069) | `mate.mozo: 1.26.0 -> 1.26.1`                                             |
| [`80a1a44c`](https://github.com/NixOS/nixpkgs/commit/80a1a44c70a99e1f563be2659921962fb5c6432d) | `fetchgitlab: fix unexpected argument`                                    |
| [`f7e03a6a`](https://github.com/NixOS/nixpkgs/commit/f7e03a6a4e75f73730aa9ca8ff5bbc9f5e61011d) | `nmon: 16m -> 16n`                                                        |
| [`eb1aed2a`](https://github.com/NixOS/nixpkgs/commit/eb1aed2a74a06d9aa00fe39c841b454582013b34) | `python3Packages.unicorn: fix build on aarch64`                           |
| [`c2729141`](https://github.com/NixOS/nixpkgs/commit/c27291414f02d7c3ae7ba51bb66228fedd61a71a) | `python3Packages.unicorn: add custom checkPhase`                          |
| [`a36a91aa`](https://github.com/NixOS/nixpkgs/commit/a36a91aaa79bf39067b4defa28ffc97702afdca1) | `python3Packages.imap-tools: 0.49.1 -> 0.50.0`                            |
| [`69ac4b31`](https://github.com/NixOS/nixpkgs/commit/69ac4b31ad92f8905498717058d0550553d0443f) | `python.pkgs.pytomlpp: 0.3.5 -> v1.0.6`                                   |
| [`7a30dd25`](https://github.com/NixOS/nixpkgs/commit/7a30dd25fcbba6af9cb0bdb47eeb65bccc80ed09) | `zookeeper: Add tests.nixos`                                              |
| [`ddb000cb`](https://github.com/NixOS/nixpkgs/commit/ddb000cb11375b2ee50fcbcb2fb72ef2cdc80f3c) | `cargo-msrv: add rustup to propagatedBuildInputs`                         |
| [`555ebb07`](https://github.com/NixOS/nixpkgs/commit/555ebb077e7d8c7278e203632c5d632ce66e6d53) | `zookeeper: jdk8 -> jdk11_headless`                                       |
| [`2411e72f`](https://github.com/NixOS/nixpkgs/commit/2411e72fa4e0d7ce78bdb6dd14b2beb2a4b96013) | `rocketchat-desktop: 3.5.7 -> 3.6.0`                                      |
| [`111b9e56`](https://github.com/NixOS/nixpkgs/commit/111b9e563033bd8a83ebe1d16d7cca512f9eaa94) | `home-assistant: enable ness_alarm tests`                                 |
| [`ed52654c`](https://github.com/NixOS/nixpkgs/commit/ed52654c891d351fb7766a4b40c14d472b9c4a8c) | `home-assistant: update component-packages`                               |
| [`9d830c14`](https://github.com/NixOS/nixpkgs/commit/9d830c1496e8700c895db56120b39e83d68bbc4b) | `python3Packages.nessclient: init at 0.9.16b2`                            |
| [`98f26c23`](https://github.com/NixOS/nixpkgs/commit/98f26c237d23e9ba34524918bb9a25ec93c34ce4) | `python3Packages.justbackoff: init at 0.6.0`                              |
| [`9951e81c`](https://github.com/NixOS/nixpkgs/commit/9951e81c004fd0f27c2740de5de39151715a7dc4) | `prisma: 3.4.0 -> 3.5.0`                                                  |
| [`0f7756d3`](https://github.com/NixOS/nixpkgs/commit/0f7756d322f624829c7b462099b458bb07b0df3f) | `rocketchat-desktop: added wrapGAppsHook`                                 |
| [`04d9dbdd`](https://github.com/NixOS/nixpkgs/commit/04d9dbddd430b169222213c20a27a81420cc4ff1) | `matrix-facebook: 0.3.1 -> 0.3.2`                                         |
| [`845089ab`](https://github.com/NixOS/nixpkgs/commit/845089ab0ff1ce5e1a9bed5e91a0bccbe74c5f5f) | `cxxtools: fix build on aarch64`                                          |
| [`39a0639b`](https://github.com/NixOS/nixpkgs/commit/39a0639b70ef924c11ac00be0337a69516807ac5) | `qgis: 3.6.10 -> 3.6.13`                                                  |
| [`38ea5245`](https://github.com/NixOS/nixpkgs/commit/38ea5245a3172ba8e449c732145dc2fe53b28e02) | `python38Packages.elementpath: 2.3.2 -> 2.4.0`                            |
| [`a997abfb`](https://github.com/NixOS/nixpkgs/commit/a997abfb2843fee283c0976c69ad93a0af509787) | `mailman: formatting`                                                     |
| [`0235f41a`](https://github.com/NixOS/nixpkgs/commit/0235f41adf64a74d25295c779cfe0d8f84e83a66) | `python3Packages.mailman-hyperkitty: 1.1.0 -> 1.2.0`                      |
| [`92b9bd4e`](https://github.com/NixOS/nixpkgs/commit/92b9bd4eb65e2205a13d74108c80b73f9736430d) | `python3Packages.hyperkitty: 1.3.4 -> 1.3.5`                              |
| [`5f8d34ad`](https://github.com/NixOS/nixpkgs/commit/5f8d34ad31289e31746d0e9d39705cb993f253cb) | `mailman-web: unstable-2021-04-10 -> 0.0.5`                               |
| [`413e2f00`](https://github.com/NixOS/nixpkgs/commit/413e2f0070c139c36e0d6d169b4c35b78148db2b) | `python3Packages.postorius: 1.3.5 -> 1.3.6`                               |
| [`4f163ad3`](https://github.com/NixOS/nixpkgs/commit/4f163ad3079533ba50ea1d7689369666d3f016f0) | `python3Packages.falcon: enable more tests`                               |
| [`3c5ffd28`](https://github.com/NixOS/nixpkgs/commit/3c5ffd288e80020a781ff1101dc223488ef46e88) | `python3Packages.mujson: init at 1.4`                                     |
| [`e22ee9bf`](https://github.com/NixOS/nixpkgs/commit/e22ee9bf77ae289ce2b75018a754e0b31d0a1905) | `plymouth: unstable-2020-12-07 -> unstable-2021-10-18`                    |
| [`7f55e03a`](https://github.com/NixOS/nixpkgs/commit/7f55e03a3eafc379742ab4ccf064eb6ddc360b18) | `openrct2: 0.3.4.1 -> 0.3.5`                                              |
| [`3f90cde7`](https://github.com/NixOS/nixpkgs/commit/3f90cde7195de363f79a22ed68808749f3f8ad61) | `llvmPackages_7.libcxxabi: fix build with gcc`                            |