### PR TITLE
chore(flake/templates): `c99b52c0` -> `16cd57c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
     },
     "templates": {
       "locked": {
-        "lastModified": 1637326938,
-        "narHash": "sha256-wHqnMeQqyFTTdcsUTThfv42KkCH38wMrIvO+gWfEIAg=",
+        "lastModified": 1637957362,
+        "narHash": "sha256-OfhmLR4Bkaz9CFh/p9Mom6BS0lnFDRJ6F4KofVX6JCU=",
         "owner": "NixOS",
         "repo": "templates",
-        "rev": "c99b52c0c8be1fb6cdb1f484d42c32993217925d",
+        "rev": "16cd57c9c3f037eddddb57f87b65350ec59ed4f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message                   |
| ------------------------------------------------------------------------------------------------ | -------------------------------- |
| [`88a14a42`](https://github.com/NixOS/templates/commit/88a14a42a2342860158566449f2add783294d5a7) | `templates/rust: fix mkApp call` |