### PR TITLE
chore(flake/nixos-hardware): `aad66afc` -> `6b3f79de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -77,11 +77,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1637831601,
-        "narHash": "sha256-axRY9AehHGXfU52RK3oqDNXd9F92Tm65vEBQir3tRLI=",
+        "lastModified": 1638182287,
+        "narHash": "sha256-vBzf+hbTJz2ZdXV/DWirl6wOO7tjdqzTIU+0FANt65U=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "aad66afc1cac4a654223f6ba326899c731e57441",
+        "rev": "6b3f79de09c3de7c91ab51e55e87879f61b6faec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                |
| ----------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`6b3f79de`](https://github.com/NixOS/nixos-hardware/commit/6b3f79de09c3de7c91ab51e55e87879f61b6faec) | `Add Intel NUC 8i7BEH (#343)` |