### PR TITLE
chore(flake/nixpkgs): `fc9ee3bc` -> `d920e9a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1637959987,
-        "narHash": "sha256-slFYQryTmoVXK8YgtYQAwXBDULKPxxcTI6iq5vvNhpI=",
+        "lastModified": 1638001932,
+        "narHash": "sha256-B2Hvq9lCw07ZtgmjlSyxuLFS7vszPS/yawRM5POENTA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fc9ee3bc0b9e6d30f76f4b37084711ae03114e21",
+        "rev": "d920e9a8c59b302ce0e0cbb0d27103bcbbdfb950",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                   |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`f104c143`](https://github.com/NixOS/nixpkgs/commit/f104c1434bb9458da9b49c0c9a7066c8e3d967c3) | `tinyscheme: add aarch64-darwin to badplatforms`                 |
| [`70307e16`](https://github.com/NixOS/nixpkgs/commit/70307e16745959c52fc6889ae546f1e4887e16ee) | `lima: 0.7.3 -> 0.7.4`                                           |
| [`8959f7b2`](https://github.com/NixOS/nixpkgs/commit/8959f7b2110972fce5f5025517399f7297dad040) | `python3Packages.flake8-polyfill: disable failing tests`         |
| [`82e26e09`](https://github.com/NixOS/nixpkgs/commit/82e26e0974a5541d3592cc446ee2d300c0291791) | `python3Packages.pylint-django: disable failing tests`           |
| [`d08d54ce`](https://github.com/NixOS/nixpkgs/commit/d08d54ced891825f0f42845c4d5bbffc3281f66a) | `python3Packages.pep8-naming: add patch to fix tests`            |
| [`f6d5c5fe`](https://github.com/NixOS/nixpkgs/commit/f6d5c5fe01bf57a9ac82946bdd9250b6cab1e136) | `shfmt: 3.4.0 -> 3.4.1`                                          |
| [`e71b01a8`](https://github.com/NixOS/nixpkgs/commit/e71b01a8fc34a2c3e3b67d354cb991c4ee9095cb) | `python3Packages.py17track: relax async_timeout constraint`      |
| [`bf730c8e`](https://github.com/NixOS/nixpkgs/commit/bf730c8e2f53e3dcd40e6a19f105cd16594832e5) | `tsung: use Python 3`                                            |
| [`6116670d`](https://github.com/NixOS/nixpkgs/commit/6116670dcb9b7d57a30acc29fe81774066af253b) | `fd: 8.2.1 -> 8.3.0`                                             |
| [`7287bf05`](https://github.com/NixOS/nixpkgs/commit/7287bf05aa441bba567cb2a98dc1987f2b8e79e0) | `openmpi: 4.1.1 -> 4.1.2`                                        |
| [`85585e9d`](https://github.com/NixOS/nixpkgs/commit/85585e9d13c9e729ecb453b26bc2426aaab17aed) | `python3Packages.potentials: add missing dependencies`           |
| [`ab211d13`](https://github.com/NixOS/nixpkgs/commit/ab211d1343bf083c21b8929098187fd865ee3409) | `python3Packages.frigidaire: 0.17 -> 0.18.3`                     |
| [`65f8d1a0`](https://github.com/NixOS/nixpkgs/commit/65f8d1a0590e8b2a983c3cff332f7049ef533658) | `tfsec: 0.60.1 -> 0.61.0`                                        |
| [`d07a9427`](https://github.com/NixOS/nixpkgs/commit/d07a9427f4303fda1a5229611391fc401e99d182) | `python3Packages.wiffi: 1.0.1 -> 1.1.0`                          |
| [`e0db47bd`](https://github.com/NixOS/nixpkgs/commit/e0db47bd82980bd66276541111ac0a50e4609efb) | `ghidra: 10.0 -> 10.0.4`                                         |
| [`257e9225`](https://github.com/NixOS/nixpkgs/commit/257e92258e0da135e560d1c36f366e9ceb932378) | `modules/nix-daemon: Add missing mk(Rename|Removed)OptionModule` |
| [`22b72c17`](https://github.com/NixOS/nixpkgs/commit/22b72c17bb0c48d6eabb2d6988040341cdce70d1) | `gnuradio3_8packages.ais: fix build`                             |
| [`30e9e7be`](https://github.com/NixOS/nixpkgs/commit/30e9e7bea5cf264c95d8d1d9d8ff53b82239e73c) | `ardour: Enable video support by default`                        |
| [`a165f9ea`](https://github.com/NixOS/nixpkgs/commit/a165f9ea9a920f26b4696f3f3e89723062131f86) | `cloud-nuke: 0.5.1 -> 0.7.1`                                     |
| [`eec0eac7`](https://github.com/NixOS/nixpkgs/commit/eec0eac7df5e02115bd3c7203087146dd2960998) | `cascadia-code: 2108.26 -> 2110.31`                              |
| [`8d2ac9de`](https://github.com/NixOS/nixpkgs/commit/8d2ac9de9bbd106b0367b0413ba9215dc7c644c7) | `libfyaml: 0.7.2 -> 0.7.3`                                       |
| [`e40ebf0b`](https://github.com/NixOS/nixpkgs/commit/e40ebf0bf7e7314649928f219ae78e2a5585b656) | `fluent-bit: use upstream patches`                               |
| [`4dd8a61b`](https://github.com/NixOS/nixpkgs/commit/4dd8a61b51f8d159e33e129ba5e6c7303bfb021f) | `boringssl: add the "dev" output to match openssl`               |