### PR TITLE
chore(flake/home-manager): `df931a59` -> `60937069`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -62,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1637721183,
-        "narHash": "sha256-4CAKKxrt9l0Hbl57Uypo7ol93Ko+5Yn+7xWWCMUyHQ8=",
+        "lastModified": 1637798993,
+        "narHash": "sha256-2YAkyII7djfo66CfFDWMBqxkonQYy8aAEo1bDVvBRb0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "df931a59a5864d6ff0c5d83598135816f8593647",
+        "rev": "609370699f2dc90988f8a6881837c5092484e9c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                             |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`60937069`](https://github.com/nix-community/home-manager/commit/609370699f2dc90988f8a6881837c5092484e9c0) | `home-manager: do not build news when using flake (#2501)` |