### PR TITLE
chore(flake/nixpkgs): `27abb57b` -> `fc9ee3bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1637914536,
-        "narHash": "sha256-tIFRbGtRy3ODL0SBW7HRAIehBGJN6TVitPllADL5mGo=",
+        "lastModified": 1637959987,
+        "narHash": "sha256-slFYQryTmoVXK8YgtYQAwXBDULKPxxcTI6iq5vvNhpI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "27abb57b7fff5c4164de6ec3dd6840177e83a11e",
+        "rev": "fc9ee3bc0b9e6d30f76f4b37084711ae03114e21",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`621f57ba`](https://github.com/NixOS/nixpkgs/commit/621f57ba6fa1efbb1785430c5919235ed67d3972) | `skopeo: 1.5.1 -> 1.5.2`                                           |
| [`f5b1b869`](https://github.com/NixOS/nixpkgs/commit/f5b1b86934eaf00d8a10646e7fd6d3a00de2c8d5) | `python3Packages.netdata: 0.2.1 -> 1.0.1`                          |
| [`c254a6e1`](https://github.com/NixOS/nixpkgs/commit/c254a6e12e2c82efaa03b890ec90e5b8ec009d71) | `factor98: add longDescription`                                    |
| [`72ca633e`](https://github.com/NixOS/nixpkgs/commit/72ca633e488098c42ef20d7e10b28e05150ea9c6) | `factor-lang: quote homepage url`                                  |
| [`732b04ba`](https://github.com/NixOS/nixpkgs/commit/732b04ba42a135409c3592b1e7df3aa6986e98a8) | `httpdirfs: init at 1.2.2 (#147182)`                               |
| [`c2f37f24`](https://github.com/NixOS/nixpkgs/commit/c2f37f240c022b5ed4fff05301bde4ef6f6a92d0) | `nix-plugins: 6.0.0 → 8.0.0.`                                      |
| [`c998b1cc`](https://github.com/NixOS/nixpkgs/commit/c998b1cc7dda9a1c4cb8d0b8518456f382f36564) | `pythonPackages: remove self from aliases`                         |
| [`e041494e`](https://github.com/NixOS/nixpkgs/commit/e041494ee9342b31a3d19483c57db6ec14aadbf1) | `brave: 1.31.91 -> 1.32.113`                                       |
| [`66133a61`](https://github.com/NixOS/nixpkgs/commit/66133a61d5b01e2da752023bb8101b4b52119116) | `rnginline: init at 0.2.0`                                         |
| [`62363f5e`](https://github.com/NixOS/nixpkgs/commit/62363f5e19d3297813fd933a092e304f1bf1b416) | `factorio: 1.1.46 -> 1.1.48`                                       |
| [`38ee5f87`](https://github.com/NixOS/nixpkgs/commit/38ee5f8707743a38898973a5c476107e3c2eb56e) | `go: update URLs`                                                  |
| [`7bec0408`](https://github.com/NixOS/nixpkgs/commit/7bec0408e7b9f9d176a2adbcc8184cdfeb39c617) | `pkgs/pantheon: remove unused `pantheon` from args`                |
| [`61b298c0`](https://github.com/NixOS/nixpkgs/commit/61b298c01f83eb5ca228fe5f024f81d5841ccd53) | `python3Packages.crownstone-sse: relax aiohttp constraint`         |
| [`b645add4`](https://github.com/NixOS/nixpkgs/commit/b645add4d3bf8f1e8949be2e39f24c9d97bb28af) | `python3Packages.aiojobs: 0.3.0 -> 1.0.0`                          |
| [`d2a02535`](https://github.com/NixOS/nixpkgs/commit/d2a0253504e9c60fbdd1a94c7c6973b158a6e8ff) | `python3Packages.types-setuptools: 57.4.3 -> 57.4.4`               |
| [`080ca052`](https://github.com/NixOS/nixpkgs/commit/080ca0520c395e67ad8c6f34a3b02f1cd597ddc1) | `python3Packages.types-requests: 2.26.0 -> 2.26.1`                 |
| [`38972db5`](https://github.com/NixOS/nixpkgs/commit/38972db50b39471ee6dc68bf6bd0b8ff3bfd4eab) | `python3Packages.pypoolstation: 0.4.0 -> 0.4.1`                    |
| [`5bf7fe52`](https://github.com/NixOS/nixpkgs/commit/5bf7fe5281dc890c105509e6fefbbce440f28d87) | `python3Packages.aiocoap: 0.4.1 -> 0.4.3`                          |
| [`91d9032d`](https://github.com/NixOS/nixpkgs/commit/91d9032d21b6045fad3123e6600172082c0eaff7) | `python3Packages.aiopvapi: patch support for async_timeout>4`      |
| [`8608d393`](https://github.com/NixOS/nixpkgs/commit/8608d393e87a33d8ebc95f76f4c5fa03467d096e) | `nix-bash-completions: Reduce priority for Nix 2.4`                |
| [`8e92630a`](https://github.com/NixOS/nixpkgs/commit/8e92630aae97864975761be92976ac0801954f3f) | `nixos: Provide nix-bash-completions again for stable commands`    |
| [`88901739`](https://github.com/NixOS/nixpkgs/commit/88901739d409c2486c811d6ce085527ad66c2605) | `checkov: 2.0.603 -> 2.0.605`                                      |
| [`e0f16829`](https://github.com/NixOS/nixpkgs/commit/e0f16829100916fe3fc3f931190f4d06ab64a1cd) | `nixos/installer: Quote variable references`                       |
| [`c9a73859`](https://github.com/NixOS/nixpkgs/commit/c9a7385997ef1385d13fe845be4e48960b939268) | `nixos/installer: Use `-n` instead of `! -z``                      |
| [`adb8f5c8`](https://github.com/NixOS/nixpkgs/commit/adb8f5c858665d4e7f5cc85dc99d25c8b3395bf9) | `nixos/installer: Mark scripts as Bash for ShellCheck`             |
| [`ebe33362`](https://github.com/NixOS/nixpkgs/commit/ebe33362a84dcbec201500088c1ccfccb65e89cb) | `parquet-tools: fix tests for arrow-cpp 6.0.1`                     |
| [`e3e77ee8`](https://github.com/NixOS/nixpkgs/commit/e3e77ee8a4c116d781273d0b189eaf24046ea4f0) | `arrow-cpp: build without jemalloc on aarch64-darwin to fix build` |
| [`9fff252d`](https://github.com/NixOS/nixpkgs/commit/9fff252dcf573a265bcdac81cfa482fa0b862a7b) | `python3Packages.pyarrow: fix sandboxed build on darwin`           |
| [`c5a0962d`](https://github.com/NixOS/nixpkgs/commit/c5a0962ddd85dd6ed1794c64f79ba2ba92b1bab0) | `arrow-cpp: fix sandboxed build on darwin`                         |
| [`38a950b3`](https://github.com/NixOS/nixpkgs/commit/38a950b37746a3772e60fff2207c14646d69479b) | `ddnet: 15.6.2 -> 15.7`                                            |
| [`eb2107cd`](https://github.com/NixOS/nixpkgs/commit/eb2107cd07460173e5517a3c070412c472aaab65) | `nushell: 0.39.0 -> 0.40.0`                                        |
| [`dc523cbb`](https://github.com/NixOS/nixpkgs/commit/dc523cbb801fc4fd3143750e3e34b1ea040715ae) | `ocaml: heed hardeningDisable flags set for individual versions`   |
| [`3664cbde`](https://github.com/NixOS/nixpkgs/commit/3664cbde798a7861c770ecbf65953962d62b67e6) | `wlr-protocols: init at unstable-2021-11-01`                       |
| [`35f13295`](https://github.com/NixOS/nixpkgs/commit/35f13295c40b8a8e51d8980c6f8ae17bb1855c83) | `libxklavier: support cross-compilation`                           |
| [`f7963ac1`](https://github.com/NixOS/nixpkgs/commit/f7963ac1e95d053b10aa2a77a61b21bc76150c00) | `libdeltachat: 1.66.0 -> 1.67.0`                                   |
| [`1bf1adbf`](https://github.com/NixOS/nixpkgs/commit/1bf1adbf0b04cdb546a6a4b9779668013efaf447) | `xob: 0.2 -> 0.3`                                                  |
| [`31fdf8b7`](https://github.com/NixOS/nixpkgs/commit/31fdf8b75e8fb9b5593644405d650d0ad8341a6f) | `varnish60: 6.0.8 -> 6.0.9`                                        |
| [`d9823c39`](https://github.com/NixOS/nixpkgs/commit/d9823c39ce1a0730c633b62c2cd2f96163158985) | `python2Packages.keyring: drop`                                    |
| [`edc83a9b`](https://github.com/NixOS/nixpkgs/commit/edc83a9bf0544787d25efd0964734503d5f179bf) | `stretchly: 1.7.0 -> 1.8.1`                                        |
| [`b0cf6d2d`](https://github.com/NixOS/nixpkgs/commit/b0cf6d2d041da1028dde2965bbb938e6d35e70e4) | `google-cloud-sdk: 365.0.0 -> 365.0.1`                             |
| [`077ba7f0`](https://github.com/NixOS/nixpkgs/commit/077ba7f0dd992c0648cf595ffa9c5a61dfae85e9) | `cagebreak: 1.8.0 -> 1.8.1`                                        |
| [`333b9792`](https://github.com/NixOS/nixpkgs/commit/333b97926ec9bb157f25be243961dcb18f50c116) | `linuxKernel.kernels.linux_xanmod: 5.15.2 -> 5.15.4`               |
| [`40202db7`](https://github.com/NixOS/nixpkgs/commit/40202db729185532328b0663829c862e7c5745e8) | `aws-sam-cli: 1.35.0 -> 1.36.0`                                    |
| [`71249a87`](https://github.com/NixOS/nixpkgs/commit/71249a8745f9f60c97c15b20041902bca12559e7) | `aws-sam-translator: 1.40.0 -> 1.42.0`                             |
| [`0d0763c9`](https://github.com/NixOS/nixpkgs/commit/0d0763c9518d9d39859475f824518a644ef9e573) | `factorio-experimental: 1.1.45 -> 1.1.48`                          |
| [`92c45083`](https://github.com/NixOS/nixpkgs/commit/92c45083e54fa06c1c54de593e4df83100e80e01) | `arrow-cpp: 6.0.0 -> 6.0.1`                                        |
| [`906e2351`](https://github.com/NixOS/nixpkgs/commit/906e23510728b4ca4a6e02b597b306166379e9b8) | `unit: 1.25.0 -> 1.26.0`                                           |
| [`d31a6f10`](https://github.com/NixOS/nixpkgs/commit/d31a6f10425240bba0673edbfd346e965f55d625) | `android-studio-beta: 2021.1.1.16 → 2021.1.1.17`                   |
| [`152633eb`](https://github.com/NixOS/nixpkgs/commit/152633eb60108eefb908d4f9e854443f094b944e) | `libreddit: 0.16.0 -> 0.19.1`                                      |
| [`5d7cfdda`](https://github.com/NixOS/nixpkgs/commit/5d7cfddadcc6e07ec83b6664ae12b723c49f526f) | `internetarchive: 2.1.0 -> 2.2.0`                                  |
| [`b382ed47`](https://github.com/NixOS/nixpkgs/commit/b382ed47fde7a896fd65eeb8cfe19469c1b2b09d) | `perlPackages.DistZilla: shortenPerlShebang on Darwin`             |
| [`cb30fd98`](https://github.com/NixOS/nixpkgs/commit/cb30fd980bdb8b0334fb0a06cea14511bba0d4f3) | `lucene: remove builder.sh`                                        |
| [`c85e2260`](https://github.com/NixOS/nixpkgs/commit/c85e2260e92eb0099f908861a9ffcdbe9fb435bc) | `jdom: remove builder.sh`                                          |
| [`63ea61bc`](https://github.com/NixOS/nixpkgs/commit/63ea61bcf0be615562d7d8f982c005d6c52d6118) | `imagemagick: 7.1.0-15 -> 7.1.0-16`                                |
| [`df1e8f0d`](https://github.com/NixOS/nixpkgs/commit/df1e8f0d11420fff898ebc7cbf4a77f07aa006a9) | `setzer: 0.4.1 -> 0.4.2`                                           |
| [`d3db4bfc`](https://github.com/NixOS/nixpkgs/commit/d3db4bfcb3cfd93a031053809bf3bfc8cf2c07b6) | `zsh-fzf-tab: unstable-2021-08-05 -> unstable-2021-11-12`          |
| [`7be91b05`](https://github.com/NixOS/nixpkgs/commit/7be91b05bb9b01115e07c91fe610f3b1874050c3) | `nodePackages.teck-programmer: fix build`                          |
| [`89063242`](https://github.com/NixOS/nixpkgs/commit/890632420d71cb79b05a1c118f33b0b4e99c45ca) | `linuxPackages.rtl88xxau-aircrack: enable for aarch64-linux`       |
| [`a7861c26`](https://github.com/NixOS/nixpkgs/commit/a7861c26690acff5d0605ffb53f6307bafc54d5a) | `linkchecker: 10.0.0 → 10.0.1`                                     |
| [`bc9ab551`](https://github.com/NixOS/nixpkgs/commit/bc9ab551d4640885f6d619b02df0e22b43167881) | `sweet: 2.0 -> 3.0`                                                |
| [`73fa8819`](https://github.com/NixOS/nixpkgs/commit/73fa88190fc6b631fedadec39d87a8f424ceb886) | `spdx-license-list-data: 3.14 -> 3.15`                             |
| [`1c804036`](https://github.com/NixOS/nixpkgs/commit/1c8040364b2003053809e52609a230f2ffc4ad0c) | `openrct2: 0.3.5 -> 0.3.5.1`                                       |
| [`37b7250f`](https://github.com/NixOS/nixpkgs/commit/37b7250f3e432b305530b1e77381924d6610561a) | `wineStable: 6.0.1 -> 6.0.2`                                       |
| [`23768626`](https://github.com/NixOS/nixpkgs/commit/23768626093fe42de8a7952702027ad9f2781ea8) | `croc: 9.4.2 -> 9.5.0`                                             |
| [`b5703dfc`](https://github.com/NixOS/nixpkgs/commit/b5703dfc4b2a2afd0d2dcb1a29e08fab79cd9f88) | `clockify: init at 2.0.3`                                          |
| [`9b104436`](https://github.com/NixOS/nixpkgs/commit/9b10443637444f3d765fab124be838c9275f5253) | `pidgin-opensteamworks: 1.7 -> 1.7.2`                              |
| [`582ec1d7`](https://github.com/NixOS/nixpkgs/commit/582ec1d7c9a8dd4c8ba6f9950f0ea90f3b518ef2) | `ffmpeg: switch to built-in RTMP implementation`                   |