### PR TITLE
chore(flake/sops-nix): `b9145d46` -> `87140858`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1637694407,
-        "narHash": "sha256-lPFxflAtnUkMX15d/vGJdaeS4/kn3FcdrcmEABxdhjg=",
+        "lastModified": 1637735079,
+        "narHash": "sha256-VC6FEfYHkNMrCd9+0nATtUQAtkWOrkH4gzwGHNG4TTQ=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "b9145d46f038979cc42fd617abaaca7a2fe2c226",
+        "rev": "871408582627f43d0ecc5e4595dcf20cfe2ee227",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message      |
| ----------------------------------------------------------------------------------------------- | ------------------- |
| [`edb3913e`](https://github.com/Mic92/sops-nix/commit/edb3913e10c2490a4e9e58e62e6649379f1640fe) | `Remove debug text` |