### PR TITLE
chore(flake/sops-nix): `c2c7e076` -> `b9145d46`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1637671790,
-        "narHash": "sha256-ab/kQjx9tcrnB4STERpzYqOOMFtmFeMx6Qnziji79Hc=",
+        "lastModified": 1637694407,
+        "narHash": "sha256-lPFxflAtnUkMX15d/vGJdaeS4/kn3FcdrcmEABxdhjg=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c2c7e076ec1d7ee971df621b1405956a9c41fadc",
+        "rev": "b9145d46f038979cc42fd617abaaca7a2fe2c226",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                 |
| ----------------------------------------------------------------------------------------------- | ------------------------------ |
| [`aae83a73`](https://github.com/Mic92/sops-nix/commit/aae83a73f0cd185f0f0bf248f94d74ee24ebc5cd) | `docs: fix more grammar`       |
| [`e6866b54`](https://github.com/Mic92/sops-nix/commit/e6866b54e65484901945a11b5660e7aa61bbaf75) | `docs: make README.md clearer` |