### PR TITLE
chore(flake/sops-nix): `87140858` -> `c4ab0098`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1637735079,
-        "narHash": "sha256-VC6FEfYHkNMrCd9+0nATtUQAtkWOrkH4gzwGHNG4TTQ=",
+        "lastModified": 1638178525,
+        "narHash": "sha256-dRj6E/rptjSX6/B1/zO6mj+ElT9CtIOQdc1h3i7NBFs=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "871408582627f43d0ecc5e4595dcf20cfe2ee227",
+        "rev": "c4ab009857a937c6789f41bf21e3b74b89ae761b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                              |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`23259ded`](https://github.com/Mic92/sops-nix/commit/23259ded2c35d6af2784fa510db1b75091fc8fc5) | `Remove restart logic from README and test` |
| [`a23a21c6`](https://github.com/Mic92/sops-nix/commit/a23a21c6f2789b646078e371db05ad121985aa60) | `migrate to gitlab ci`                      |
| [`cbae163e`](https://github.com/Mic92/sops-nix/commit/cbae163e6cfa8fb5b70e80d01a318ff2f89d887f) | `update flakes`                             |