### PR TITLE
chore(flake/nixpkgs): `d920e9a8` -> `16eb0035`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1638001932,
-        "narHash": "sha256-B2Hvq9lCw07ZtgmjlSyxuLFS7vszPS/yawRM5POENTA=",
+        "lastModified": 1638045166,
+        "narHash": "sha256-HguPozGbLldZ9BBQbD02S+LkgLkB2szsAyCf22Wx0Cs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d920e9a8c59b302ce0e0cbb0d27103bcbbdfb950",
+        "rev": "16eb003524804f7c6d6f522a238e8ab2557eedf9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`dcb941f3`](https://github.com/NixOS/nixpkgs/commit/dcb941f3ede938c01b82ea6be4aa148eb479a413) | `security/pam: Document test location`                                                     |
| [`3b2e6e72`](https://github.com/NixOS/nixpkgs/commit/3b2e6e72faff6255230b17991eb545824b00630f) | `tests: Move all PAM tests into a separate directory`                                      |
| [`1cfecb63`](https://github.com/NixOS/nixpkgs/commit/1cfecb636b14a88174d914cd0522b78ff3bf9f82) | `Revert "Merge pull request #141192 from helsinki-systems/feat/improved-socket-handling2"` |
| [`d20dc696`](https://github.com/NixOS/nixpkgs/commit/d20dc696648e8c389150fb104043cf21b1c75bd8) | `residualvm: remove`                                                                       |
| [`73b3f81d`](https://github.com/NixOS/nixpkgs/commit/73b3f81d96f266d4acab6bf96a77e5f68558d1cf) | `zydis: add myself as maintainer`                                                          |
| [`b8fceba8`](https://github.com/NixOS/nixpkgs/commit/b8fceba81305d0cf3a36e8fbc91e34f363ee8c60) | `python3Packages.md-toc: relax fpyutils constraint`                                        |
| [`d5d4aa22`](https://github.com/NixOS/nixpkgs/commit/d5d4aa223705a26ad600dfe9c0702c33346182c0) | `python3Packages.boschshcpy: 0.2.23 -> 0.2.24`                                             |
| [`4982ca6e`](https://github.com/NixOS/nixpkgs/commit/4982ca6e67ee2083589e5cafb45cb0efa173d955) | `tut: 0.0.36 -> 0.0.41`                                                                    |
| [`90be2bed`](https://github.com/NixOS/nixpkgs/commit/90be2bed3905b147f0ac8822c20ecd75c34ce570) | `metasploit: 6.1.15 -> 6.1.16`                                                             |
| [`6daa24a1`](https://github.com/NixOS/nixpkgs/commit/6daa24a1c7059e7a940e164320419ca1fea82315) | `python3Packages.fpyutils: 2.0.1 -> 2.1.0`                                                 |
| [`6d808dfb`](https://github.com/NixOS/nixpkgs/commit/6d808dfbaec8d1ad324a6fbc650cb43aa4b134ff) | `python3Packages.aiopulse: 0.4.2 -> 0.4.3`                                                 |
| [`7ae23b2f`](https://github.com/NixOS/nixpkgs/commit/7ae23b2ffc159bcc295c62ba89c89a1db94d39cc) | `gdu: 5.10.1 -> 5.11.0`                                                                    |
| [`ed3cfc8a`](https://github.com/NixOS/nixpkgs/commit/ed3cfc8abe467110ded21593f8695ebb3e392087) | `invidious/lsquic: fix build`                                                              |
| [`f9da65f6`](https://github.com/NixOS/nixpkgs/commit/f9da65f6703b982c2c4710804186431fb1b147e7) | `python39Packages.guessit: 3.3.1 -> 3.4.3`                                                 |
| [`7944324d`](https://github.com/NixOS/nixpkgs/commit/7944324d80d50bdfa7649598db6a06f0620cd9bb) | `programmer-calculator: 2.1 -> 2.2`                                                        |
| [`595543a3`](https://github.com/NixOS/nixpkgs/commit/595543a3149b64a809da8fb4fdabbd6800d29ad4) | `tests: Verify /etc/pam.d/chfn file contents`                                              |
| [`0dd351d4`](https://github.com/NixOS/nixpkgs/commit/0dd351d423a56e796e2ed758364f112c39c896de) | `trezor-suite: 21.10.2 -> 21.11.2`                                                         |
| [`ee74e654`](https://github.com/NixOS/nixpkgs/commit/ee74e6547d318cea196eefe497cf78fb6339ca8e) | `electron_16: 16.0.1 -> 16.0.2`                                                            |
| [`51ab665a`](https://github.com/NixOS/nixpkgs/commit/51ab665ad7d29ace29dd1b3702fa2a44d48e4e56) | `zydis: 3.2.0 -> 3.2.1`                                                                    |
| [`c86da07d`](https://github.com/NixOS/nixpkgs/commit/c86da07d5df5f26bfefd1fb0442b668ec46916d6) | `teapot: init at 2.3.0`                                                                    |
| [`3234331b`](https://github.com/NixOS/nixpkgs/commit/3234331b20576f81e54217f50a21081ed421ef0a) | `arcan.pipeworld: 0.pre+unstable=2021-08-01 -> 0.pre+date=2021-11-26`                      |
| [`b144d5bd`](https://github.com/NixOS/nixpkgs/commit/b144d5bd6a9f753b7efc4dee8f2592c3249ef26e) | `arcan.durden: 0.6.1+unstable=2021-10-15 -> 0.6.1+date=2021-10-17`                         |
| [`6cd2dba1`](https://github.com/NixOS/nixpkgs/commit/6cd2dba1d1e1f774dcbff0043a0fe8001d495a81) | `arcan.arcan: 0.6.1pre1+unstable=2021-10-16 -> 0.6.1`                                      |
| [`dbcd65e5`](https://github.com/NixOS/nixpkgs/commit/dbcd65e54ac0908788047b82220cd94fedeabf3b) | `python3Packages.tololib: init at 0.1.0b3`                                                 |
| [`8febc767`](https://github.com/NixOS/nixpkgs/commit/8febc76765194df3eab94d756b182a65d2faad40) | `czkawka: 3.3.0 -> 3.3.1`                                                                  |
| [`c9fe608a`](https://github.com/NixOS/nixpkgs/commit/c9fe608abda6af4d91bb6223b7686a2882e4eb5d) | `python3Packages.google-nest-sdm: 0.3.9 -> 0.4.0`                                          |
| [`717ddc6c`](https://github.com/NixOS/nixpkgs/commit/717ddc6c38c60cce70088920f1f8785fafa50ffe) | `home-assistant: enable nest tests`                                                        |
| [`7afd674b`](https://github.com/NixOS/nixpkgs/commit/7afd674bfa4d8459728915d06d0388d4379e6316) | `home-assistant: update component-packages`                                                |
| [`96901a01`](https://github.com/NixOS/nixpkgs/commit/96901a019cca4fa512f33e4017da87e48881d284) | `python3Packages.google-nest-sdm: init 0.3.9`                                              |
| [`2be1adac`](https://github.com/NixOS/nixpkgs/commit/2be1adac5740debd251da5a35608a8b5b9054642) | `python3Packages.python-google-nest: init at 5.1.1`                                        |