### PR TITLE
chore(flake/home-manager): `c4c761ba` -> `df931a59`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -62,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1637649415,
-        "narHash": "sha256-I82k+kFZuezkWPJypuqhqhChFbzDR4jpn89e2Fm2zRo=",
+        "lastModified": 1637721183,
+        "narHash": "sha256-4CAKKxrt9l0Hbl57Uypo7ol93Ko+5Yn+7xWWCMUyHQ8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c4c761ba554bc674b0d5a89eb7e9f7a488a8859d",
+        "rev": "df931a59a5864d6ff0c5d83598135816f8593647",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                                  |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`df931a59`](https://github.com/nix-community/home-manager/commit/df931a59a5864d6ff0c5d83598135816f8593647) | `taskwarrior: change config file location and use relative theme paths (#2455)` |