### PR TITLE
chore(flake/home-manager): `579f2e8b` -> `a28cf79a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -62,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1637875789,
-        "narHash": "sha256-kwW26kGhqNsWpTz+prw/pAfqz673GojbxZuB0boc1eM=",
+        "lastModified": 1637915295,
+        "narHash": "sha256-jWW2Q83O4O/TV3PDsZkEo0bhKzlLBhJ5CGqQFMM05lE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "579f2e8bebb954a103a96b905c27b10f15ef38c7",
+        "rev": "a28cf79a78040b4e6d8d50a39760a296d5e95dd6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                     |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`a28cf79a`](https://github.com/nix-community/home-manager/commit/a28cf79a78040b4e6d8d50a39760a296d5e95dd6) | `ci: bump cachix/install-nix-action from 15 to 16` |
| [`ea1794a7`](https://github.com/nix-community/home-manager/commit/ea1794a798d60ac10b0354b811aea6fe652914a3) | `gpg: support declarative trust and public keys`   |