### PR TITLE
chore(flake/nixpkgs): `d00918cc` -> `db223258`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1637605846,
-        "narHash": "sha256-Llelj1pYeAhGLftPxM2ixSgAfdPBAZOnpBZtpvaZ3Xo=",
+        "lastModified": 1637692247,
+        "narHash": "sha256-NQmfA2RHAMuFcptksFQoWzG1c0Qjn2KEWXUVFujEMF4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d00918ccaf7e1532d35db2f1e3d44db3da39b851",
+        "rev": "db22325869a05e376dbab1c31ea7664dd5fcf860",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                  |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`dbabce36`](https://github.com/NixOS/nixpkgs/commit/dbabce365c0d273ac7541b96533313b43280b2a1) | `python3.pkgs.holoviews: remove optional dependencies`                          |
| [`b8173c4a`](https://github.com/NixOS/nixpkgs/commit/b8173c4a0e03f3f25601bf4c12175a9fa6a887f0) | `luaPackages.moonscript: Correct package version to dev-1`                      |
| [`e9f11956`](https://github.com/NixOS/nixpkgs/commit/e9f119566ad0437cc9538a435b78aabaf710ffa0) | `warzone2100: 4.2.1 -> 4.2.2`                                                   |
| [`846ebc44`](https://github.com/NixOS/nixpkgs/commit/846ebc44a6f72f8b9ac6c0186449c79cb9b0dec8) | `python3Package.aionotify: remove myself from maintainers`                      |
| [`70c877ea`](https://github.com/NixOS/nixpkgs/commit/70c877ea4c62ceb5bca9cf02b5a1060aef884952) | `hover: remove myself from maintainers`                                         |
| [`2962edb9`](https://github.com/NixOS/nixpkgs/commit/2962edb9445971ce804189be8e4c9e3edfb2f465) | `flutter: remove myself from maintainers`                                       |
| [`9ef72b90`](https://github.com/NixOS/nixpkgs/commit/9ef72b907ca9054bfe8205d839f2063901aca609) | `corrosion: fix darwin build (#147120)`                                         |
| [`2f5b793c`](https://github.com/NixOS/nixpkgs/commit/2f5b793c9b386ce8de0c559938c806e356a063b2) | `whalebird: 4.4.5 -> 4.4.6`                                                     |
| [`ad4ff305`](https://github.com/NixOS/nixpkgs/commit/ad4ff3050df5292d8ab39e159dbe0f999a641d5a) | `gtk4.updateScript: correct policy`                                             |
| [`e2b522ca`](https://github.com/NixOS/nixpkgs/commit/e2b522ca015ce1e76232f690c37a3bc5fc717f1f) | `libhandy: 1.4.0 → 1.5.0`                                                       |
| [`c87458e0`](https://github.com/NixOS/nixpkgs/commit/c87458e0023129164af036bd5e6e97417f91884e) | `gupnp-tools: 0.10.1 → 0.10.2`                                                  |
| [`74a48763`](https://github.com/NixOS/nixpkgs/commit/74a4876377281cb83b2e226e71f98069a4c9baf3) | `gnome-builder: 41.1 → 41.2`                                                    |
| [`de1413c3`](https://github.com/NixOS/nixpkgs/commit/de1413c3966a74f01c8078519345727e59944b93) | `gtk-vnc: 1.2.0 → 1.3.0`                                                        |
| [`e9f6e6c4`](https://github.com/NixOS/nixpkgs/commit/e9f6e6c49f279a405debe8c081ad5f887011fe21) | `gnome.gnome-screenshot: 40.0 → 41.0`                                           |
| [`1ad7180e`](https://github.com/NixOS/nixpkgs/commit/1ad7180e2132dcbb5c11611eb2e84e7dd06c91b9) | `gnome.gnome-flashback: 3.40.0 → 3.42.0`                                        |
| [`e102c85c`](https://github.com/NixOS/nixpkgs/commit/e102c85c09b6658f5574e403d0d9c1a3c24f7bfe) | `evince: 41.2 → 41.3`                                                           |
| [`76353582`](https://github.com/NixOS/nixpkgs/commit/763535823582f5072aafa1b1a73a212b6a10fe6f) | `gnome.cheese: 41.0 → 41.1`                                                     |
| [`e41a7715`](https://github.com/NixOS/nixpkgs/commit/e41a7715a29b193f14abd366f3c26b32017801da) | `gnomeExtensions: improve README`                                               |
| [`bc1f025a`](https://github.com/NixOS/nixpkgs/commit/bc1f025afb28de72e9a8363d7553bafcffc086c8) | `gnomeExtensions: improve override mechanism`                                   |
| [`c6e22b59`](https://github.com/NixOS/nixpkgs/commit/c6e22b597b7e5abf69170ac7ae8ba73456e60a30) | `cups-brother-hll2350dw: init at 4.0.0-1`                                       |
| [`4985724c`](https://github.com/NixOS/nixpkgs/commit/4985724c823c15661374d0ec396cf6039a4a476b) | `build(deps): bump cachix/install-nix-action from 15 to 16`                     |
| [`469d7d50`](https://github.com/NixOS/nixpkgs/commit/469d7d5013d0629a508f46f435ee0ef0c788c2e9) | `wireguard-tools: remove myself as maintainer`                                  |
| [`ebf1e164`](https://github.com/NixOS/nixpkgs/commit/ebf1e1645946a77346bcd813fd094d084a32f6a5) | `sbcl_2_1_10: init at 2.1.10`                                                   |
| [`a391439b`](https://github.com/NixOS/nixpkgs/commit/a391439b7bbec2fdc3234cf7a8e0bf661c579cf9) | `gnomeExtensions.arcmenu: 14 -> 19`                                             |
| [`1cc5df03`](https://github.com/NixOS/nixpkgs/commit/1cc5df0346c486952924542d971fbed14a4da5ce) | `matrix-synapse: 1.47.0 -> 1.47.1`                                              |
| [`8ca4296c`](https://github.com/NixOS/nixpkgs/commit/8ca4296c20eb7762c0f73a4fabdd00c545551ad9) | `checkov: 2.0.595 -> 2.0.598`                                                   |
| [`3705b869`](https://github.com/NixOS/nixpkgs/commit/3705b869bd20562aae2d1ca95111950752c05fb6) | `python3Packages.volkszaehler: 0.3.0 -> 0.3.2`                                  |
| [`080a563f`](https://github.com/NixOS/nixpkgs/commit/080a563fb5635fa83f8d4814778c4ac48428a16a) | `exploitdb: 2021-11-18 -> 2021-11-23`                                           |
| [`33bff3a7`](https://github.com/NixOS/nixpkgs/commit/33bff3a785e2af2039bfd6b77f4ea787062f18a0) | `python3Packages.volkszaehler: 0.2.2 -> 0.3.0`                                  |
| [`8e986f63`](https://github.com/NixOS/nixpkgs/commit/8e986f6389393bbbb593c2a34f7139b9b5f450af) | `nixos/bluetooth: fix bluetooth warnings`                                       |
| [`e4058657`](https://github.com/NixOS/nixpkgs/commit/e40586575cffec1f8a8fbe20d608f5b6ce0c92fa) | `python3Packages.opensensemap-api: 0.1.6 -> 0.2.0`                              |
| [`1e3ff0d2`](https://github.com/NixOS/nixpkgs/commit/1e3ff0d215c263bb5a0038ea035ab335ad265329) | `tfsec: 0.60.0 -> 0.60.1`                                                       |
| [`712b4025`](https://github.com/NixOS/nixpkgs/commit/712b402565e53a0e00113e9b617d4edd428d158c) | `python3Packages.cwcwidth: fix tests on darwin`                                 |
| [`67c9d4ae`](https://github.com/NixOS/nixpkgs/commit/67c9d4ae0086730668661af469886dfc99f1392e) | `glm: fix aarch64-darwin build by fixing cmake warnings`                        |
| [`ebbca75d`](https://github.com/NixOS/nixpkgs/commit/ebbca75dc2b74d6b68f9a157ac2ec643a7570d19) | `glances: 3.2.3.1 -> 3.2.4.2`                                                   |
| [`74d907ad`](https://github.com/NixOS/nixpkgs/commit/74d907ad052d0ebeb67dcda97c6f227de3c5a3a5) | `libcanberra-gtk3: mark as unbroken on darwin (#147045)`                        |
| [`decac5a0`](https://github.com/NixOS/nixpkgs/commit/decac5a0d20b05d7b95b9e0e2ad324e4fe7df7ba) | `kicad-unstable: 2021-07-12 -> 6.0.0-rc1 (#142261)`                             |
| [`d2c4e0a3`](https://github.com/NixOS/nixpkgs/commit/d2c4e0a3ba7ad7b0b81ea8854b88ea38799b4d2e) | `kicad: 5.1.11 -> 5.1.12 (#145403)`                                             |
| [`fff44a9c`](https://github.com/NixOS/nixpkgs/commit/fff44a9c1a1c7fa5c103ea9535dec71ed622f305) | `slack: 4.21.1 -> 4.22.0`                                                       |
| [`fd5df16c`](https://github.com/NixOS/nixpkgs/commit/fd5df16c244dc320a31fb2788153c8a109d81adc) | `bwbasic: init at 3.20`                                                         |
| [`106286b4`](https://github.com/NixOS/nixpkgs/commit/106286b498496bc824157c2b5e8185dc6c83b4c6) | `erlang: 24.1.6 -> 24.1.7 (#146999)`                                            |
| [`8b8bd0e2`](https://github.com/NixOS/nixpkgs/commit/8b8bd0e23effca7cb845e1089de9ceb3d1715690) | `systemdgenie: init at  0.99.0 (#143984)`                                       |
| [`ab0c0747`](https://github.com/NixOS/nixpkgs/commit/ab0c07470b52cf74bb1b671f80c182f6bde8faf6) | `kaffeine: init at 2.0.18 (#143985)`                                            |
| [`9c390b6b`](https://github.com/NixOS/nixpkgs/commit/9c390b6b38e7b67df6c25f45dd25746976b09c5f) | `python3Packages.hangups: fix async-timeout`                                    |
| [`7727ce7c`](https://github.com/NixOS/nixpkgs/commit/7727ce7c3bcea49ee389966f659aa3b96394b649) | `Revert "wireguard-tools: allow system resolvconf implementation if available"` |
| [`17dc5d7f`](https://github.com/NixOS/nixpkgs/commit/17dc5d7faa81b7c3c735ded16a1b24892db93ffb) | `palemoon: factor mozconfig in a new file`                                      |
| [`55c7dfad`](https://github.com/NixOS/nixpkgs/commit/55c7dfade090887ad5b8ea9004c08159d2dfd9a9) | `nixos/documentation: index devman by default if enabled`                       |
| [`daa8c594`](https://github.com/NixOS/nixpkgs/commit/daa8c59404ba38fef684996e1cc98f5e5a634780) | `yambar: build with dual support, both wayland and x11 (#146568)`               |
| [`ef63ed7b`](https://github.com/NixOS/nixpkgs/commit/ef63ed7b10f6d41babec249d897329848eb0de87) | `nixos/doc: check in converted docbook for 22.05 release notes`                 |
| [`a18f40f0`](https://github.com/NixOS/nixpkgs/commit/a18f40f0e29ae257df9f010f150ff491715b6338) | `foot: 1.9.2 -> 1.10.1`                                                         |
| [`2768bc07`](https://github.com/NixOS/nixpkgs/commit/2768bc07f78a18aa26f869f39e37e87fd15544a6) | `add release notes for 22.05 and update codename`                               |
| [`e96c6680`](https://github.com/NixOS/nixpkgs/commit/e96c668072d7c98ddf2062f6d2b37f84909a572b) | `increment version to 22.05`                                                    |
| [`8bcc4130`](https://github.com/NixOS/nixpkgs/commit/8bcc413092dd4f3bcd421e12665e5aca50100820) | `linux: enable kTLS`                                                            |
| [`3987f215`](https://github.com/NixOS/nixpkgs/commit/3987f21582750fbcb18aa6f1d898f1a8bd0c2b9f) | `slowlorust: init at 0.1.1`                                                     |
| [`6c142e02`](https://github.com/NixOS/nixpkgs/commit/6c142e0215a1f7c6ce9a87ee786336aa28d6825b) | `maintainers: remove mdlayher from golang team`                                 |
| [`bdaa71a1`](https://github.com/NixOS/nixpkgs/commit/bdaa71a14a2efa6aabf3c297a28f5d3547579609) | `flatbuffers: pull pending upstream fix for gcc-12 (#146930)`                   |
| [`528716bb`](https://github.com/NixOS/nixpkgs/commit/528716bb8e61dfc443566c9f3345df4b25d72483) | `ocaml: Fix aarch64-darwin build`                                               |
| [`6cfd23fa`](https://github.com/NixOS/nixpkgs/commit/6cfd23fa0b30b696e10e5f2e25adb53fa678c20c) | `nixos-install: support --no-root-password`                                     |
| [`2676de37`](https://github.com/NixOS/nixpkgs/commit/2676de37fe0a62f983f14eefb5ef3d54fc40c963) | `mill: 0.9.9 → 0.9.10 (#147008)`                                                |
| [`edcb8f81`](https://github.com/NixOS/nixpkgs/commit/edcb8f814123ef18f24e97063f74db0c4bd99405) | `python3Packages.aionanoleaf: 0.0.3 -> 0.0.4`                                   |
| [`bcb04277`](https://github.com/NixOS/nixpkgs/commit/bcb0427773687c04ee2c1c59e30d86ca31ef8942) | `libtool: add meta.platforms and make cctools Darwin only`                      |
| [`4041bc18`](https://github.com/NixOS/nixpkgs/commit/4041bc18302d1ee695abf606c33490ea2391fbe8) | `palemoon: 29.4.1 -> 29.4.2.1`                                                  |
| [`09f96392`](https://github.com/NixOS/nixpkgs/commit/09f96392834cf7b863e7331025afdd871d6b3df6) | `python3Packages.qcs-api-client: 0.20.0 -> 0.20.1`                              |
| [`43b5491a`](https://github.com/NixOS/nixpkgs/commit/43b5491aca61efe683c2abea8b958cc44d0dd2a0) | `python3Packages.pytado: 0.11.0 -> 0.13.0`                                      |
| [`ff0b3401`](https://github.com/NixOS/nixpkgs/commit/ff0b34015da77756ca5e6de136dee223d5872fe9) | `python3Packages.pytado: 0.2.7 -> 0.11.0`                                       |
| [`25bfb58e`](https://github.com/NixOS/nixpkgs/commit/25bfb58ed0bda9c0532d3c9c6a3ffad99b717f43) | `python3Packages.pysaml2: switch to pytestCheckHook`                            |
| [`43dc57e0`](https://github.com/NixOS/nixpkgs/commit/43dc57e03e6c46465654832b5d70231946e5dae0) | `python3Packages.pysaml2: 7.0.1 -> 7.1.0`                                       |
| [`bd917934`](https://github.com/NixOS/nixpkgs/commit/bd9179343af415cf45656671d65f18c0e50ee2f5) | `flatpak-builder: 1.0.14 → 1.2.0`                                               |
| [`0bbd6b82`](https://github.com/NixOS/nixpkgs/commit/0bbd6b822e1898a605c4d31683f7bcdcc4a41410) | `debugedit: unstable-2021-07-05 → 5.0`                                          |
| [`ddc86424`](https://github.com/NixOS/nixpkgs/commit/ddc86424766e0cd18befea3ca56a2be276c7ef1e) | `nordic: this git revision was released as stable`                              |
| [`98fd890f`](https://github.com/NixOS/nixpkgs/commit/98fd890f48702a0634a74a69c1e60d3c2549a860) | `nordic: install the kde related themes`                                        |
| [`01f3f665`](https://github.com/NixOS/nixpkgs/commit/01f3f665fec1089a6e6aa19d6821f0f5f13ac4fd) | `python3Packages.sendgrid: 6.8.3 -> 6.9.1`                                      |
| [`b45bf887`](https://github.com/NixOS/nixpkgs/commit/b45bf887cd7978fa3caab2c3008b170559db2310) | `python3Packages.sepaxml: 2.2.0 -> 2.4.1`                                       |
| [`b948cee1`](https://github.com/NixOS/nixpkgs/commit/b948cee1848ead6b55d05feacfb023d9c5e6ad14) | `python3Packages.aiomusiccast: 0.13.1 -> 0.14.0`                                |
| [`e86fa71b`](https://github.com/NixOS/nixpkgs/commit/e86fa71ba6785a563ae3c8b7ce4c8cf72f6ce3c0) | `shaderc: include darwin libtool`                                               |
| [`b91f4d00`](https://github.com/NixOS/nixpkgs/commit/b91f4d0097fe68910185e2813e7754acbf66f36b) | `bicgl: fix build for x86_64-darwin`                                            |
| [`069ae0ad`](https://github.com/NixOS/nixpkgs/commit/069ae0ada191b1985d76cfec18afe7fe36c39846) | `cargo-deny: 0.10.1 -> 0.10.2`                                                  |
| [`b1cfb04d`](https://github.com/NixOS/nixpkgs/commit/b1cfb04d5e39aee1625d7d58da6a53acd3ae1b38) | `hck: 0.6.7 -> 0.7.0`                                                           |
| [`4a82bca5`](https://github.com/NixOS/nixpkgs/commit/4a82bca53019050767e95fb18ade8f775de0a5d4) | `gnomeExtensions: expose gnome41Extensions in top-level`                        |
| [`645cd20f`](https://github.com/NixOS/nixpkgs/commit/645cd20f666b4271b25474b361f82d3571a45bd0) | `chopchop: init at 1.0.0`                                                       |
| [`5ff62e34`](https://github.com/NixOS/nixpkgs/commit/5ff62e34a64442fb1ba9bf0d6b7f8b2e4648537e) | `boofuzz: init at 0.4.0`                                                        |
| [`3aa5d80b`](https://github.com/NixOS/nixpkgs/commit/3aa5d80be94d37b39d9a87a726f7b9226d46162d) | `stacs: init at 0.2.0`                                                          |
| [`44bd0265`](https://github.com/NixOS/nixpkgs/commit/44bd0265ba2fa225ca5bc2d13004190f43a0bb58) | `python3Packages.setupmeta: init at 3.3.0`                                      |
| [`d06436f7`](https://github.com/NixOS/nixpkgs/commit/d06436f798cdc47c3570d17773a4081475ef608b) | `python3Packages.pep440: init at 0.1.0`                                         |
| [`d3c7e580`](https://github.com/NixOS/nixpkgs/commit/d3c7e5801f572697f0483436dff80fc4ffa1658d) | `imagemagick: 7.1.0-14 -> 7.1.0-15`                                             |
| [`f4441ac4`](https://github.com/NixOS/nixpkgs/commit/f4441ac4033bc89956e3fcdec419bcfa3de59aab) | `ghostwriter: 2.0.2 -> 2.1.0`                                                   |
| [`ef17d663`](https://github.com/NixOS/nixpkgs/commit/ef17d66328a06fc0720f824feec382c8f0070b6b) | `linux_zen: 5.15.2-zen1 -> 5.15.3-zen1`                                         |
| [`541a3a73`](https://github.com/NixOS/nixpkgs/commit/541a3a73327ae9a9169e67b586880198ce14faef) | `linux_latest-libre: 18473 -> 18484`                                            |
| [`392ccc54`](https://github.com/NixOS/nixpkgs/commit/392ccc54319d5330e43348e721c10a988e527be5) | `linux: 5.4.160 -> 5.4.161`                                                     |
| [`d789aebb`](https://github.com/NixOS/nixpkgs/commit/d789aebb56279078206b021aed1e4b06427bf41a) | `linux: 5.15.3 -> 5.15.4`                                                       |
| [`df8b7f5d`](https://github.com/NixOS/nixpkgs/commit/df8b7f5d062bcd2bca30a7acf4661c7b69f73338) | `linux: 5.14.20 -> 5.14.21`                                                     |
| [`06629bb1`](https://github.com/NixOS/nixpkgs/commit/06629bb117ff9cd4b5c79e5be6aa42f21fe981a3) | `linux: 5.10.80 -> 5.10.81`                                                     |
| [`e25e4731`](https://github.com/NixOS/nixpkgs/commit/e25e4731af5b03537128e75fe39b2964d29cf6a1) | `python3Packages.greeclimate: 0.12.5 -> 1.0.0`                                  |
| [`bdae0261`](https://github.com/NixOS/nixpkgs/commit/bdae026114bd0fd2e691e61bfdb1f99dd42b8224) | `thunderbird: 91.3.1 -> 91.3.2`                                                 |
| [`d0cd160c`](https://github.com/NixOS/nixpkgs/commit/d0cd160ca288029250bf82edb8c7ab774d622329) | `nixopsUnstable: Add nixops-digitalocean plugin`                                |
| [`9ae49340`](https://github.com/NixOS/nixpkgs/commit/9ae4934062f8b71f9eb9782025b86a7c347ee3fc) | `nixopsUnstable: Add nixops-hetzner plugin`                                     |
| [`9c1e7250`](https://github.com/NixOS/nixpkgs/commit/9c1e72507b70c847abf2330dcf6e73137d8fccf2) | `nixopsUnstable: Sort plugins`                                                  |
| [`6aabe7f7`](https://github.com/NixOS/nixpkgs/commit/6aabe7f73672f1c002934eb9df7751d703cae843) | `nixopsUnstable: (2.0.0-pre) 2021-11-02 -> 2021-11-18`                          |
| [`01f4c7ec`](https://github.com/NixOS/nixpkgs/commit/01f4c7ec881a0a52638f090aacf51461a20b472f) | `gradle: Decouple gradleGen and JDK`                                            |
| [`7e899fd1`](https://github.com/NixOS/nixpkgs/commit/7e899fd18e39b82ec29db402773bd595a7477b1e) | `thunderbird: reintroduce buildconfig patch to reduce closure size`             |
| [`b7ababb9`](https://github.com/NixOS/nixpkgs/commit/b7ababb9398e7c8b49c50e6520988fe049b5d0a3) | `python3Packages.smbprotocol: 1.8.2 -> 1.8.3`                                   |
| [`5ba86837`](https://github.com/NixOS/nixpkgs/commit/5ba86837095dda9ff8d4cf494990eea1a33ae1c5) | `thunderbird-bin: 91.3.0 -> 91.3.2`                                             |
| [`21b6b5a0`](https://github.com/NixOS/nixpkgs/commit/21b6b5a069a37981bca82683618cce43cf60f213) | `ntfy: Patch Slack integration to work again.`                                  |
| [`090ebba3`](https://github.com/NixOS/nixpkgs/commit/090ebba30fbecde536ed31e3cd989104c28ce0c4) | `nix-universal-prefetch: 0.3.0 -> 0.4.0`                                        |
| [`88120a13`](https://github.com/NixOS/nixpkgs/commit/88120a137726a274905a7fc18c8d01888582384a) | `discourse/update.py: use nix-instantiate`                                      |
| [`5346a90b`](https://github.com/NixOS/nixpkgs/commit/5346a90b83b92adbe2a1356726b7da6e224938a9) | `megapixels: 1.4.0 -> 1.4.2`                                                    |
| [`6e5bd668`](https://github.com/NixOS/nixpkgs/commit/6e5bd6685580ec5be0895e898ff2e7ef3f6d955d) | `python3Packages.graphviz: 0.18 -> 0.18.1`                                      |
| [`a18ceb42`](https://github.com/NixOS/nixpkgs/commit/a18ceb42152e65def0cc6213773be821c1941dd5) | `alloy: add alloy 6`                                                            |
| [`1573e35b`](https://github.com/NixOS/nixpkgs/commit/1573e35ba0cb5b85dac35aa827ed9bad4775dc15) | `python3Packages.natsort: 7.1.1 -> 8.0.0`                                       |
| [`f329d721`](https://github.com/NixOS/nixpkgs/commit/f329d721575dcd0fc4c6a5a00082a4c63b341f46) | `python3Packages.fastnumbers: init at 3.2.1`                                    |