### PR TITLE
chore(flake/nixpkgs): `b0819012` -> `bc0e3db2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1638480607,
-        "narHash": "sha256-tv+SXCgsuBGtuHa/wjPtCDGzfxk6PUT30F9mpX/FWaE=",
+        "lastModified": 1638523822,
+        "narHash": "sha256-p8B9rC8h1lcthYofsGMuQIlzTNJH1izKz8Zb7X+jAM8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b0819012c4d3bcbe68024d6da3576a7e5607606d",
+        "rev": "bc0e3db2b6d097a54111d9c17eacc977fe9c856b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`6bad84a2`](https://github.com/NixOS/nixpkgs/commit/6bad84a25da85dd16a2c9badd2ed893ad231210f) | `shellcheck: drop removeAttrs workaround for hydraPlatforms`                          |
| [`31ea056e`](https://github.com/NixOS/nixpkgs/commit/31ea056e676c29b1f996098165a76ce0bafe1124) | `poke: 1.3 → 1.4`                                                                     |
| [`2a295f42`](https://github.com/NixOS/nixpkgs/commit/2a295f42c84df1a413295e580945d7c334c9b6b0) | `symbiyosys: 2021.09.13 -> 2021.11.30`                                                |
| [`5b253be5`](https://github.com/NixOS/nixpkgs/commit/5b253be5913facf6e4958db2f04c3e31923b5300) | `nextpnr: 2021.09.27 -> 2021.11.24, with apycula update`                              |
| [`a79ca33d`](https://github.com/NixOS/nixpkgs/commit/a79ca33d94fb577cbd30bb8c641fa020098f915a) | `yosys: 0.10+1 -> 0.11+52, with abc update`                                           |
| [`37f81936`](https://github.com/NixOS/nixpkgs/commit/37f81936fadac1d5dd0c4467e550cacc7aa713be) | `python3Packages.bx-python: 0.8.11 -> 0.8.12`                                         |
| [`6c4f2d73`](https://github.com/NixOS/nixpkgs/commit/6c4f2d7399ffca3a7eb6f00b9a6ec5b264c23109) | `python3Packages.sqlmap: 1.5.11 -> 1.5.12`                                            |
| [`c3338bcd`](https://github.com/NixOS/nixpkgs/commit/c3338bcdc4634d846354b3a24e6b0ad45d3c6a83) | `.github/workflows/editorconfig.yml: allow PRs to skip check`                         |
| [`6cbce58b`](https://github.com/NixOS/nixpkgs/commit/6cbce58b9d4dec01cae59168c85d25e6e4b87456) | `python3Packages.qcs-api-client: 0.20.3 -> 0.20.4`                                    |
| [`322365c6`](https://github.com/NixOS/nixpkgs/commit/322365c68beb02f53280117346580854573a3fc5) | `python3Packages.pytenable: 1.4.0 -> 1.4.2`                                           |
| [`78a18960`](https://github.com/NixOS/nixpkgs/commit/78a189600d533105d16d5195f9293f5254126979) | `python3Packages.sendgrid: 6.9.1 -> 6.9.2`                                            |
| [`2f89af4d`](https://github.com/NixOS/nixpkgs/commit/2f89af4d34762bded3ed3c64179f2e7fc06428d3) | `nfd: init at 0.7.1 (#144010)`                                                        |
| [`a3401f6e`](https://github.com/NixOS/nixpkgs/commit/a3401f6e3356cbf76050ed276f7b26d87766dc26) | `OpenJDK: expose more versions`                                                       |
| [`305b7de4`](https://github.com/NixOS/nixpkgs/commit/305b7de42166f28b4fb0f7401c285d5772b34f45) | `bloop: 1.4.9 -> 1.4.11`                                                              |
| [`24d71739`](https://github.com/NixOS/nixpkgs/commit/24d717393fef671609d270f3319d2db2c793ddf9) | `bloop: add kubukoz as maintainer`                                                    |
| [`c47f9914`](https://github.com/NixOS/nixpkgs/commit/c47f9914356d15e7d3ee6e9f57d7140502bc43bf) | `top-level: add depsHostHost splicing`                                                |
| [`3bf91048`](https://github.com/NixOS/nixpkgs/commit/3bf91048f85654c6dec62bbbf4e79a85beda3bb0) | `scala-cli: 0.0.8 -> 0.0.9`                                                           |
| [`e2738be1`](https://github.com/NixOS/nixpkgs/commit/e2738be13650e2f5ee498654a3a48b3b11f8dbab) | `nix-output-monitor: 1.0.3.3 -> 1.0.4.0`                                              |
| [`d0bcc212`](https://github.com/NixOS/nixpkgs/commit/d0bcc212de13b1cd876bb8f01c90a8e8f42e25b6) | `nixosTests.docker-tools: Use unique binary in test case`                             |
| [`b6b825ac`](https://github.com/NixOS/nixpkgs/commit/b6b825ac0929b6c295b98cc677b7ccf38443c630) | `python3Packages.flux-led: 0.25.1 -> 0.25.10`                                         |
| [`6c55d68c`](https://github.com/NixOS/nixpkgs/commit/6c55d68c16b351fcaeffd09b0cf3848e515cb396) | `Removing zoomulator (my self) as maintainer.`                                        |
| [`cfc39c03`](https://github.com/NixOS/nixpkgs/commit/cfc39c0331813fd6f3db894a8591182160a53fbc) | `kubescape: 1.0.131 -> 1.0.132`                                                       |
| [`a99ea202`](https://github.com/NixOS/nixpkgs/commit/a99ea202552ebd447b835b2ccc98b8fcc4f64336) | `checkov: 2.0.614 -> 2.0.625`                                                         |
| [`89369e06`](https://github.com/NixOS/nixpkgs/commit/89369e069d456a4fc4b3799967d00719433a5e24) | `jadx: 1.2.0 -> 1.3.0`                                                                |
| [`6b2b9071`](https://github.com/NixOS/nixpkgs/commit/6b2b9071309286316691b0b89d67bd076b707a3b) | `babashka: 0.6.7 -> 0.6.8`                                                            |
| [`0a78df51`](https://github.com/NixOS/nixpkgs/commit/0a78df519d30f904606448bfc253720c1ff3d5b5) | `earthly: 0.5.24 -> 0.6.2`                                                            |
| [`e3cba2b9`](https://github.com/NixOS/nixpkgs/commit/e3cba2b9da27e0cc5873305ad5a85cc892f39f47) | `haskellPackages.hasura: 2.0.9 -> 2.0.10`                                             |
| [`18bab166`](https://github.com/NixOS/nixpkgs/commit/18bab16610d79366aa635e763e480a0de1a458c0) | ` xsos:init at 0.7.19`                                                                |
| [`6496069d`](https://github.com/NixOS/nixpkgs/commit/6496069ddaa38504450897831579b44798cab454) | `haskell.lib{,.compose}.doDistribute: default to lib.platforms.all`                   |
| [`93266415`](https://github.com/NixOS/nixpkgs/commit/93266415489c4079eb62308a7829c30d72334048) | `shellcheck: add override for newer version`                                          |
| [`c610be58`](https://github.com/NixOS/nixpkgs/commit/c610be58c0b6484c18728dc3ed60310cdbfbd456) | `haskell.compiler.*: use build->target LLVM in build`                                 |
| [`512c0ee7`](https://github.com/NixOS/nixpkgs/commit/512c0ee78a8dcfc74758108822247f1205cbf909) | `haskellPackages.xmonad*_0_17_0: build on Hydra`                                      |
| [`6bdb60a4`](https://github.com/NixOS/nixpkgs/commit/6bdb60a4055b23f468e355c5fb486bb34c14e357) | `haskellPackages.xmonad-extras_0_17_0: build with matching releases`                  |
| [`a9fb1cb7`](https://github.com/NixOS/nixpkgs/commit/a9fb1cb78a2273e8087e3d76ce2c561852d1f971) | `haskellPackages.xmonad-contrib_0_17_0: mv override closer to xmonad`                 |
| [`36d5761b`](https://github.com/NixOS/nixpkgs/commit/36d5761b3e5aca9742fec85107e3d308a9af872c) | `haskellPackages.xmonad_0_17_0: respect NIX_GHC and XMONAD_XMESSAGE`                  |
| [`93ee1a9c`](https://github.com/NixOS/nixpkgs/commit/93ee1a9cb0cedc65b26c8ebd748c7045506c4e9b) | `knot-resolver: 5.4.2 -> 5.4.3`                                                       |
| [`3151b3d7`](https://github.com/NixOS/nixpkgs/commit/3151b3d7174ef35219dd63896503990ae9623a04) | `goverlay: 0.6.4 → 0.7`                                                               |
| [`c23e14e3`](https://github.com/NixOS/nixpkgs/commit/c23e14e33f207dd38b6cc50401493d640a4745db) | `haskell.compiler.*: assert that host->target == build->target tools`                 |
| [`19fc2292`](https://github.com/NixOS/nixpkgs/commit/19fc2292942cfcb7c07dade739989a64545d812f) | `haskell.compiler.*: use targetCC for hasGold check`                                  |
| [`c876c749`](https://github.com/NixOS/nixpkgs/commit/c876c7498eee66ae77f49b0075e3217f7625f1b2) | `haskell.compiler.*: only set CLANG to match llc/opt`                                 |
| [`b2e47081`](https://github.com/NixOS/nixpkgs/commit/b2e47081059a37d6edbd7f1d89066cb7f640297e) | `haskell.compiler.ghc921: check if ld.gold is available in useLdGold`                 |
| [`b04ef6a5`](https://github.com/NixOS/nixpkgs/commit/b04ef6a552bb910372578f45f62d746db917da06) | `kstars: 3.5.5 -> 3.5.6`                                                              |
| [`3b74f906`](https://github.com/NixOS/nixpkgs/commit/3b74f9060768c5963bab33810f4c489f677351c3) | `linux_zen: 5.15.3-zen1 -> 5.15.5-zen1`                                               |
| [`c7bbff3f`](https://github.com/NixOS/nixpkgs/commit/c7bbff3f4d37f9652865157c6cb1c90a826095f1) | `haskellPackages.fakedata: Disable test suite`                                        |
| [`2d0c11c0`](https://github.com/NixOS/nixpkgs/commit/2d0c11c034fd89678dcc717cd77819ac4437010c) | `qgis: add erictapen as maintainer`                                                   |
| [`cc8cade9`](https://github.com/NixOS/nixpkgs/commit/cc8cade9bab34326e9c191782718ae4bf9b3867d) | `go_1_16: 1.16.9 -> 1.16.10`                                                          |
| [`63a370df`](https://github.com/NixOS/nixpkgs/commit/63a370df6fed838d8850d6d874342c69a91ccf10) | `mesa: 21.2.5 -> 21.2.6`                                                              |
| [`e5adc91d`](https://github.com/NixOS/nixpkgs/commit/e5adc91d637c8a110a9d8bb37a68bb2984dca1aa) | `qgis: 3.16.13 -> 3.16.14`                                                            |
| [`dfcd49af`](https://github.com/NixOS/nixpkgs/commit/dfcd49afe25d931432844f057cdc541c0ebe1018) | `python3Packages.numpy: remove unneeded patch`                                        |
| [`88e9beea`](https://github.com/NixOS/nixpkgs/commit/88e9beea985a8a0c661a213ad1f3558da32b78af) | `python3Packages.aiohttp-wsgi: disable network test`                                  |
| [`45d6eede`](https://github.com/NixOS/nixpkgs/commit/45d6eedec39da64e4e456721ed150374fc1a37d2) | `python3Packages.importlib-metadata: 4.8.1 -> 4.8.2`                                  |
| [`27f9348e`](https://github.com/NixOS/nixpkgs/commit/27f9348ee7648f87db0c37fdccf087a676d3264f) | `wafHook: always enable parallel building (#136641)`                                  |
| [`28625f78`](https://github.com/NixOS/nixpkgs/commit/28625f78619e77e48dde0c453f9ed5944f30b3d7) | `selinux: 2.9, 3.0 -> 3.3`                                                            |
| [`20fd3b10`](https://github.com/NixOS/nixpkgs/commit/20fd3b100215364e6d88cf5a6becc91827ad0a73) | `setools: 4.3.0 -> 4.4.0`                                                             |
| [`ae3ffded`](https://github.com/NixOS/nixpkgs/commit/ae3ffded45243a77e0580845f293d17bd65e41d1) | `pkgsMusl.valgrind-light: fix build`                                                  |
| [`e9dfe892`](https://github.com/NixOS/nixpkgs/commit/e9dfe892ef40e6b6f34effb8c93aff7eaf80e14a) | `llvm_{5..11}: pull upstream build fix for for gcc-12`                                |
| [`dd8ad828`](https://github.com/NixOS/nixpkgs/commit/dd8ad828de283d4bb71fe67689581989549f8421) | `llvmPackages_{13,git}.clang: build clang-tools-extra`                                |
| [`65855071`](https://github.com/NixOS/nixpkgs/commit/65855071f2bb87a6249dc317b983c399cfbfd38f) | `rhash: apply clang patch unconditionally`                                            |
| [`f91691f6`](https://github.com/NixOS/nixpkgs/commit/f91691f6a88b73866cad1dc70948dc4c8de8833b) | `bash: update patches (#146463)`                                                      |
| [`fad0d94c`](https://github.com/NixOS/nixpkgs/commit/fad0d94ce86ad01d96f2c5768d18ab8bf3013a75) | `Revert "python39Packages.python-language-server: mark broken"`                       |
| [`49a23923`](https://github.com/NixOS/nixpkgs/commit/49a2392306e6e4f4f13dd6f8887e20c252e82df9) | `gengetopt: disable parallelism`                                                      |
| [`a19b4efc`](https://github.com/NixOS/nixpkgs/commit/a19b4efc77b76d5c66edb31e2ae285f5c1c3ca17) | `nixos/tests/custom-ca: fix firefox test`                                             |
| [`6f3b6a2f`](https://github.com/NixOS/nixpkgs/commit/6f3b6a2fea3278a91c120e67802b54a5823912d0) | `gnutls: enable p11-kit by default`                                                   |
| [`cf3013b4`](https://github.com/NixOS/nixpkgs/commit/cf3013b4c0df4e01ea761d2fa2c6b69a38f9a5a4) | `p11-kit: add Fedora/RHEL trust store path`                                           |
| [`740155f9`](https://github.com/NixOS/nixpkgs/commit/740155f9e4989bb2ce52012d7cb32c5d4250cdce) | `nftables: 1.0.0 -> 1.0.1`                                                            |
| [`9ee913d6`](https://github.com/NixOS/nixpkgs/commit/9ee913d6c24cc53215ed34fb3d1a5dcf956704f8) | `libnetfilter_log: 1.0.1 -> 1.0.2`                                                    |
| [`fc598f26`](https://github.com/NixOS/nixpkgs/commit/fc598f2681440e4bd8a42efe7570f5c7cf2bfdeb) | `libnftnl: 1.2.0 -> 1.2.1`                                                            |
| [`8af91e55`](https://github.com/NixOS/nixpkgs/commit/8af91e5588a9ecbe9e39d4a1d6c50ee9d1847d6a) | `python39Packages.python-language-server: mark broken`                                |
| [`b6e1eeb9`](https://github.com/NixOS/nixpkgs/commit/b6e1eeb9e4cdf71d89439215bf0a61c7a37ba33a) | `python3Packages.pylsp_mypy: disable test test_multiple_workspaces`                   |
| [`8401031f`](https://github.com/NixOS/nixpkgs/commit/8401031f6b536da462c0645fc10ed84ef451be26) | `hydra-check: include types for mypy`                                                 |
| [`08e86542`](https://github.com/NixOS/nixpkgs/commit/08e86542c4a9e748889e7fe61b2053e9ef34522f) | `python39Packages.typed-ast: add SuperSandro2000 as maintainer, minor cleanup`        |
| [`8bd7e5c1`](https://github.com/NixOS/nixpkgs/commit/8bd7e5c1624ef006786aa763892778c027d25266) | `python39Packages.types-typed-ast: 1.4.4 -> 1.5.0`                                    |
| [`ffb5403e`](https://github.com/NixOS/nixpkgs/commit/ffb5403eb6a43989227feda2e3d9b713d2519da7) | `python39Packages.tomli: 1.2.1 -> 1.2.2, patch type error which occurs with mypy`     |
| [`a5691cfc`](https://github.com/NixOS/nixpkgs/commit/a5691cfc9a577ebfa05b7b5c847db5f41de052c4) | `python39Packages.mypy_extensions: little cleanup, add SuperSandro2000 as maintainer` |
| [`5f2f409a`](https://github.com/NixOS/nixpkgs/commit/5f2f409a2649da5b011ae8e490fe023657384bcb) | `python39Packages.types-typed-ast: init 1.4.4`                                        |
| [`8a976728`](https://github.com/NixOS/nixpkgs/commit/8a976728e35bf1e8933bc2a48c16adbbd0bdff38) | `python39Packages.mypy: 0.812 -> unstable-2021-11-14`                                 |
| [`80887010`](https://github.com/NixOS/nixpkgs/commit/8088701061742cee560435419e3e996b5c7bf8ea) | `python3Packages.mypy: relax typed_ast constraint`                                    |
| [`ce410eb2`](https://github.com/NixOS/nixpkgs/commit/ce410eb2e2054261b66f27302540c4f196621bc8) | `python3Packages.typed-ast: 1.4.3 -> 1.5.0`                                           |
| [`85852b94`](https://github.com/NixOS/nixpkgs/commit/85852b941d8e0888a98f1a21ac0a43875ccf7073) | `postgresql_14: 14.0 -> 14.1`                                                         |
| [`67abda78`](https://github.com/NixOS/nixpkgs/commit/67abda7877aaf6af6f04be25fdff424302486d2f) | `postgresql_13: 13.4 -> 13.5`                                                         |
| [`c046c5d6`](https://github.com/NixOS/nixpkgs/commit/c046c5d6ff02699d5dbe7fb5287c56abd83af15d) | `postgresql_12: 12.8 -> 12.9`                                                         |
| [`b701405b`](https://github.com/NixOS/nixpkgs/commit/b701405be7879df38f3aebbc150f6b925ab2e9a1) | `postgresql_11: 11.13 -> 11.14`                                                       |
| [`1d35ef9e`](https://github.com/NixOS/nixpkgs/commit/1d35ef9ee0951c0870484e7b8981b27a821e843b) | `postgresql_10: 10.18 -> 10.19`                                                       |
| [`7f523aa8`](https://github.com/NixOS/nixpkgs/commit/7f523aa88a31fc3b34615b4075544ccedb995d5e) | `postgresql_9_6: 9.6.23 -> 9.6.24`                                                    |
| [`e148f5ff`](https://github.com/NixOS/nixpkgs/commit/e148f5ff46ebd8e420896d9cac1d311311b8eed8) | `mariadb-connector-c: install my_config.h`                                            |
| [`cd838da1`](https://github.com/NixOS/nixpkgs/commit/cd838da194ca8aa795c732e330f7634d057da05b) | `vanity: Indent with spaces part 2`                                                   |
| [`afac2c3c`](https://github.com/NixOS/nixpkgs/commit/afac2c3c6867e3f88531aab14387290b2f727a36) | `gmp: use pname and version`                                                          |
| [`39619219`](https://github.com/NixOS/nixpkgs/commit/3961921973524fc4805141a6a5eb1d6e7157a79c) | `imagemagick: 7.1.0-13 -> 7.1.0-14`                                                   |
| [`6e78c933`](https://github.com/NixOS/nixpkgs/commit/6e78c9331e4c04b3e884896e74946bebb964762f) | `git: 2.33.1 -> 2.34.0`                                                               |
| [`806b33a0`](https://github.com/NixOS/nixpkgs/commit/806b33a0493a16c3b110936f505669a0f1eea05d) | `libuninameslist: 20210917 -> 20211114`                                               |
| [`20caa762`](https://github.com/NixOS/nixpkgs/commit/20caa76219ce345f334db86c1ba02a0d761a428d) | `sourceHighlight: fix tests on clang and gcc-12`                                      |
| [`57b496ea`](https://github.com/NixOS/nixpkgs/commit/57b496ea98bdbd633c48f16af1c69a196aaf963a) | `misc: Replace tab indentation with spaces`                                           |
| [`90dbec47`](https://github.com/NixOS/nixpkgs/commit/90dbec47b7c8eff5262fda73d97335fb29e079fa) | `vanity: Indent with spaces`                                                          |
| [`9d01ce82`](https://github.com/NixOS/nixpkgs/commit/9d01ce82acd4c36f97ee3e689ebfe574640e3e25) | `nixos/tests: add step-ca test`                                                       |
| [`972d7e74`](https://github.com/NixOS/nixpkgs/commit/972d7e74f61e2ded43e8ff998c1b8678c14f8e49) | `linux-kernel: enable BPF_LSM`                                                        |
| [`f522c412`](https://github.com/NixOS/nixpkgs/commit/f522c412d5e15fa2b6ed530f6e33bac37847a58b) | `haskellPackages.graphviz: hardcode references to graphviz tools`                     |
| [`1d9e598b`](https://github.com/NixOS/nixpkgs/commit/1d9e598b5fadab5b52236268dfcd21153ce3edf3) | `gnome2.ORBit2: explicitly disable build parallelism due to missing depends`          |
| [`3780c7c2`](https://github.com/NixOS/nixpkgs/commit/3780c7c21127eed5753a7df6017d43eeb0b7aa9a) | `gnome2.ORBit2: update homepage to https://developer-old.gnome.org/ORBit2/`           |
| [`48cfdc8c`](https://github.com/NixOS/nixpkgs/commit/48cfdc8ca57bbd88b3d16ddb0c83c2be6a643f8c) | `dockerTools: Add store dependencies of the customization layer`                      |
| [`160c8d88`](https://github.com/NixOS/nixpkgs/commit/160c8d88867dfe95ec75fb6133d1768c014226d7) | `python3Packages.numpy: proper fix for Werror misdetection bug`                       |