### PR TITLE
chore(flake/home-manager): `fbb80207` -> `1aaa1a03`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -62,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1638484748,
-        "narHash": "sha256-Xb5X84/PUMXCyZGnixyqjtVyEt5tlCCrSp4lfJdtiHw=",
+        "lastModified": 1638554279,
+        "narHash": "sha256-o5m0JqGolzn73IKhn6MLp/y5EJG4L391eGobzgOZoJY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fbb80207f3840785e2918143ebe709f26372f91d",
+        "rev": "1aaa1a033bae6c53773ad4374756ac72ba25b729",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                 |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`1aaa1a03`](https://github.com/nix-community/home-manager/commit/1aaa1a033bae6c53773ad4374756ac72ba25b729) | `docs: add note about Waybar modules`          |
| [`290a188d`](https://github.com/nix-community/home-manager/commit/290a188dad547df8b1069bf14cb21f9aa276413d) | `docs: change stable from 21.05 to 21.11`      |
| [`f46972e4`](https://github.com/nix-community/home-manager/commit/f46972e46676886423b8336c30bd0f1027fa87af) | `powerline-go: add support for -modules-right` |