### PR TITLE
chore(flake/nixpkgs): `296032dd` -> `53edfe1d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1637469704,
-        "narHash": "sha256-tNbrZZDHCLBw5/3REe8Dm/WMYiAXgXy7n5GuhRn5lI0=",
+        "lastModified": 1637509688,
+        "narHash": "sha256-NcKdyLZflWeSrwgavNGIG7LcP6XBcYGne04HIzWP1D4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "296032dd5ff5e4c266782e73f9c00ee044f19c70",
+        "rev": "53edfe1d1c51c38e2adc4d8eb37a7a2657e3fe01",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                      |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`54ece050`](https://github.com/NixOS/nixpkgs/commit/54ece050b8ff6ce12a665832b2c83bfd925ce8a3) | `nixos/qemu-vm: default memorySize 384 -> 1024`                     |
| [`05bbe40f`](https://github.com/NixOS/nixpkgs/commit/05bbe40f68313e08486151d014dc99e037924c56) | `cingaweb2: 2.9.3 -> 2.9.4`                                         |
| [`996f991b`](https://github.com/NixOS/nixpkgs/commit/996f991b5deed60fc613e2d62b414c96335127d8) | `icingaweb2-ipl: 0.6.1 -> 0.7.0`                                    |
| [`09a54b14`](https://github.com/NixOS/nixpkgs/commit/09a54b14cd1abb87c7f9e5357cd0030f9d8aefda) | `fluent-bit: fix build on darwin`                                   |
| [`46c3452a`](https://github.com/NixOS/nixpkgs/commit/46c3452a16a030c20cf2f842ee3820cf6bebd0a3) | `python3Packages.pyahocorasick: fix build on Hydra (x86_64-darwin)` |
| [`f508ae88`](https://github.com/NixOS/nixpkgs/commit/f508ae889415b51263ea1c20b6b4c0e0ecbfc0bd) | `mirrors: add kernel.org mirrors where appropriate`                 |
| [`858f0e8e`](https://github.com/NixOS/nixpkgs/commit/858f0e8ed9ac9b00d03feccb5fb564bf6b75e27a) | `python3.pkgs.keyutils: fix cross`                                  |
| [`82ccc7f1`](https://github.com/NixOS/nixpkgs/commit/82ccc7f17b5f70c36568918c386992fa4706faff) | `libgphoto2: fix cross`                                             |
| [`512fadbc`](https://github.com/NixOS/nixpkgs/commit/512fadbc6410660737da7a4977445005e6bdb151) | `gwtwidgets: remove builder.sh`                                     |
| [`ea6fb1e2`](https://github.com/NixOS/nixpkgs/commit/ea6fb1e297fcee773e3cf3c8a833c2964e3564e1) | `gwtdragdrop: remove builder.sh`                                    |
| [`28aae759`](https://github.com/NixOS/nixpkgs/commit/28aae75929bb2a04a3e789052cb8128c91dfc6bf) | `python3Packages.casbin: 1.9.7 -> 1.11.1`                           |
| [`f1e8640c`](https://github.com/NixOS/nixpkgs/commit/f1e8640c5482f39b90864eadedab20c3f4b075c6) | `libisl: Make derivations generic, add 0.24 (#146693)`              |
| [`ff6d13cd`](https://github.com/NixOS/nixpkgs/commit/ff6d13cdad94b08d5ddb7765c34310716f5b6422) | `rippled: 1.7.0 -> 1.7.3`                                           |
| [`32478d22`](https://github.com/NixOS/nixpkgs/commit/32478d226dc47c9984464f57c4c3062421789e14) | `python3Packages.env-canada: 0.5.16 -> 0.5.17`                      |
| [`6ba916f5`](https://github.com/NixOS/nixpkgs/commit/6ba916f5ad7c5634cf2692a996938c644ec72a85) | `python3Packages.qcs-api-client: 0.19.0 -> 0.20.0`                  |
| [`8a2be272`](https://github.com/NixOS/nixpkgs/commit/8a2be27251d9a36c7cbdb684d97c07e481d2c5f4) | `firefox: disable jemalloc by default to fix crash`                 |
| [`a343380d`](https://github.com/NixOS/nixpkgs/commit/a343380d9dca9305951fe4eca8b58745b4bb3f97) | `firefox: enable cross-language LTO`                                |
| [`8d4bef71`](https://github.com/NixOS/nixpkgs/commit/8d4bef7124cfab618d25113ef22d0852b0e33387) | `firefox: enable separated debug symbols`                           |
| [`c2409db9`](https://github.com/NixOS/nixpkgs/commit/c2409db926de4b7435e14e8366e8d08b0f69fd12) | `firefox: remove unnecessary make flags and LD_FLAGS`               |
| [`2175b157`](https://github.com/NixOS/nixpkgs/commit/2175b157acf1fd338021bc162ec7c4d6d7f90306) | `treewide: refactor isi686 && isx86_64 -> isx86`                    |
| [`0ca14515`](https://github.com/NixOS/nixpkgs/commit/0ca14515c6ed3c4f80afd80b315cf7bcf559200a) | `testVersion: name runCommand after package.name`                   |
| [`00a52ef6`](https://github.com/NixOS/nixpkgs/commit/00a52ef677eb7098c42c6deb81d11bf9e5740e20) | `R: manually fix things after patches got applied`                  |
| [`fedc3db7`](https://github.com/NixOS/nixpkgs/commit/fedc3db7ba5a6f29f2518db4c01fcda87ef0c487) | `qvge: don't use libsForQt5.mkDerivation`                           |
| [`74cb0717`](https://github.com/NixOS/nixpkgs/commit/74cb07175b8788ad33dcc622aca8769828b925d1) | `qvge: enable on darwin`                                            |
| [`ec24bab9`](https://github.com/NixOS/nixpkgs/commit/ec24bab90eac4c100aa5eeef77dec10dc391158b) | `hmmer: restrict platforms to x86_64`                               |
| [`717bac8a`](https://github.com/NixOS/nixpkgs/commit/717bac8a4d88852d8a71e5ea91fc13064da9c0a0) | `makemkv: add libcurl to runtimeDependencies`                       |
| [`a05acfc2`](https://github.com/NixOS/nixpkgs/commit/a05acfc2c073f129768a576bf3833357510410f3) | `python3Packages.pyads: 3.3.8 -> 3.3.9`                             |
| [`5efc4fbb`](https://github.com/NixOS/nixpkgs/commit/5efc4fbb0c3c01334fd42d238cca18555ab95c5a) | `fprintd-tod: fix the build`                                        |
| [`1b2f4e09`](https://github.com/NixOS/nixpkgs/commit/1b2f4e09b675c71e11d1ddbe1f4451925ab070f8) | `Update pkgs/tools/security/fprintd/tod.nix`                        |
| [`3cabab85`](https://github.com/NixOS/nixpkgs/commit/3cabab85865aa1f9d6a409e55c03f9edd06269d5) | `fprintd-tod: fix the build`                                        |
| [`fbd8c908`](https://github.com/NixOS/nixpkgs/commit/fbd8c90829cb646fe63349efce2ec521b9b864b7) | `python3Packages.flux-led: 0.24.24 -> 0.24.25`                      |
| [`02ed0b2c`](https://github.com/NixOS/nixpkgs/commit/02ed0b2ca3ee6ebb22ed483d7e9cc5cd8814fc4f) | `fluxus: switch to racket_7_9`                                      |
| [`f7822885`](https://github.com/NixOS/nixpkgs/commit/f7822885f8adaffc3e2e700d51f02666d708d356) | `racket_7_9: init at 7.9`                                           |
| [`4d576666`](https://github.com/NixOS/nixpkgs/commit/4d57666646477d960610309b00e7883ca09133ba) | `bsdiff: disable bugfix patches for darwin`                         |
| [`200ffaa0`](https://github.com/NixOS/nixpkgs/commit/200ffaa0727c1f5c09f2f76fdf1a607b6c83d0ec) | `bsdiff: fix patch`                                                 |
| [`47a9d5e4`](https://github.com/NixOS/nixpkgs/commit/47a9d5e419a32c41b0e0e3d650acdf312372a7b3) | `bsdiff: add patch to default.nix`                                  |
| [`842a8553`](https://github.com/NixOS/nixpkgs/commit/842a855325c8e050a874bc8249904b02405de74e) | `bsdiff: fix patch file for aarch64-linux`                          |
| [`84245c84`](https://github.com/NixOS/nixpkgs/commit/84245c843f30a7b535280e35f4d2d56e2a0ab789) | `bspatch: security and bug fixes`                                   |