### PR TITLE
chore(flake/nixos-hardware): `6b3f79de` -> `4c9f0727`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -77,11 +77,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1638182287,
-        "narHash": "sha256-vBzf+hbTJz2ZdXV/DWirl6wOO7tjdqzTIU+0FANt65U=",
+        "lastModified": 1638440530,
+        "narHash": "sha256-kmoNW+RmSka988iWvSrkiAxO8g6D76O0gW2cIIhL6U8=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "6b3f79de09c3de7c91ab51e55e87879f61b6faec",
+        "rev": "4c9f07277bd4bc29a051ff2a0ca58c6403e3881a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                  |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`1794de7d`](https://github.com/NixOS/nixos-hardware/commit/1794de7d78fcc70337800ee5cbce171ae138ec15) | `xps-9310: Remove upstreamed kernel patches with custom config` |