### PR TITLE
chore(flake/nixpkgs): `53edfe1d` -> `726f7c96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1637509688,
-        "narHash": "sha256-NcKdyLZflWeSrwgavNGIG7LcP6XBcYGne04HIzWP1D4=",
+        "lastModified": 1637550001,
+        "narHash": "sha256-WzwiXc1iIvMTKGnAuRAdrIWFIcEexB3EZH9nFnWuG+Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "53edfe1d1c51c38e2adc4d8eb37a7a2657e3fe01",
+        "rev": "726f7c9688bad4574abee4f47565bf272daf8f81",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                 |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`7ea3e0f3`](https://github.com/NixOS/nixpkgs/commit/7ea3e0f3f24780c8344492a494c905947e038d7f) | `qemu: fix managedsave (snapshot creation) with QXL video device`              |
| [`69e914bd`](https://github.com/NixOS/nixpkgs/commit/69e914bdb3289851d96cefa763723ab2001f217f) | `libtensorflow: increase meta.timeout to 24h`                                  |
| [`92029c12`](https://github.com/NixOS/nixpkgs/commit/92029c12ee0709d869a6c6bbc82af42d4b698c8c) | `kernels: set testing to latest if it's newer`                                 |
| [`8d0f1c17`](https://github.com/NixOS/nixpkgs/commit/8d0f1c1725a1b2ab34f401cf1b7fda1fc5bf60e6) | `kernel: compare version against the base version`                             |
| [`712db36f`](https://github.com/NixOS/nixpkgs/commit/712db36fa2c30e0fda89d997753708df69ddbdbe) | `kernel/generic: remove redundant kernelOlder/kernelAtLeast`                   |
| [`09454d0f`](https://github.com/NixOS/nixpkgs/commit/09454d0f4a23f79d884de9d6ff0d3dfe5ea1e97b) | `parquet-tools: init at 0.2.9 (#142562)`                                       |
| [`82a8f891`](https://github.com/NixOS/nixpkgs/commit/82a8f891ed2a63f95ef5c86be298ac95ae3beedd) | `dendrite: 0.5.0 -> 0.5.1`                                                     |
| [`36a37f7a`](https://github.com/NixOS/nixpkgs/commit/36a37f7a8f4498b33788729aed10b13b8d6ceb47) | `rtaudio: 5.1.0 -> 5.2.0`                                                      |
| [`652d17ec`](https://github.com/NixOS/nixpkgs/commit/652d17ec7823e81baaebf07abf2939f10919740d) | `discord: remove double systemd dependency`                                    |
| [`7e037d3b`](https://github.com/NixOS/nixpkgs/commit/7e037d3b386d72a75d753ffd8e18af57cae4bf36) | `python3Packages.cozy: format default.nix`                                     |
| [`9c8ce83e`](https://github.com/NixOS/nixpkgs/commit/9c8ce83ecb898f68dc72934af404b3da971a9f91) | `python3Packages.cozy: rename dependency python-igraph -> igraph`              |
| [`5421e153`](https://github.com/NixOS/nixpkgs/commit/5421e153c1cd2b84f5f97d88b0ce33df679eb681) | `ddosify: 0.5.1 -> 0.6.0`                                                      |
| [`87d20e35`](https://github.com/NixOS/nixpkgs/commit/87d20e352ff27c4a0fed11d30f437495baa13c1a) | `cernlib: fix for gfortran10`                                                  |
| [`68f226ae`](https://github.com/NixOS/nixpkgs/commit/68f226aedb66f1be56ea48d929cd356fb4aa6904) | `jwt-cli: 4.0.0 -> 5.0.0`                                                      |
| [`03e8e584`](https://github.com/NixOS/nixpkgs/commit/03e8e5848be209ddffa968ebe9de4dafb76bbf4e) | `nixos/tests/installer: increase memorySize to 3G`                             |
| [`fdd35e77`](https://github.com/NixOS/nixpkgs/commit/fdd35e7715c556b995e8615f73efd2f166cdfe16) | `vdr-vaapidevice: Fix libva-x11`                                               |
| [`d3a670eb`](https://github.com/NixOS/nixpkgs/commit/d3a670eb7ebbdbd5728a6adcfe451aaea271b57f) | `qmk: cosmetic cleanups`                                                       |
| [`de5ed818`](https://github.com/NixOS/nixpkgs/commit/de5ed8189b421190e407c83626f3e06802324604) | `qmk-dotty-dict: add longDescription`                                          |
| [`0eddc870`](https://github.com/NixOS/nixpkgs/commit/0eddc8707d102af771defea92efaaf50a20f875a) | `grafana: 8.2.4 -> 8.2.5`                                                      |
| [`faadbddc`](https://github.com/NixOS/nixpkgs/commit/faadbddcd7af99f908c9111c6612e90dae1c201e) | `clickhouse: Add passthru.tests`                                               |
| [`427941d7`](https://github.com/NixOS/nixpkgs/commit/427941d7377ff2762305f36479fb4365ad2abe68) | `nixos/clickhouse: add package option`                                         |
| [`783dbd1b`](https://github.com/NixOS/nixpkgs/commit/783dbd1ba87c1f5e8624c140f0c7d1f0f0cdc182) | `bitcoin: fix tests on darwin by using en_US.UTF-8 instead of C.UTF-8`         |
| [`ef9bcf24`](https://github.com/NixOS/nixpkgs/commit/ef9bcf24ca2ee5c6d348b1b95c3a8d59aba33490) | `bitcoin-knots: 0.20.0.knots20200614 -> 22.0.knots20211108`                    |
| [`2a997524`](https://github.com/NixOS/nixpkgs/commit/2a99752451956fb7cd2a323c3e16fd4f4e499521) | `nordic: unstable-2021-08-13 -> unstable-2021-11-19`                           |
| [`e156e78d`](https://github.com/NixOS/nixpkgs/commit/e156e78d4b78c3f31ad032f77b84464771b7fca4) | `droopy: Fix Python 3.9 compatiblity (#145702)`                                |
| [`984f0f29`](https://github.com/NixOS/nixpkgs/commit/984f0f29fdcbd7845655ce41ee9a97f2359c5c9a) | `maintainers: add shikanime`                                                   |
| [`b8d69b12`](https://github.com/NixOS/nixpkgs/commit/b8d69b120d8ef5e8f0d44c67b3d594de435456eb) | `mame: 0.226 -> 0.237`                                                         |
| [`5beb83e0`](https://github.com/NixOS/nixpkgs/commit/5beb83e061f9ebb0392cd681d29c6bf495b92d22) | `tor-browser-bundle-bin: enable pulseaudio by default`                         |
| [`87ae243d`](https://github.com/NixOS/nixpkgs/commit/87ae243d2e51263865e6a94778928c66f08bd254) | `picom-next: unstable-2021-10-31 -> unstable-2021-11-19`                       |
| [`8996f6a2`](https://github.com/NixOS/nixpkgs/commit/8996f6a2bca508f1d31dd6f7ceaa17f68ccd6f68) | `ctl: fix build on darwin`                                                     |
| [`c4ecae1b`](https://github.com/NixOS/nixpkgs/commit/c4ecae1bd4743d0f33e86188be8d029356bffbe1) | `jami-*: 20211005.2.251ac7d -> 20211104.2.e80361d`                             |
| [`bb898727`](https://github.com/NixOS/nixpkgs/commit/bb898727ec1a11be1d8544602a8a0331850a205a) | `hdr-plus: fix build on darwin`                                                |
| [`0241bd3d`](https://github.com/NixOS/nixpkgs/commit/0241bd3d64f9fc757514b0d4c5b43ef8fc0c5e82) | `libqb: fix build on darwin`                                                   |
| [`279ef8ed`](https://github.com/NixOS/nixpkgs/commit/279ef8ed7eea250a1727c0c4a56f01aad786882c) | `libtsm: set platforms to linux only`                                          |
| [`cde18dcb`](https://github.com/NixOS/nixpkgs/commit/cde18dcb924b80cc2c01a27133f0fc035827a4ac) | `python3Packages.oath: switch to pytestCheckHook`                              |
| [`849e45fe`](https://github.com/NixOS/nixpkgs/commit/849e45fe7ae4d426deba3bfde6df7416b43f7fc5) | `python3Packages.oath: 1.4.3 -> 1.4.4`                                         |
| [`339974e1`](https://github.com/NixOS/nixpkgs/commit/339974e1a868527b88928de5784f1ee95f284853) | `libite: set platforms to linux + netbsd`                                      |
| [`0c593779`](https://github.com/NixOS/nixpkgs/commit/0c59377977dd7b11e9752cf6ac873d0d70137e11) | `python3Packages.sense-energy: 0.9.2 -> 0.9.3`                                 |
| [`7640f6e6`](https://github.com/NixOS/nixpkgs/commit/7640f6e678cec99f4a5bf22015ba0651581e352e) | `callaudiod: support cross-compilation, enable strictDeps`                     |
| [`625150b2`](https://github.com/NixOS/nixpkgs/commit/625150b22d9cb55a3d0ad9b0e0a9d953093f5745) | `reproxy: 0.9.0 → 0.11.0`                                                      |
| [`a99b6112`](https://github.com/NixOS/nixpkgs/commit/a99b61127e8e370b49dc872fc40b6a7aa9120c4f) | `arj: fix build on darwin`                                                     |
| [`4459b353`](https://github.com/NixOS/nixpkgs/commit/4459b35304dfb86626778a1118a485a2be2d73ed) | `mpv: set meta.mainProgram`                                                    |
| [`194310ce`](https://github.com/NixOS/nixpkgs/commit/194310ce7c48962be2ebf662e0cf1752db135bd8) | `_2048-in-terminal: 2017-11-29 -> 2021-09-12`                                  |
| [`fb93af82`](https://github.com/NixOS/nixpkgs/commit/fb93af82cc08df7b0641e26b524bd8e7b814087a) | `cernlib: binutils 2.37 fix`                                                   |
| [`ccfc3b0f`](https://github.com/NixOS/nixpkgs/commit/ccfc3b0f411c67e5afb4e93c00b1da9519cfe788) | `checkov: 2.0.591 -> 2.0.594`                                                  |
| [`92322a1a`](https://github.com/NixOS/nixpkgs/commit/92322a1a6570cd153769a868d82d7afc87c6d69d) | `invoice2data: 0.2.93 -> 0.3.6`                                                |
| [`6f2adb82`](https://github.com/NixOS/nixpkgs/commit/6f2adb82875db4346a7a4400422f2e609f991eb8) | `python3Packages.azure-servicebus: 7.3.3 -> 7.4.0`                             |
| [`0ecb09b2`](https://github.com/NixOS/nixpkgs/commit/0ecb09b2a3c8edade3aa186ad907b6e0468bc107) | `python3Packages.azure-eventhub: 5.6.0 -> 5.6.1`                               |
| [`130ef76c`](https://github.com/NixOS/nixpkgs/commit/130ef76ca7a286dbd8fa0aba50e592299357f96b) | `python3Packages.uamqp: 1.4.1 -> 1.4.3`                                        |
| [`34802d57`](https://github.com/NixOS/nixpkgs/commit/34802d57bdc640b240bbd231a58d5429d00f4aba) | `python3Packages.aiopvpc: 2.2.2 -> 2.2.4`                                      |
| [`b1b274bb`](https://github.com/NixOS/nixpkgs/commit/b1b274bb9f54efe4e1cff5c964f6af94538e93eb) | `python3Packages.pyiqvia: 2021.10.0 -> 2021.11.0`                              |
| [`4f53f0d9`](https://github.com/NixOS/nixpkgs/commit/4f53f0d9c5cc73d8a6f6d941e357b630b0460355) | `python3Packages.pyopenuv: 2021.10.0 -> 2021.11.0`                             |
| [`4afcb8d1`](https://github.com/NixOS/nixpkgs/commit/4afcb8d1e8f4bcb24834dffae50ab6d502a73cb2) | `python3Packages.pyvesync: 1.4.1 -> 1.4.2`                                     |
| [`fe15c4fd`](https://github.com/NixOS/nixpkgs/commit/fe15c4fd239b0c355119aaa6e99c7af93986170f) | `kopia: 0.9.5 -> 0.9.6`                                                        |
| [`92487083`](https://github.com/NixOS/nixpkgs/commit/924870839f8c5667246f4eb81a368ef033eb081e) | `vscode-extensions.tamasfe.even-better-toml: 0.9.3 -> 0.14.2`                  |
| [`e12d98f2`](https://github.com/NixOS/nixpkgs/commit/e12d98f2db31dd2245be168254c566a99ac88432) | `super-slicer-latest: renamed from super-slicer-staging`                       |
| [`195a5798`](https://github.com/NixOS/nixpkgs/commit/195a579890f79c2c2d8f5e4301f59aee325deb27) | `gnomeExtensions.caffeine remove manual packaging and use extension overrides` |
| [`0cd1cbef`](https://github.com/NixOS/nixpkgs/commit/0cd1cbefe67061125fd597e9b76e06f17ae1a3b5) | `gnomeExtensions: auto-update`                                                 |
| [`a4dd21a6`](https://github.com/NixOS/nixpkgs/commit/a4dd21a6cdbedf35eff2a4fb33d8ec1daaa7c1c7) | `dnsx: 1.0.6 -> 1.0.7`                                                         |
| [`35f3429e`](https://github.com/NixOS/nixpkgs/commit/35f3429e988af0611bb9b9e5860ca36a45e52cef) | `firefox: 94.0.1 -> 94.0.2`                                                    |
| [`b7b835e5`](https://github.com/NixOS/nixpkgs/commit/b7b835e59cb5b6ccdc2629a54ac9f66ca5a6f1dc) | `firefox-bin: 94.0 -> 94.0.2`                                                  |
| [`4639589f`](https://github.com/NixOS/nixpkgs/commit/4639589f8830c5a9e728d716c942fa5e24f0aeaa) | `nixos/sabnzbd: add package option`                                            |
| [`4aea8b21`](https://github.com/NixOS/nixpkgs/commit/4aea8b21ed879c79e79503d32bc688d67d5d6710) | `netdiscover: init at 0.8.1`                                                   |
| [`fe6952a3`](https://github.com/NixOS/nixpkgs/commit/fe6952a39384fd2f352201a4282cfd8740baa65d) | `maintainers: add vdot0x23`                                                    |
| [`6a1fdd60`](https://github.com/NixOS/nixpkgs/commit/6a1fdd60e6e74f7ae85a647eb7552fd9591640ab) | `nixos/nomad: add flag of plugin-dir`                                          |
| [`a19640fb`](https://github.com/NixOS/nixpkgs/commit/a19640fb81269efe44491c7ac7f0db015630aa35) | `gnomeExtensions: make buildShellExtension visible`                            |
| [`5ba0f488`](https://github.com/NixOS/nixpkgs/commit/5ba0f48841b58ce9b796f766fbb925c26e202860) | `python3.pkgs.llfuse: fix cross`                                               |
| [`ae0e800b`](https://github.com/NixOS/nixpkgs/commit/ae0e800b8921615d3df39526dff0cee4dab5d563) | `gfs2-utils: pull pending upstream inclusion fix for ncurses-6.3`              |
| [`afd62c27`](https://github.com/NixOS/nixpkgs/commit/afd62c277375f6962d305b27c0092f99b10c7819) | `nixos/dovecot: use the count backend for quota plugin`                        |
| [`83265a85`](https://github.com/NixOS/nixpkgs/commit/83265a850dea2824456db1debf902520db1a536d) | `sway: Install the wallpapers by default and use them on NixOS`                |