### PR TITLE
chore(flake/nixpkgs): `726f7c96` -> `d00918cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1637550001,
-        "narHash": "sha256-WzwiXc1iIvMTKGnAuRAdrIWFIcEexB3EZH9nFnWuG+Q=",
+        "lastModified": 1637605846,
+        "narHash": "sha256-Llelj1pYeAhGLftPxM2ixSgAfdPBAZOnpBZtpvaZ3Xo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "726f7c9688bad4574abee4f47565bf272daf8f81",
+        "rev": "d00918ccaf7e1532d35db2f1e3d44db3da39b851",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`d464ccfd`](https://github.com/NixOS/nixpkgs/commit/d464ccfdd9e101d4f5a112ab58d91ccbb912524a) | `modules: Add moduleType to module arguments`                                                    |
| [`eb90ae99`](https://github.com/NixOS/nixpkgs/commit/eb90ae9972ae56e0bdfa5b26859dd9c071b4df4c) | `electrs: 0.9.2 -> 0.9.3`                                                                        |
| [`cda036f1`](https://github.com/NixOS/nixpkgs/commit/cda036f189d6dfad27fae50db0e260466e8a2529) | `edk2: pull upstream brotli fix for gcc-11 (#144137)`                                            |
| [`ded247ad`](https://github.com/NixOS/nixpkgs/commit/ded247ada384ceacc5d0d186cffa7c1cc927d268) | `driftctl: init at 0.15.0 (#138494)`                                                             |
| [`41069d41`](https://github.com/NixOS/nixpkgs/commit/41069d41dcfe90a44a15dc28a692ebee2caad573) | `znapzend: 0.20.0 -> 0.21.0 (#141042)`                                                           |
| [`426ab31f`](https://github.com/NixOS/nixpkgs/commit/426ab31fdeb828886c22ec0e561eca2b90b84b94) | `modules: Document that extendModules is also a module argument`                                 |
| [`c71ccc04`](https://github.com/NixOS/nixpkgs/commit/c71ccc045c1fb81fd0785f891a8251bc819efbf9) | `v2ray-domain-list-community: 20211103073737 -> 20211119143108`                                  |
| [`90e60e65`](https://github.com/NixOS/nixpkgs/commit/90e60e65291d2ef76798d09e51249f0f265f7fff) | `wdisplays: set metaProgram`                                                                     |
| [`1a92baf7`](https://github.com/NixOS/nixpkgs/commit/1a92baf7a2258ab3da9f7516c6f72cacc4aecbc9) | `slurm: 21.08.3.1 -> 21.08.4.1`                                                                  |
| [`ed869fb4`](https://github.com/NixOS/nixpkgs/commit/ed869fb4176c5048ee0f292245916341acbb9beb) | `advancecomp: pull upstream patch for gcc-11 support`                                            |
| [`ec713fe2`](https://github.com/NixOS/nixpkgs/commit/ec713fe238f1d3b31089f1668d849cf6c0502bfc) | `burp: pull upstream fix for ncurses-6.3`                                                        |
| [`773e7702`](https://github.com/NixOS/nixpkgs/commit/773e7702c1a8bb907fd3af5787e58a206c9213e8) | `python3Packages.typecode: disable failing test`                                                 |
| [`3ef4ee2e`](https://github.com/NixOS/nixpkgs/commit/3ef4ee2ec987188e85be0c90b2c3af7ceab0e096) | `python3Packages.toggl-cli: fix build`                                                           |
| [`ff640a88`](https://github.com/NixOS/nixpkgs/commit/ff640a88ad848b9b0196dd7b52cdd2e97b1225ff) | `checkov: 2.0.594 -> 2.0.595`                                                                    |
| [`4e10e30e`](https://github.com/NixOS/nixpkgs/commit/4e10e30e62530195776495667dcb36448a2c6660) | `zk: 0.7.0 -> 0.8.0`                                                                             |
| [`7f24a5ff`](https://github.com/NixOS/nixpkgs/commit/7f24a5ff35a7b9eac0c3454c71cbd32dbe52a1a9) | `nixos/systemd: readd dbus-org.freedesktop.login1.service to upstreamSystemUnits`                |
| [`7d6b3abe`](https://github.com/NixOS/nixpkgs/commit/7d6b3abe12c1c8b2e6f760ab82de80d087df57d8) | `arc_unpacker: Move to catch2 to support aarch64-darwin`                                         |
| [`2110b293`](https://github.com/NixOS/nixpkgs/commit/2110b2937f7050303595c10438a10a1f8a50526d) | `cargo-about: 0.4.1 -> 0.4.2`                                                                    |
| [`b0221e06`](https://github.com/NixOS/nixpkgs/commit/b0221e0651bba5e680dd323b937a0cc35d8c0867) | `glitter: 1.5.5 -> 1.5.6`                                                                        |
| [`9a0d636d`](https://github.com/NixOS/nixpkgs/commit/9a0d636d7d220e084c14f32b0d3a0aa16abdc9c1) | `opentabletdriver: use buildDotnetModule`                                                        |
| [`1b366cb9`](https://github.com/NixOS/nixpkgs/commit/1b366cb92b2640816c54df8af17c8d3914f088dd) | `buildDotnetModule: support setting projectFile as an array && properly interpret disabledTests` |
| [`6b804479`](https://github.com/NixOS/nixpkgs/commit/6b8044795e4b7ff99b96259a4a6b09eb9380703d) | `qtwebengine: 5.15.6 → 5.15.7`                                                                   |
| [`d00b852a`](https://github.com/NixOS/nixpkgs/commit/d00b852a90e5d39fead1b2727e51a5bc7bf50e13) | `linuxPackages.rtl8821ce: unstable-2021-05-28 -> unstable-2021-11-19`                            |
| [`26bc8f7e`](https://github.com/NixOS/nixpkgs/commit/26bc8f7eb32b548b64e48a01fd1bd9e6a769e6a0) | `python3Packages.levenshtein: init at 0.16.0`                                                    |
| [`2ba04c2b`](https://github.com/NixOS/nixpkgs/commit/2ba04c2b4e0d872880baea61ef50a5f2a2616b6e) | `python3Packages.python-Levenshtein: add pythonImportsCheck`                                     |
| [`33632479`](https://github.com/NixOS/nixpkgs/commit/33632479f8588671ec5e9e95def1d5b63a8621bc) | `python3Packages.pkginfo: enable tests`                                                          |
| [`931e4927`](https://github.com/NixOS/nixpkgs/commit/931e4927c6ebc7f661b80bc1716e39fed54de759) | `python3Packages.pkginfo: 1.7.1 -> 1.8.1`                                                        |
| [`d4ca0252`](https://github.com/NixOS/nixpkgs/commit/d4ca0252c4a14d03f982d02cc86cab3e7551c258) | `python3Packages.plexapi: 4.7.2 -> 4.8.0`                                                        |
| [`1f5ffefa`](https://github.com/NixOS/nixpkgs/commit/1f5ffefa4546148e209518006f771301f1e213d2) | `python3Packages.goodwe: init at 0.2.7`                                                          |
| [`373eb080`](https://github.com/NixOS/nixpkgs/commit/373eb080dc2703de2051b38d1ca6f3f01304a3cb) | `home-assistant: update component-packages`                                                      |
| [`71de64a1`](https://github.com/NixOS/nixpkgs/commit/71de64a139f3ab2090ff4186fb01b2f859d34cc3) | `python3Packages.afsapi: init at 0.0.4`                                                          |
| [`6f8cb0dc`](https://github.com/NixOS/nixpkgs/commit/6f8cb0dc007090acccbf46ad5e2214a615f2c638) | `grafana-image-renderer: 3.2.1 -> 3.3.0`                                                         |
| [`4aff9530`](https://github.com/NixOS/nixpkgs/commit/4aff9530e5bd708bca16b417f5350721b0bec212) | `home-assistant: update component-packages`                                                      |
| [`3ec513d7`](https://github.com/NixOS/nixpkgs/commit/3ec513d79877bbea0ce786ff13524aed11ec95ba) | `python3Packages.py-zabbix: init at 1.1.7`                                                       |
| [`feceb9ce`](https://github.com/NixOS/nixpkgs/commit/feceb9ce85cefeae19284959b6615b37f8b6ff29) | `home-assistant: update component-packages`                                                      |
| [`9981890c`](https://github.com/NixOS/nixpkgs/commit/9981890cbc9173a30d3bb32964e11b484a4f322a) | `python3Packages.pyskyqhub: init at 0.1.4`                                                       |
| [`673c63bd`](https://github.com/NixOS/nixpkgs/commit/673c63bdcec0f9118313a1adde7c04d7b01cdfe7) | `home-assistant: update component-packages`                                                      |
| [`64c7052a`](https://github.com/NixOS/nixpkgs/commit/64c7052abc1d4201beaae0b6cdcb91ca188e6705) | `python3Packages.eliqonline: init at 1.2.2`                                                      |
| [`d70a6fe8`](https://github.com/NixOS/nixpkgs/commit/d70a6fe8bfefd5d5177a4490c49261b26d209816) | `home-assistant: update component-packages`                                                      |
| [`6c775112`](https://github.com/NixOS/nixpkgs/commit/6c7751121c4263cd7f860895dda5f7bb071a77b2) | `python3Packages.pyephember: init at 0.3.1`                                                      |
| [`b1e3827e`](https://github.com/NixOS/nixpkgs/commit/b1e3827e27a260a33d1fb0353e6865f417d1af0b) | `home-assistant: update component-packages`                                                      |
| [`fafe74f1`](https://github.com/NixOS/nixpkgs/commit/fafe74f1574482f27f3c40a204008c5cea1fb9f3) | `python3Packages.ritassist: init at 0.9.3`                                                       |
| [`9203c9e9`](https://github.com/NixOS/nixpkgs/commit/9203c9e9e4f9971fdacbe7fbb8b8470336579c97) | `python3Packages.exchangelib: 4.6.0 -> 4.6.1`                                                    |
| [`92ed0039`](https://github.com/NixOS/nixpkgs/commit/92ed0039ffd20300515abc52b09452a0d2d60cc9) | `python3Packages.pyezviz: 0.2.0.0 -> 0.2.0.5`                                                    |
| [`e70b543e`](https://github.com/NixOS/nixpkgs/commit/e70b543e123e0407f4a201c17dd703502a156b79) | `python3Packages.aioshelly: 1.0.4 -> 1.0.5`                                                      |
| [`86f53d1f`](https://github.com/NixOS/nixpkgs/commit/86f53d1f77c49780337a68364793f57f025c0a27) | `home-assistant: update component-packages`                                                      |
| [`7f1b902b`](https://github.com/NixOS/nixpkgs/commit/7f1b902bf9ed41b5e02b322dcfbbd502c4cebb78) | `python3Packages.life360: init at 4.1.1`                                                         |
| [`c564882e`](https://github.com/NixOS/nixpkgs/commit/c564882ee8342c3968fad64f4eb086f3fc6d6d00) | `home-assistant: update component-packages`                                                      |
| [`6e642977`](https://github.com/NixOS/nixpkgs/commit/6e64297712c83b18cc26756d6a88cf8da755d5f9) | `python3Packages.oemthermostat: init at 1.1.1`                                                   |
| [`11d5edb4`](https://github.com/NixOS/nixpkgs/commit/11d5edb4d1c9ec3a07ff75d1a2e67ac4e05e0b23) | `home-assistant: update component-packages`                                                      |
| [`d66a25e8`](https://github.com/NixOS/nixpkgs/commit/d66a25e89bcadb6c9bde040d03ee1bf698c05590) | `python3Packages.libpyvivotek: init at 0.4.0`                                                    |
| [`2bb36119`](https://github.com/NixOS/nixpkgs/commit/2bb36119e594db7bc152da9b0e49902e7059d9b3) | `home-assistant: update component-packages`                                                      |
| [`fcd53ad4`](https://github.com/NixOS/nixpkgs/commit/fcd53ad43a7ae2477e47ec141b8727e0b2651157) | `python3Packages.pyversasense: init at 0.0.6`                                                    |
| [`73c01771`](https://github.com/NixOS/nixpkgs/commit/73c01771f1a503017b590b79e0fb31c4aecaaf5e) | `krane: 2.3.1 → 2.3.2`                                                                           |
| [`18aca788`](https://github.com/NixOS/nixpkgs/commit/18aca788e537d70665aca9d877f5c776e3681d75) | `python3Packages.pysecuritas: init at 0.1.6`                                                     |
| [`bf8619a8`](https://github.com/NixOS/nixpkgs/commit/bf8619a820f7354370b0aa5c484540a12dbac9c5) | `python3Packages.pynina: init at unstable-2021-11-11`                                            |
| [`ea767b13`](https://github.com/NixOS/nixpkgs/commit/ea767b13954722e451ba1ab63b4f378e5a0bc45a) | `python3Packages.qnap-qsw: init at 0.3.0`                                                        |
| [`94cde3d3`](https://github.com/NixOS/nixpkgs/commit/94cde3d3db32a656fa002d3ea9e76b3715af4628) | `python3Packages.halohome: init at 0.4.0`                                                        |
| [`643ef114`](https://github.com/NixOS/nixpkgs/commit/643ef1145e2bc2634b1e74a8eb4467dd57e69844) | `python3Packages.diskcache: disable flakey test`                                                 |
| [`7268b1ea`](https://github.com/NixOS/nixpkgs/commit/7268b1ea831e7349d5a8749a82693981bfec25ae) | `hybridreverb2: fix eval with expoxy rename`                                                     |
| [`2d2d4722`](https://github.com/NixOS/nixpkgs/commit/2d2d47227398480259d1d117c6bb974ce5a49f56) | `rhash: fix build on darwin`                                                                     |
| [`e08e1505`](https://github.com/NixOS/nixpkgs/commit/e08e150504b177232b0718fddc2b7c67c3e4cbb6) | `multitail: pull pending upstream inclusion fix for ncurses-6.3`                                 |
| [`485e62c1`](https://github.com/NixOS/nixpkgs/commit/485e62c1840ba0b3d96774c100ee4df311a1a71e) | `python3Packages.hypothesis: 6.23.2 → 6.24.5`                                                    |
| [`f6a5d2ed`](https://github.com/NixOS/nixpkgs/commit/f6a5d2ed514c6bb788a6676383b87c55f80292fd) | `libpsl: 0.21.0 -> 0.21.1`                                                                       |
| [`07e0679c`](https://github.com/NixOS/nixpkgs/commit/07e0679c3c9292b65093bb6efe97398d5048243a) | `ssm-session-manager-plugin: add "aarch64-darwin" support`                                       |
| [`f1672177`](https://github.com/NixOS/nixpkgs/commit/f16721775ee53a355733d9e18233234f6620070c) | `mandoc: allow makewhatis(8) to index the nix store`                                             |
| [`4b655c42`](https://github.com/NixOS/nixpkgs/commit/4b655c423b62f82e51a97344c010c9556682a7e6) | `probe-run: 0.2.5 -> 0.3.0`                                                                      |
| [`c271888a`](https://github.com/NixOS/nixpkgs/commit/c271888a89849aa9bb88b3eb0ce44008cbfe1b35) | `netbsd.man: fix build`                                                                          |
| [`7481bc7a`](https://github.com/NixOS/nixpkgs/commit/7481bc7a31658b955fea01e836b0a0791a339897) | `publicsuffix-list: 2019-05-24 -> 2021-09-03 (#136680)`                                          |
| [`f4ac75e7`](https://github.com/NixOS/nixpkgs/commit/f4ac75e7e3488f7d6bee28f37848436729b652ad) | `python38Packages.qtawesome: 1.0.3 -> 1.1.0`                                                     |
| [`b3139e4e`](https://github.com/NixOS/nixpkgs/commit/b3139e4e9e4928ef6728402bee9fc152de7ec009) | `sysprof: 3.42.0 → 3.42.1`                                                                       |
| [`9e2114fa`](https://github.com/NixOS/nixpkgs/commit/9e2114fadef8284e3da135db3171e9aab2d4becf) | `tracker: 3.2.0 → 3.2.1`                                                                         |
| [`5fd5dd9c`](https://github.com/NixOS/nixpkgs/commit/5fd5dd9ca6c0ddb92abe77a9ef3cd37c9426f0d5) | `python38Packages.pymatgen: 2022.0.14 -> 2022.0.16`                                              |
| [`5577bc63`](https://github.com/NixOS/nixpkgs/commit/5577bc63801f52a39048586784749f97c007b434) | `python38Packages.knack: 0.8.2 -> 0.9.0`                                                         |
| [`c3d6b5d8`](https://github.com/NixOS/nixpkgs/commit/c3d6b5d847b9a3150184d66a8f5a528d3d044654) | `python38Packages.jupyterlab: 3.1.18 -> 3.2.3`                                                   |
| [`b4d7056b`](https://github.com/NixOS/nixpkgs/commit/b4d7056b9436b31d6713048bd4c40fd9b1658046) | `harfbuzz: 2.8.2 -> 3.0.0`                                                                       |
| [`f390ad51`](https://github.com/NixOS/nixpkgs/commit/f390ad51bf7331ecb9d30f6568eeb17d7ab68e95) | `jnettop: pull pending upstream inclusion fix for ncurses-6.3`                                   |
| [`a0a7b29b`](https://github.com/NixOS/nixpkgs/commit/a0a7b29b5b2373d923831d2f27adce9f5b918c41) | `trafficserver: 9.0.2 -> 9.1.1`                                                                  |
| [`fd17139b`](https://github.com/NixOS/nixpkgs/commit/fd17139b805a6eac0676d92f2655176724c119df) | `elfutils: 0.185 -> 0.186`                                                                       |
| [`82d7a450`](https://github.com/NixOS/nixpkgs/commit/82d7a450e5d2eb26cb855097e15866d66f99ffe7) | `python3Packages.pytest-flake8: fix patch hash`                                                  |
| [`c921653f`](https://github.com/NixOS/nixpkgs/commit/c921653fbb3c1a1f940784b9eadd981866e8ff96) | `vimPlugins.luatab-nvim: init at 2021-11-08`                                                     |
| [`f236c90c`](https://github.com/NixOS/nixpkgs/commit/f236c90ccbff63285736c58d777b0ea3334cefe4) | `vimPlugins.tabline-nvim: init at 2021-11-10`                                                    |
| [`b1f8e163`](https://github.com/NixOS/nixpkgs/commit/b1f8e1634f9f0c913aa37b1d8c8c95b2bf950fad) | `libopenmpt: fix build on gcc-12`                                                                |
| [`3cc3a762`](https://github.com/NixOS/nixpkgs/commit/3cc3a7626deb5da3dea74487f3f044512b977fc4) | `sassc: 3.6.1 -> 3.6.2, add comment to keep in sync with libsass`                                |
| [`3c710c46`](https://github.com/NixOS/nixpkgs/commit/3c710c46b16e1d0d9ec42f1541774c29db2fc90c) | `graphviz: fix cross`                                                                            |
| [`95947f6d`](https://github.com/NixOS/nixpkgs/commit/95947f6dd765d51729bb7e60bbb202b3ef5a1a9d) | `python2.pkgs.pycairo: fix cross`                                                                |
| [`c18332ae`](https://github.com/NixOS/nixpkgs/commit/c18332aed360857965ceebe7e389421d78f8181a) | `python3.pkgs.pycairo: fix cross`                                                                |
| [`2bca5258`](https://github.com/NixOS/nixpkgs/commit/2bca52581723992ccadfb221fd1ddafffee47f6f) | `python39Packages.regex: 2021.10.8 -> 2021.11.10`                                                |
| [`cc6068c2`](https://github.com/NixOS/nixpkgs/commit/cc6068c2c02558d6d5a7069b794db872b0e772e2) | `maintainers: Change email for ivankovnatsky`                                                    |
| [`c9a95534`](https://github.com/NixOS/nixpkgs/commit/c9a9553496f4cc944e00e9ab6a5651963e82852e) | `python3Packages.yarl: 1.7.0 -> 1.7.2`                                                           |
| [`15e7302a`](https://github.com/NixOS/nixpkgs/commit/15e7302a9a496f061df5abe20bb3f2441f09bad8) | `python3Packages.aiohttp: 3.7.4.post0 -> 3.8.0`                                                  |
| [`21db3959`](https://github.com/NixOS/nixpkgs/commit/21db3959b496f948f2569d2593ff3ad63e727e3d) | `python3Packages.async-timeout: 3.0.1 -> 4.0.1`                                                  |
| [`d9fdae1b`](https://github.com/NixOS/nixpkgs/commit/d9fdae1b8e0710a6e8b27103e46524321733a7e0) | `thedesk: init at 22.3.1`                                                                        |
| [`1f84f953`](https://github.com/NixOS/nixpkgs/commit/1f84f953ecee944b9ceee0540a47df08ae8cb491) | `pixeluvo: init at 1.6.0-2`                                                                      |
| [`8f76cb12`](https://github.com/NixOS/nixpkgs/commit/8f76cb12c172106ff1070b1994bc040449fcf9d9) | `indigenous-desktop: init at 1.3.0`                                                              |
| [`8544de56`](https://github.com/NixOS/nixpkgs/commit/8544de565e6fb2efae3fd36e57f6ab6a2f7a3769) | `indigenous-desktop: init at 1.2.0`                                                              |
| [`94f3d500`](https://github.com/NixOS/nixpkgs/commit/94f3d500983c9daa5fe644a1cc4ffe45df5f2df8) | `python3Packages.sqlalchemy: 1.4.26 -> 1.4.27`                                                   |
| [`8daf6962`](https://github.com/NixOS/nixpkgs/commit/8daf69629cfd071d58cbb3b6f54a9321514ec5ba) | `timidity: fix cross`                                                                            |