### PR TITLE
chore(flake/home-manager): `de54d513` -> `fbb80207`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -62,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1638415301,
-        "narHash": "sha256-iqszstbHaO5PYeBXQf1ukgYj/aq9wznBbZMrtYMZzgI=",
+        "lastModified": 1638484748,
+        "narHash": "sha256-Xb5X84/PUMXCyZGnixyqjtVyEt5tlCCrSp4lfJdtiHw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "de54d513c74bf8f4f3a58954b80b5f690639fe72",
+        "rev": "fbb80207f3840785e2918143ebe709f26372f91d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`fbb80207`](https://github.com/nix-community/home-manager/commit/fbb80207f3840785e2918143ebe709f26372f91d) | `darwin: add midchildan to maintainers`                         |
| [`0d585828`](https://github.com/nix-community/home-manager/commit/0d585828877a2a840d7ba7e87731080394408392) | `darwin: keep the options for the "defaults" system up-to-date` |