### PR TITLE
chore(flake/home-manager): `c27c8f49` -> `579f2e8b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -62,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1637825539,
-        "narHash": "sha256-TmSZRsBA59HHv6Dym3ZGm2eZDa2z5EmfyAA5F5tW03Q=",
+        "lastModified": 1637875789,
+        "narHash": "sha256-kwW26kGhqNsWpTz+prw/pAfqz673GojbxZuB0boc1eM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c27c8f49c0bccaff91f5f637ad727d440b769997",
+        "rev": "579f2e8bebb954a103a96b905c27b10f15ef38c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                   |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`579f2e8b`](https://github.com/nix-community/home-manager/commit/579f2e8bebb954a103a96b905c27b10f15ef38c7) | `Switch to 22.05 as current development release` |
| [`2889ee23`](https://github.com/nix-community/home-manager/commit/2889ee23630d3e54bd20d0b6b45361b67533edc0) | `mpv: temporarily disable tests`                 |
| [`dc2a4e41`](https://github.com/nix-community/home-manager/commit/dc2a4e4146d1626bc6a916cb57c9e12be2399ca3) | `Switch to 21.11 as stable release`              |