### PR TITLE
chore(flake/nixpkgs): `33ef578c` -> `c1ab62e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1638220705,
-        "narHash": "sha256-HpRLe61ZysTcZcZUB6ZLyBZGQ5e+/NgGKvTE6sDGqaI=",
+        "lastModified": 1638307101,
+        "narHash": "sha256-87SP7ereiFVs5qRd3gaMANUAf9FX/FwQNGfn7YNA5fg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "33ef578c3d4931c73db0f546d9e84fa2ec1fa65d",
+        "rev": "c1ab62e75514ac25526e8a46ffd154bbaedef330",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                          |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`1923c51c`](https://github.com/NixOS/nixpkgs/commit/1923c51c0ae99671ba5af07c25c77996fd46a49a) | `cdesktopenv: fix build on upcoming binutils-2.36 (#146750)`                            |
| [`efd9bd36`](https://github.com/NixOS/nixpkgs/commit/efd9bd36672e8115eeb7011c0e1fb56bb6622031) | `lifeograph: init at 2.0.2`                                                             |
| [`1b6daffd`](https://github.com/NixOS/nixpkgs/commit/1b6daffd8494af0ed1504370cb7f541fd93bb7cd) | `matrix-synapse: 1.47.1 -> 1.48.0`                                                      |
| [`29d1f6e1`](https://github.com/NixOS/nixpkgs/commit/29d1f6e1f625d246dcf84a78ef97b4da3cafc6ea) | `direnv: 2.28.0 -> 2.29.0 (#147956)`                                                    |
| [`dad4fddd`](https://github.com/NixOS/nixpkgs/commit/dad4fddd52923d90c5ad981d5e29963e829de3c1) | `nixos/nvidia: check modesetting for gdm-wayland only when gdm is enabled`              |
| [`67004944`](https://github.com/NixOS/nixpkgs/commit/6700494410b7cf9c24d2a1515fb7731d9ff21249) | `babashka: 0.6.5 -> 0.6.7`                                                              |
| [`1143032d`](https://github.com/NixOS/nixpkgs/commit/1143032da0c331dae5f24f29a51b9a0d83894277) | `solanum: unstable-2021-04-27 -> unstable-2021-11-14`                                   |
| [`86bc7865`](https://github.com/NixOS/nixpkgs/commit/86bc7865897ba69e54c394ffb86f541af8919dea) | `ledger-live-desktop: 2.35.1 -> 2.35.2`                                                 |
| [`de6181dc`](https://github.com/NixOS/nixpkgs/commit/de6181dc51d9606848becf5cc469fbb7225cae70) | `nixos/acme: fix typo in docs`                                                          |
| [`da8dfd51`](https://github.com/NixOS/nixpkgs/commit/da8dfd5128d9ba847b48ea21fbf4da7a313cfb34) | `python3Packages.pyarrow: enable flight module`                                         |
| [`442468f4`](https://github.com/NixOS/nixpkgs/commit/442468f4ade3b315e1c9e092536109a79f600d9b) | `python3Packages.pyarrow: enable dataset module`                                        |
| [`af180d55`](https://github.com/NixOS/nixpkgs/commit/af180d554b5a81878cd030f65a470f56116c7566) | `qemu, runInLinuxVM: change default cpu to qemu64`                                      |
| [`08bbd123`](https://github.com/NixOS/nixpkgs/commit/08bbd123d562fb13d031cdd955dbe21097a6e9c0) | `qemu: emit warnings when KVM acceleration is not usable`                               |
| [`5d06f693`](https://github.com/NixOS/nixpkgs/commit/5d06f6933d5373f9f4c4ea63d03029869855f876) | `qemu, runInLinuxVM: fix KVM availability check`                                        |
| [`87aed70b`](https://github.com/NixOS/nixpkgs/commit/87aed70b18c88598f7f27d79e0e53f673a7e5094) | `warzone2100: 4.2.2 -> 4.2.3`                                                           |
| [`716815ce`](https://github.com/NixOS/nixpkgs/commit/716815ce2a1fcb135843c7441648a59d62fb6eb6) | `re2: enable parallel builds (#147991)`                                                 |
| [`62df7285`](https://github.com/NixOS/nixpkgs/commit/62df72857c2987a270e0bdb7c6f2738f56132e4a) | `pythonPackages.requests-toolbelt: disable time-dependant tests`                        |
| [`eab0561e`](https://github.com/NixOS/nixpkgs/commit/eab0561eb02a240c9ce7797b2be4119a167e3194) | `singularity: 3.8.4 -> 3.8.5`                                                           |
| [`9d3d02f9`](https://github.com/NixOS/nixpkgs/commit/9d3d02f9c1272f1845bcd3295a22f4a3acb6326a) | `screen: disable parallel build (#147990)`                                              |
| [`a0683eed`](https://github.com/NixOS/nixpkgs/commit/a0683eed686936a99810f2b0b215485f37e8664b) | `python3Packages.ipympl: 0.8.0 -> 0.8.2`                                                |
| [`0a989ec7`](https://github.com/NixOS/nixpkgs/commit/0a989ec7caa63aabd47b4aff5aecd5a754cd6cea) | `pantheon.elementary-files: drop filechooser-portal-hardcode-gsettings-for-nixos.patch` |
| [`3c92df54`](https://github.com/NixOS/nixpkgs/commit/3c92df54cc3135abc77195424f9745028aefbc24) | `protoc-gen-twirp: 8.1.0 -> 8.1.1`                                                      |
| [`bc3eea0c`](https://github.com/NixOS/nixpkgs/commit/bc3eea0c68d0be91f7491d22df63f2665ec3e1dc) | `chezmoi: 2.7.4 -> 2.9.0`                                                               |
| [`af21d412`](https://github.com/NixOS/nixpkgs/commit/af21d41260846fb9c9840a75e310e56dfe97d6a3) | `.github/PULL_REQUEST_TEMPLATE.md, CONTRIBUTING.md: 21.11 -> 22.05 (#147977)`           |
| [`d05b6060`](https://github.com/NixOS/nixpkgs/commit/d05b606009fc8e8780ba5223349a789d320167fd) | `opencl-clhpp: 2.0.12 -> 2.0.15`                                                        |
| [`94365b62`](https://github.com/NixOS/nixpkgs/commit/94365b62a84143b1f59d155a761e8409ac4f1b11) | `apkeep: 0.6.0 -> 0.7.0`                                                                |
| [`94d1b0d5`](https://github.com/NixOS/nixpkgs/commit/94d1b0d54154614c17be5e4c9465f05b45cf851d) | `pantheon.elementary-files: 6.0.4 -> 6.1.0`                                             |
| [`4abccb54`](https://github.com/NixOS/nixpkgs/commit/4abccb54668940f1d83c825daab64620a727ebb6) | `nixos/webdav: set uid and gid`                                                         |
| [`ce4ad53e`](https://github.com/NixOS/nixpkgs/commit/ce4ad53e6a985ba9d35462d4734014223fa79758) | `nixos/webdav-server-rs: init`                                                          |
| [`34ec1a38`](https://github.com/NixOS/nixpkgs/commit/34ec1a380a6897ffe631aabe0612c367a5bb3727) | `webdav-server-rs: init at unstable-2021-08-16`                                         |
| [`c60adb94`](https://github.com/NixOS/nixpkgs/commit/c60adb947e363a915e057244cfd1c2d61fa22d9a) | `kuma: init at 1.4.0`                                                                   |
| [`2253021b`](https://github.com/NixOS/nixpkgs/commit/2253021b7e911016509bae8ad922f9b8db1d27ac) | `alfaview: init at 8.32.0`                                                              |
| [`c19234d0`](https://github.com/NixOS/nixpkgs/commit/c19234d0dff963a1d49628f648db3d618e8a9c29) | `nixos/tests/installer: increase /boot sizes to 100MB`                                  |
| [`b1faa37c`](https://github.com/NixOS/nixpkgs/commit/b1faa37cdf91a5c06b3eccd2611dc8faa7e6e6ec) | `21.11 Release Notes: fix typos`                                                        |
| [`af92f1c0`](https://github.com/NixOS/nixpkgs/commit/af92f1c0cc2d83361771f7b3f6612219ffca5b3c) | `[21.11] update README.md`                                                              |
| [`6f968f15`](https://github.com/NixOS/nixpkgs/commit/6f968f15727cbf39adbb0d60623f2c11f56eab6b) | `python3Packages.ignite: remove optional pynvml dependency`                             |
| [`34fa1ffb`](https://github.com/NixOS/nixpkgs/commit/34fa1ffbe4140d501bb8d8bfdee5afdf55d50d10) | `Revert ".github/workflows/editorconfig.yml: Don't use GitHub API for PR diff."`        |
| [`4db84ed1`](https://github.com/NixOS/nixpkgs/commit/4db84ed126a16e226c5f1a3f13c7bee92fa0a3a4) | `.github/workflows/editorconfig.yml: Don't use GitHub API for PR diff.`                 |
| [`fa6ad743`](https://github.com/NixOS/nixpkgs/commit/fa6ad743e97e9955fce97ca9bb346d13a3e1f9bd) | `zellij: 0.20.1 -> 0.21.0`                                                              |
| [`eefac98f`](https://github.com/NixOS/nixpkgs/commit/eefac98f1a0e3363a57288703fa1961ea554d13e) | `python3Packages.pyvex: fix build for aarch64-linux`                                    |
| [`1191cd58`](https://github.com/NixOS/nixpkgs/commit/1191cd58ba5e7b4394e60868029dc114e8dc7de1) | `viking: 1.9 → 1.10`                                                                    |
| [`f30f9c8a`](https://github.com/NixOS/nixpkgs/commit/f30f9c8aa8b4f1a128d08692fe9edbf81079b884) | `frogatto-data: 2020-12-17 -> 2021-11-29`                                               |
| [`cd959d22`](https://github.com/NixOS/nixpkgs/commit/cd959d22517bebb1d767a91c758f626e16337536) | `maigret: init at 0.3.1`                                                                |
| [`1f2c1647`](https://github.com/NixOS/nixpkgs/commit/1f2c16475455fb4a83465e152886d400cb211d30) | `python3Packages.xmind: init at 1.2.0`                                                  |
| [`a75207e9`](https://github.com/NixOS/nixpkgs/commit/a75207e966c24b2c5d9a57e9fbea4dcc70f1742e) | `python3Packages.socid-extractor: init at 0.0.22`                                       |
| [`04a499cd`](https://github.com/NixOS/nixpkgs/commit/04a499cdde91c75ccaac3724827b2636c5e4460e) | `Revert "nixos/hidpi: add xserver dpi"`                                                 |
| [`23188a5f`](https://github.com/NixOS/nixpkgs/commit/23188a5f00dfdc2ff17606fcc5b21531f9569fb2) | `python2Packages.jinja2: fix tests`                                                     |
| [`9c7406a1`](https://github.com/NixOS/nixpkgs/commit/9c7406a10fbd5da521ceb357a53a2d9e169abb72) | `vimPlugins.vim-clap: fix cargoSha256`                                                  |
| [`fa83ed46`](https://github.com/NixOS/nixpkgs/commit/fa83ed462a9bb38939d2676403e5cdfa1438d193) | `python3Packages.nilearn: unbreak tests`                                                |
| [`f2ce3748`](https://github.com/NixOS/nixpkgs/commit/f2ce374855a063a17c7940011b28f20ae5079081) | `python3Packages.cppe: fix build with clang`                                            |
| [`e8cc900e`](https://github.com/NixOS/nixpkgs/commit/e8cc900eaec34c2b7399678f0cd47c1b0e36a6ef) | `make-disk-image: Make additionalPaths work with Nix 2.4`                               |
| [`958ceefb`](https://github.com/NixOS/nixpkgs/commit/958ceefb3ed3ddb82c10818731747b901044bfac) | `python3Packages.pydicom: add missing setuptools runtime dependency`                    |
| [`7cbda553`](https://github.com/NixOS/nixpkgs/commit/7cbda5539d48d899d99d9f77cfc0c305d07ef161) | `cppe: fix build with clang`                                                            |
| [`b1308f90`](https://github.com/NixOS/nixpkgs/commit/b1308f90793ed57f35c43b880948b6a59f5d38f7) | `telescope: 0.5.2 → 0.6.1`                                                              |
| [`8cbd56b6`](https://github.com/NixOS/nixpkgs/commit/8cbd56b6718d8d6562c7f74a9facabc2d125e5e5) | `cinnamon.*: apply nixpkgs-fmt`                                                         |
| [`4d3ed16d`](https://github.com/NixOS/nixpkgs/commit/4d3ed16dd8182d647abb7735912bdf61088aa2b9) | `fira-code: 5.2 → 6`                                                                    |
| [`26f82bce`](https://github.com/NixOS/nixpkgs/commit/26f82bcea78203ed32a185f388c54637221b905c) | `legendary-gl: 0.20.10 -> 0.20.18`                                                      |
| [`640e54cd`](https://github.com/NixOS/nixpkgs/commit/640e54cda9166b43e2b53f876dee8145834b0765) | `maintainers: Rename pengmeiyu to pmy`                                                  |
| [`89dd3384`](https://github.com/NixOS/nixpkgs/commit/89dd3384d1e011916130961c6499f1f90ad3d8a2) | `ngtcp2: init at unstable-2021-11-10`                                                   |
| [`955e944d`](https://github.com/NixOS/nixpkgs/commit/955e944d95cfc34ffe941afebdd2894f7641b13d) | `nghttp3: init at unstable-2021-11-10`                                                  |
| [`4aa1a4d8`](https://github.com/NixOS/nixpkgs/commit/4aa1a4d8a220cd937fab8eeb16d4fa9b82a030b3) | `quictls: init at v3.0.0+quic_unstable-2021-11-02`                                      |
| [`cecf41f5`](https://github.com/NixOS/nixpkgs/commit/cecf41f57156a6e613ff2d873bc55ff5d50a42fe) | `python3Packages.autoit-ripper: 1.0.1 -> 1.1.0`                                         |
| [`43f1a2e5`](https://github.com/NixOS/nixpkgs/commit/43f1a2e59f48cd59a9d31aa98c450696bd08eb6d) | `got: 0.60 -> 0.64`                                                                     |
| [`05d3fb59`](https://github.com/NixOS/nixpkgs/commit/05d3fb59a34699b4bbe31be3c0547b1fc7dfb2dd) | `bore: 0.3.3 -> 0.4.1`                                                                  |
| [`3e894f67`](https://github.com/NixOS/nixpkgs/commit/3e894f67fe87c887cf4ff44110603a0437c6a639) | `gptfdisk: fix build against upcoming ncurses-6.3`                                      |
| [`a94a2370`](https://github.com/NixOS/nixpkgs/commit/a94a2370bb1831dc212e8567bd3e273fd0b5be7f) | `noice: fix build against ncurses-6.3`                                                  |
| [`730fc9ca`](https://github.com/NixOS/nixpkgs/commit/730fc9cae014027254c3ff78bcf8b03dd28296bc) | `bakelite: init at unstable-2021-10-19`                                                 |
| [`18f8296f`](https://github.com/NixOS/nixpkgs/commit/18f8296fb9d11cbd6f788f5d8576cae54cb00e37) | `cdrkit: fix -fno-common build`                                                         |
| [`56cd5ac4`](https://github.com/NixOS/nixpkgs/commit/56cd5ac4db773ddfdd833ca34844927efdcaf3d3) | `vcs: substitute standalone getopt outside of linux`                                    |
| [`9c431b85`](https://github.com/NixOS/nixpkgs/commit/9c431b8569e0c046b1a1709dfae04dabbca2ef8e) | `vowpalwabbit: fix build`                                                               |
| [`f028a519`](https://github.com/NixOS/nixpkgs/commit/f028a5195a7fb8e046ee4e281cb1a4a552b82b37) | `solaar: 1.0.7 -> 1.1.0`                                                                |
| [`8191c8e2`](https://github.com/NixOS/nixpkgs/commit/8191c8e226fc158e73358d4951b5f09471753a5a) | `grub2: fix buildPackage bash shebang`                                                  |
| [`76e515cb`](https://github.com/NixOS/nixpkgs/commit/76e515cb267c6de577d14aeab1c2efe7cb2d84a6) | `grub2: switch to release tarball`                                                      |
| [`46485455`](https://github.com/NixOS/nixpkgs/commit/4648545542a33726ef9eecccc3e5393a52f012ae) | `qca-qt5: fix gcc-11 from upstream`                                                     |
| [`5881a720`](https://github.com/NixOS/nixpkgs/commit/5881a720d3643fa7c30cd2532f054d0f81fced3b) | `gst_all_1.gst-plugins-bad: fix gcc-11 build by applying fix unconditionally`           |
| [`21364d15`](https://github.com/NixOS/nixpkgs/commit/21364d1579b2f66af4af8983c5674e7accca09c3) | `abcmidi: 2021.10.15 -> 2021.11.25`                                                     |
| [`5677e477`](https://github.com/NixOS/nixpkgs/commit/5677e477d34f45d5c12be2f39f1f5d471762b495) | `ldns: 1.7.1 -> 1.8.0`                                                                  |
| [`28237545`](https://github.com/NixOS/nixpkgs/commit/28237545a5553bf4bfe1bb2702867cc5288c53d8) | `sharedown: 2.0.0 → 3.0.1`                                                              |
| [`283e178e`](https://github.com/NixOS/nixpkgs/commit/283e178e6c3667c5b8527a5bb603d8b6ae2e384e) | `scribusUnstable: patch for harfbuzz 3.0`                                               |
| [`79e5ac3d`](https://github.com/NixOS/nixpkgs/commit/79e5ac3df42fb197535b0814399e9dd4516bfdfa) | `scribusUnstable: clarify license`                                                      |
| [`e63e7a33`](https://github.com/NixOS/nixpkgs/commit/e63e7a33586309c70776739cb5973dadf6d2d388) | `python3Packages.bimmer-connected: 0.8.0 -> 0.8.2`                                      |
| [`1e31ea1b`](https://github.com/NixOS/nixpkgs/commit/1e31ea1b44a1f54d79e5a6ced74a24dbb6503410) | `bviplus: pull pending upstream inclusion fix for ncurses-6.3`                          |
| [`539811a4`](https://github.com/NixOS/nixpkgs/commit/539811a4d3c680c21a4d493e79048c5aea8fb8bf) | `nixos/gdm: enable nvidiaWayland by default`                                            |
| [`324e9f68`](https://github.com/NixOS/nixpkgs/commit/324e9f686ec39ba5d4a760d957509c52039cec27) | `nixosTests.vengi-tools: init`                                                          |
| [`218f1435`](https://github.com/NixOS/nixpkgs/commit/218f14351463ed26809479410600f2ef136d05b4) | `vengi-tools: init at 0.0.14`                                                           |
| [`b8b08eb0`](https://github.com/NixOS/nixpkgs/commit/b8b08eb07ee6ed03d32f78b775171966cbd52122) | `python3Packages.total-connect-client: 2021.11.4 -> 2021.11.5`                          |
| [`a00c0e09`](https://github.com/NixOS/nixpkgs/commit/a00c0e093e14d7ecc1361cfe757e68f681a7174c) | `python3Packages.pikepdf: 4.0.1.post1 -> 4.0.2`                                         |
| [`5b2e2ba6`](https://github.com/NixOS/nixpkgs/commit/5b2e2ba60c0b877f87bea336aeaa93aa482c9545) | `python3Packages.pyahocorasick: use upstream patch`                                     |
| [`0824be95`](https://github.com/NixOS/nixpkgs/commit/0824be950d5991c9e46f7f1f4d155dd56114c085) | `python3Packages.ledgerwallet: use upstream patch`                                      |
| [`51839886`](https://github.com/NixOS/nixpkgs/commit/51839886b359e5350bd235983b475d490348b540) | `nvidia_x11: add production alias`                                                      |
| [`2470459e`](https://github.com/NixOS/nixpkgs/commit/2470459e2eb5563806f780dbceb0b781159de64b) | `indilib: 1.9.2 -> 1.9.3`                                                               |
| [`d793cbc4`](https://github.com/NixOS/nixpkgs/commit/d793cbc4aa4192c19abee64718ac0b3785cda10f) | `nx-libs: fix build on upcoming binutils-2.36`                                          |
| [`8765f1ca`](https://github.com/NixOS/nixpkgs/commit/8765f1cae4e9cb75f4bbf3b437cf922cd8ffd79f) | `gscan2pdf: 2.12.3 -> 2.12.4`                                                           |
| [`b03e3fd6`](https://github.com/NixOS/nixpkgs/commit/b03e3fd65f9009a8bc55afad2cf813f953a9baab) | `lunar-client: 2.7.3 -> 2.8.8`                                                          |
| [`046ac669`](https://github.com/NixOS/nixpkgs/commit/046ac66948a7470bdc7bc1ac9317568718ecc266) | `keen4: convert away from builder.sh`                                                   |
| [`9cb930ff`](https://github.com/NixOS/nixpkgs/commit/9cb930ff687a6f5dc9d37477e50ad24aea38fd5f) | `nixos/nginx: fix start when recommendedOptimisation is off`                            |
| [`978c08a5`](https://github.com/NixOS/nixpkgs/commit/978c08a5dea7b1c04401f965479b782024fcc7eb) | `Add kotlin-language-server`                                                            |
| [`5287d014`](https://github.com/NixOS/nixpkgs/commit/5287d0146d0cab7ef0186cf26835be296d0470aa) | `nixos/locate: PRUNE_BIND_MOUNTSFR -> PRUNE_BIND_MOUNTS`                                |
| [`acf50477`](https://github.com/NixOS/nixpkgs/commit/acf504773240020d57b1b26a5936b63c45ff796c) | `qflipper: init at 0.5.3`                                                               |
| [`129c47ae`](https://github.com/NixOS/nixpkgs/commit/129c47ae88eadcc50e66357a621bab5c3f96bc26) | `nixos/locate: include missing filesystems`                                             |
| [`c7f31cfa`](https://github.com/NixOS/nixpkgs/commit/c7f31cfa6a26bb71e7198594c228f43ba92112b7) | `cvise: 2.3.0 -> 2.4.0`                                                                 |
| [`3247e757`](https://github.com/NixOS/nixpkgs/commit/3247e757416496ef6a19fb53ffdc4c92c969f39a) | `emacs: resolve wrapper load-path at build time`                                        |
| [`f0af311f`](https://github.com/NixOS/nixpkgs/commit/f0af311f6286c6416866ecd468449134789a3ce2) | `linux_lqx: 5.14.17 -> 5.14.18`                                                         |
| [`dd00c495`](https://github.com/NixOS/nixpkgs/commit/dd00c495c3b63692558235ea0c88e115ae3d6bf1) | `linux_lqx: 5.14.16 -> 5.14.17`                                                         |
| [`16f44b24`](https://github.com/NixOS/nixpkgs/commit/16f44b24f8d1c1136f27b588a234b7393a6465b8) | `nixpkgs-basic-release-checks: check for use of url literals`                           |
| [`08c5c121`](https://github.com/NixOS/nixpkgs/commit/08c5c121f573de019932d02c9e7f95e0104c84e5) | `mopidy-iris: 3.59.0 -> 3.60.0`                                                         |
| [`dee31690`](https://github.com/NixOS/nixpkgs/commit/dee3169047a7f5cf4713ca7dc85a8e491354c418) | `gmu: pull pending upstream inclusion fix for ncurses-6.3`                              |
| [`992458a7`](https://github.com/NixOS/nixpkgs/commit/992458a7842e45021fb4b4c4b520736c8210bd79) | `freesweep: pull pending upstream inclusion fix for ncurses-6.3`                        |
| [`84ba0119`](https://github.com/NixOS/nixpkgs/commit/84ba0119869aa7f42734a0e9cff8bca1ebf382c2) | `linode-cli: 5.11.1 -> 5.12.0`                                                          |
| [`0c23bd5c`](https://github.com/NixOS/nixpkgs/commit/0c23bd5c4681b75bd0cc1d7fd311fce3d46fdac1) | `libmysofa: 1.2 -> 1.2.1`                                                               |
| [`d492837c`](https://github.com/NixOS/nixpkgs/commit/d492837c98aa5e26b75cda16cafb52b8d2af3a32) | `betaflight-configurator: 10.7.0 -> 10.7.1`                                             |
| [`235c562c`](https://github.com/NixOS/nixpkgs/commit/235c562c9e16615350d946ac55ce0495b9b8f729) | `salt: 3003.3 -> 3004`                                                                  |
| [`4c391b43`](https://github.com/NixOS/nixpkgs/commit/4c391b43292d8370de0846ccec6ded81c147528a) | `pythonPackages.pandas: disable tests on armv7l`                                        |