### PR TITLE
chore(flake/home-manager): `9de77227` -> `f23073f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -62,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1638150501,
-        "narHash": "sha256-aWH3MRmjUtx8ciSGLegBJC5mhymsuroHPs74ZldrNTU=",
+        "lastModified": 1638311312,
+        "narHash": "sha256-OMAd3WZ/VtMK0QQwDrrynP6+jOlWLd1yQtnW56+eZtA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9de77227d7780518cfeaee5a917970247f3ecc56",
+        "rev": "f23073f1daa769a28a12ac587eea487aa8afb196",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                           |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`f23073f1`](https://github.com/nix-community/home-manager/commit/f23073f1daa769a28a12ac587eea487aa8afb196) | `less: allow customization`                              |
| [`7c320a53`](https://github.com/nix-community/home-manager/commit/7c320a53254609d9814280a34e312b7f00fd160b) | `waybar: make module a freeform module, remove warnings` |