### PR TITLE
chore(flake/home-manager): `a28cf79a` -> `3ec7f6fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -62,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1637915295,
-        "narHash": "sha256-jWW2Q83O4O/TV3PDsZkEo0bhKzlLBhJ5CGqQFMM05lE=",
+        "lastModified": 1638130066,
+        "narHash": "sha256-BdrVURx4wUUagLbXJXnJ816Xl2IicDp12Sw6OKZn4ug=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a28cf79a78040b4e6d8d50a39760a296d5e95dd6",
+        "rev": "3ec7f6fb43ff77cff429aba1a2541d28cc44d37c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`3ec7f6fb`](https://github.com/nix-community/home-manager/commit/3ec7f6fb43ff77cff429aba1a2541d28cc44d37c) | `rofi: fix theme definition in configuration for 1.7.0+ (#2513)` |