### PR TITLE
chore(flake/nixpkgs): `a77874bb` -> `58371472`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1638393813,
-        "narHash": "sha256-R1OyNqKoGSNL35VHSEAD5wJvb6/FF5NvhPm4AlSKI+8=",
+        "lastModified": 1638437181,
+        "narHash": "sha256-Y9H127RyfXNTHs1E1DrUzQ0aLEw4fmZ40sI3j5lxoHQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a77874bb9c35445a00875e9de5758edda78f8326",
+        "rev": "58371472fe78c979964df42542e9db0e74c5c2bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                    |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`cf6fc1fd`](https://github.com/NixOS/nixpkgs/commit/cf6fc1fd1734373a5dc9dc6c223caaaad2a8592e) | `podman-compose: 2021-05-18 → 0.1.8`                              |
| [`559edc03`](https://github.com/NixOS/nixpkgs/commit/559edc03590da7bf77bfa262a111cf0834473aa7) | `bunnyfetch: unstable-2021-06-19 -> 0.2.0`                        |
| [`b952a9b1`](https://github.com/NixOS/nixpkgs/commit/b952a9b16ee8a8b6c45d16d84aa298717624e34f) | `adopt multiple packages`                                         |
| [`8db9c46d`](https://github.com/NixOS/nixpkgs/commit/8db9c46d69ac92675a9b675e41193d6376265b7e) | `python3Packages.rdkit: fix on aarch64-darwin`                    |
| [`6cbd21cb`](https://github.com/NixOS/nixpkgs/commit/6cbd21cb02170f8f53fd5c8410a62af1fab2b46f) | `julia_16-bin and julia_17-bin: punctuation fixes`                |
| [`6e176f71`](https://github.com/NixOS/nixpkgs/commit/6e176f712be1dd51c2c53528f4ee1b3efb6ac222) | `julia_10-bin: deprecate`                                         |
| [`36afb584`](https://github.com/NixOS/nixpkgs/commit/36afb5849371a1898dc605b0905f4d351cee4b39) | `julia_10-bin and julia_16-bin: update LTS alias`                 |
| [`1526faf0`](https://github.com/NixOS/nixpkgs/commit/1526faf075bdb52ece4fd5c259c54c66d1fcf003) | `julia_17-bin: init at 1.7.0`                                     |
| [`5b0af757`](https://github.com/NixOS/nixpkgs/commit/5b0af75786ec92a997c8db73b2492a429cb2f587) | `materia-theme: 20200916 -> 20210322`                             |
| [`ee36cb7d`](https://github.com/NixOS/nixpkgs/commit/ee36cb7d2c90faac15a670aa867387dbe31df208) | `nss: 3.72 -> 3.73 (#148219)`                                     |
| [`0d02ab20`](https://github.com/NixOS/nixpkgs/commit/0d02ab20287ebf6bbd249ca18a53a3d7952b05e3) | `.github/workflows/editorconfig.yml: write changed files to disk` |
| [`ecb836f4`](https://github.com/NixOS/nixpkgs/commit/ecb836f4dd22665a6cf1e3ddd7b06f26cbafff8e) | `hydrus: 463 -> 464`                                              |
| [`755320fe`](https://github.com/NixOS/nixpkgs/commit/755320fe14d22e585eb2e85fd0b87ff73844739a) | `signal-desktop: 5.24.0 -> 5.25.0`                                |
| [`8fafb2d3`](https://github.com/NixOS/nixpkgs/commit/8fafb2d3cf04df3d6ae5d5931cd49c07cb6747e5) | `python39Packages.open-meteo: init at 0.2.0`                      |
| [`52209dc5`](https://github.com/NixOS/nixpkgs/commit/52209dc538b144b997f8365f76d1cbf0dcc240fb) | `python3Packages.vehicle: 0.2.0 -> 0.2.2`                         |
| [`1c5f50da`](https://github.com/NixOS/nixpkgs/commit/1c5f50daf3919d636475026a9100286dbcc78731) | `python3Packages.cloudsplaining: 0.4.6 -> 0.4.8`                  |
| [`9859ef86`](https://github.com/NixOS/nixpkgs/commit/9859ef861c9fd45ad50da5bed54fae5ee645536e) | `python3Packages.tailscale: 0.1.2 -> 0.1.3`                       |
| [`82aef795`](https://github.com/NixOS/nixpkgs/commit/82aef7957db4f08ff7415761321ace9ec77d89e3) | `fastp: 0.23.1 -> 0.23.2`                                         |
| [`33b9a304`](https://github.com/NixOS/nixpkgs/commit/33b9a3048d1201c4abb610908aecad664c75b872) | `clang-tools: update maintainers`                                 |
| [`e87aec12`](https://github.com/NixOS/nixpkgs/commit/e87aec124e710d3ccbf7c6a0d4f7538ec62ffa68) | `maintainers: update patryk27's email`                            |
| [`5dfface8`](https://github.com/NixOS/nixpkgs/commit/5dfface8d549fdc80100c7dd06f00fe5e6226bd2) | `pinta: 1.6 -> 1.7.1`                                             |
| [`f0a01556`](https://github.com/NixOS/nixpkgs/commit/f0a01556c72c279fd16f3c52665b1453eef5b334) | `libxc: fix darwin build`                                         |
| [`af765f3a`](https://github.com/NixOS/nixpkgs/commit/af765f3abd7193ec5256cea3d5e8b7692dc99931) | `nixos/test-driver: give more functions nested labels`            |
| [`c6ee6325`](https://github.com/NixOS/nixpkgs/commit/c6ee63259a744b204ef2283a931de9f4e246f238) | `nixos/test-driver: more context when step finishes`              |
| [`cc084edc`](https://github.com/NixOS/nixpkgs/commit/cc084edc89974e7d98ae329585956b9d27bc349e) | `kubeval: 0.16.0 -> 0.16.1`                                       |
| [`6074436c`](https://github.com/NixOS/nixpkgs/commit/6074436c1bb0576402968638c3e8ac2790772bc9) | `python3Packages.md-toc: 8.0.1 -> 8.1.0`                          |
| [`3a972acb`](https://github.com/NixOS/nixpkgs/commit/3a972acb377a06a6356aa0e45cd0eae778609bf8) | `python3Packages.mypy-boto3-s3: 1.20.12 -> 1.20.17`               |
| [`574e92da`](https://github.com/NixOS/nixpkgs/commit/574e92dac65adab09b44ab101cde1b4b1737a7b7) | `python3Packages.pre-commit: 2.15.0 -> 2.16.0`                    |
| [`21e5acd3`](https://github.com/NixOS/nixpkgs/commit/21e5acd30888d414953ef69257f9510e29a311c5) | `python3Packages.twitterapi: 2.7.7 -> 2.7.9.1`                    |
| [`20dd43c6`](https://github.com/NixOS/nixpkgs/commit/20dd43c6df11af4248a9ec2b0c0ab0b0d9bfb0f2) | `python3Packages.meshtastic: 1.2.40 -> 1.2.43`                    |
| [`cb91e61c`](https://github.com/NixOS/nixpkgs/commit/cb91e61c5680e499e70fe535b4f18569b8f81908) | `chromiumDev: 98.0.4710.4 -> 98.0.4736.0`                         |
| [`26038de2`](https://github.com/NixOS/nixpkgs/commit/26038de2256eae025045e4646d91a73285700ed3) | `ruby: 2.7.4 -> 2.7.5, 3.0.2 -> 3.0.3`                            |