### PR TITLE
chore(flake/nixpkgs): `0943a5c5` -> `a77874bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1638350908,
-        "narHash": "sha256-eBA9Sk3AF0/y22R6I1kwOIpAkjVQrVPV2TS/T239e4s=",
+        "lastModified": 1638393813,
+        "narHash": "sha256-R1OyNqKoGSNL35VHSEAD5wJvb6/FF5NvhPm4AlSKI+8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0943a5c5a089761ea06ecf95e56bab8ce84e35f3",
+        "rev": "a77874bb9c35445a00875e9de5758edda78f8326",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`1195e8ce`](https://github.com/NixOS/nixpkgs/commit/1195e8cecc8651d7168e4064a4d4c4e6e83a985a) | `clj-kondo: 2021.10.19 -> 2021.12.01`                                     |
| [`a542c7c8`](https://github.com/NixOS/nixpkgs/commit/a542c7c8c52b1d7ba014c326126cd298f8e0720e) | `esphome: apply patch to fix subprocess usage`                            |
| [`f69af24c`](https://github.com/NixOS/nixpkgs/commit/f69af24c74715039420a999690870433ef991127) | `esphome: 2021.10.1 -> 2021.11.4`                                         |
| [`3d468e03`](https://github.com/NixOS/nixpkgs/commit/3d468e031569ba21e2c0b393e7f43767f8a078f5) | `gradle: 7.3 -> 7.3.1`                                                    |
| [`6daa4a5c`](https://github.com/NixOS/nixpkgs/commit/6daa4a5c045d40e6eae60a3b6e427e8700f1c07f) | `haskell.compiler.*: use wrapped darwin bintools on aarch64`              |
| [`21a54a4e`](https://github.com/NixOS/nixpkgs/commit/21a54a4e4c91f043aa46063a9276b768fa6af8b1) | `nixos/transmission: adjust message-level enum`                           |
| [`3b1c4a73`](https://github.com/NixOS/nixpkgs/commit/3b1c4a732f9d8f4961153a087d86e66ca704ac55) | `compcert: fix for Coq 8.14.1`                                            |
| [`3782c097`](https://github.com/NixOS/nixpkgs/commit/3782c097b2ac1ef19ed573eeaf7b1a02ae10ac3a) | `matcha-gtk-theme: 2021-09-24 -> 2021-11-29`                              |
| [`48406e3f`](https://github.com/NixOS/nixpkgs/commit/48406e3fca5be837df5cfa3a5b891dd3d6557e1b) | `coq_8_14: 8.14.0 → 8.14.1`                                               |
| [`4f51fae5`](https://github.com/NixOS/nixpkgs/commit/4f51fae5bbbb5b232ca340f5836875cc2c0f10cc) | `coqPackages.serapi: remove with Coq 8.14`                                |
| [`9cb58616`](https://github.com/NixOS/nixpkgs/commit/9cb58616cc4f95300c7b9eedf05c5c9eb8b60ce8) | `ocamlPackages.merlin: 4.3.1 → 4.4`                                       |
| [`bd9ae0ab`](https://github.com/NixOS/nixpkgs/commit/bd9ae0ab7b7613d9f636caa53c0f45a1193f8233) | `ktlint: 0.43.0 -> 0.43.1`                                                |
| [`7dd5a9c0`](https://github.com/NixOS/nixpkgs/commit/7dd5a9c02997c98acf721a311e30799c8a37d048) | `gosec: 2.9.1 -> 2.9.3`                                                   |
| [`86c99790`](https://github.com/NixOS/nixpkgs/commit/86c99790e6e3b1eaef116de6685f0877bfd65278) | `httpx: 1.1.3 -> 1.1.4`                                                   |
| [`bdaf195e`](https://github.com/NixOS/nixpkgs/commit/bdaf195e9854a1491b4d463384128fbb5f8afd5a) | `spdk: enable parallel building`                                          |
| [`b1d95dca`](https://github.com/NixOS/nixpkgs/commit/b1d95dca5645c107f49873ad5ab08e6d01c416cf) | `mrtrix: 3.0.2 -> unstable-2021-11-25`                                    |
| [`bc25e8f2`](https://github.com/NixOS/nixpkgs/commit/bc25e8f24f317daadaa8b19ed3d5c1937ae9cb69) | `protontricks: 1.6.1 → 1.6.2`                                             |
| [`eea9da36`](https://github.com/NixOS/nixpkgs/commit/eea9da363dde044099f9a9249ded3d17300c11c2) | `ncspot: 0.9.0 -> 0.9.2`                                                  |
| [`c8ddc08a`](https://github.com/NixOS/nixpkgs/commit/c8ddc08aabf8aa5bfac408696184f866c4c338c4) | `vale: 2.11.2 -> 2.13.0`                                                  |
| [`579cc4c0`](https://github.com/NixOS/nixpkgs/commit/579cc4c0658fc9a7463c17c2cdd90e66e6929006) | `certigo: 1.12.1 -> 1.13.0`                                               |
| [`753c1f5a`](https://github.com/NixOS/nixpkgs/commit/753c1f5a975b9d62bcaf78e8f5c082860b1f342d) | `gnomeExtensions.pop-shell: init at unstable-2021-11-30`                  |
| [`9e234eba`](https://github.com/NixOS/nixpkgs/commit/9e234eba80af954e38cef182b4d0774b5fb40a47) | `nixos/tests/home-assistant: test hardening with extraComponents`         |
| [`254dd2a1`](https://github.com/NixOS/nixpkgs/commit/254dd2a1025e46bccd05c4cc0dd461093b689480) | `nixos/home-assistant: consider extraComponents in hardening`             |
| [`cb928788`](https://github.com/NixOS/nixpkgs/commit/cb928788e024e2d2326f63550663acfd7205e759) | `libdeltachat: 1.68.0 -> 1.69.0`                                          |
| [`1f726635`](https://github.com/NixOS/nixpkgs/commit/1f726635ee4f0a5faebc4c9b9787bc0d76d0ace4) | `nixos/charybdis: implement reload functionality`                         |
| [`0f2f663d`](https://github.com/NixOS/nixpkgs/commit/0f2f663d26540fb99f2e30aa9f59bc8a07de4760) | `matrix-appservice-irc: fix current version detection in update script`   |
| [`5bb9d917`](https://github.com/NixOS/nixpkgs/commit/5bb9d9176d8eb8fbc4893d77be20e6eaf5843dff) | `gnome: update docs regarding nvidiaWayland`                              |
| [`43ec279d`](https://github.com/NixOS/nixpkgs/commit/43ec279d771da1ba85be75159de93f0f0d13d2bd) | `minecraft-server: 1.17.1 -> 1.18`                                        |
| [`1f373869`](https://github.com/NixOS/nixpkgs/commit/1f37386976936130c9399f7c9428425c1b947110) | `goreleaser: 0.184.0 -> 1.1.0`                                            |
| [`22dffe27`](https://github.com/NixOS/nixpkgs/commit/22dffe27f394427505d1c9006dcb6aebc6b9f85b) | `pkgs/tools: use pname&version instead of name`                           |
| [`225ffe5d`](https://github.com/NixOS/nixpkgs/commit/225ffe5dd0a9d2e29fbfce87607046e2cacd304d) | `matrix-appservice-irc: improve updateScript`                             |
| [`428620c9`](https://github.com/NixOS/nixpkgs/commit/428620c9c5b7a208bf5df34a6fa30ea8fde02947) | `matrix-appservice-irc: 0.30.0 -> 0.32.1`                                 |
| [`640050fc`](https://github.com/NixOS/nixpkgs/commit/640050fcb94dd4735098ca87ae432198a1db04cf) | `ionide.ionide-fsharp: 5.5.5 -> 5.10.1`                                   |
| [`57ab6231`](https://github.com/NixOS/nixpkgs/commit/57ab62314b18dcdeb4c3e0365cf1821dd1f3340b) | `maxima, sage: Simplify lisp-compiler arguments namings`                  |
| [`8d17f4ba`](https://github.com/NixOS/nixpkgs/commit/8d17f4babf00cb40c893d4dfc84a67a5805c0b69) | `maxima: 5.45.0 -> 5.45.1`                                                |
| [`8d227fe0`](https://github.com/NixOS/nixpkgs/commit/8d227fe05c146aee8ae6ded8ad2168f074f1b203) | `wxmaxima: 21.05.2 -> 21.11.0`                                            |
| [`9a0723cc`](https://github.com/NixOS/nixpkgs/commit/9a0723cc3f472d5e36ff622eb47303da5291d156) | `unbound-full: fix the build again`                                       |
| [`c5be6ef1`](https://github.com/NixOS/nixpkgs/commit/c5be6ef14f7133cdecbb3e8f87dfc4a4ee396c91) | `probe-run: 0.3.0 -> 0.3.1`                                               |
| [`e62b8020`](https://github.com/NixOS/nixpkgs/commit/e62b8020f3d6597ffe4c5444fe824546af88e739) | `nixos/test-driver: add (functional) timeouts to more functions`          |
| [`363d7f3a`](https://github.com/NixOS/nixpkgs/commit/363d7f3ae857aeb863bc2e00fb487591b7d5db2b) | `nixos/test-driver: add timeout parameter to execute`                     |
| [`b5681a7a`](https://github.com/NixOS/nixpkgs/commit/b5681a7a4096b81101626a0853c28bede0495490) | `nixos/specialisation: Rephrase in terms of extendModules, noUserModules` |
| [`00563d4f`](https://github.com/NixOS/nixpkgs/commit/00563d4f076a476c670635fbe266689af1a73f07) | `amazon-ec2-amis: Add aarch64 amis`                                       |
| [`5a6c43dd`](https://github.com/NixOS/nixpkgs/commit/5a6c43dda3f74e78ba1c143cb2ee2652567e362c) | `ec2-amis.nix -> amazon-ec2-amis.nix, new format`                         |