### PR TITLE
chore(flake/home-manager): `e28185a2` -> `c27c8f49`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -62,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1637805338,
-        "narHash": "sha256-RPbq/YvsLjxEb3NZnZYo+CIaHr/31C7uHbPxFgwOIp8=",
+        "lastModified": 1637825539,
+        "narHash": "sha256-TmSZRsBA59HHv6Dym3ZGm2eZDa2z5EmfyAA5F5tW03Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e28185a2c062e7d77fd2a71678a75ce7a2eeb6fe",
+        "rev": "c27c8f49c0bccaff91f5f637ad727d440b769997",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                         |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`c27c8f49`](https://github.com/nix-community/home-manager/commit/c27c8f49c0bccaff91f5f637ad727d440b769997) | `taskwarrior: clean up news entry`     |
| [`18461b5d`](https://github.com/nix-community/home-manager/commit/18461b5dda5341828d66e5acce6ac2c08ba1be34) | `firefox: fix tests`                   |
| [`81fc0c6f`](https://github.com/nix-community/home-manager/commit/81fc0c6fbfb2a94ee406fac824090e07aaf618de) | `tests: disable Nixpkgs release check` |