### PR TITLE
chore(flake/sops-nix): `c4ab0098` -> `0e0dcc74`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1638178525,
-        "narHash": "sha256-dRj6E/rptjSX6/B1/zO6mj+ElT9CtIOQdc1h3i7NBFs=",
+        "lastModified": 1638188662,
+        "narHash": "sha256-heLEbhH3W3GrtYDwacghCiO3g94QkJLW0LhErMWbT2g=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c4ab009857a937c6789f41bf21e3b74b89ae761b",
+        "rev": "0e0dcc74bae23c7ef7fb6251c43c277b827e8c34",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                          | Commit Message                                      |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`8677dd69`](https://github.com/Mic92/sops-nix/commit/8677dd6909fbc984712de2bbc42a96a8352ce9cc) | `Replace separator for nested keys for consistency` |