### PR TITLE
chore(flake/nixos-hardware): `08cda8e3` -> `aad66afc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -77,11 +77,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1637564544,
-        "narHash": "sha256-wwdjkfdQEbFn+Gr1iBiA5DGgl+Q7PASL83Swo/Wqwy0=",
+        "lastModified": 1637831601,
+        "narHash": "sha256-axRY9AehHGXfU52RK3oqDNXd9F92Tm65vEBQir3tRLI=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "08cda8e3a5a4e685af525e5a589dfeb74267d505",
+        "rev": "aad66afc1cac4a654223f6ba326899c731e57441",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                       |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`eafbea9e`](https://github.com/NixOS/nixos-hardware/commit/eafbea9efd854d969a89e8de9f1ac3597afa068a) | `nanopc-t4: use kernelParams to set tty baud rate`   |
| [`20512410`](https://github.com/NixOS/nixos-hardware/commit/2051241010c87ffda348c97c092a1358753f8ecd) | `g733qs: lates linux only if kernel older than 5.12` |
| [`4161f8ae`](https://github.com/NixOS/nixos-hardware/commit/4161f8aee8c750fb7b0c3605f257877d9e9c42ae) | `Update asus/battery.nix`                            |
| [`a9de5327`](https://github.com/NixOS/nixos-hardware/commit/a9de532758241c1aec78f62ea677ff635c0cb288) | `Update README.md`                                   |
| [`6479f584`](https://github.com/NixOS/nixos-hardware/commit/6479f584f7247f43eba2f37304bcb085f8ae8995) | `Added ROG Strix G733QS`                             |