### PR TITLE
chore(flake/nixpkgs): `bc0e3db2` -> `f9a1652a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1638523822,
-        "narHash": "sha256-p8B9rC8h1lcthYofsGMuQIlzTNJH1izKz8Zb7X+jAM8=",
+        "lastModified": 1638565206,
+        "narHash": "sha256-5z7RBRw0qh3REJieanK3PkMHl0EuzZr2efZqAz44Bjg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bc0e3db2b6d097a54111d9c17eacc977fe9c856b",
+        "rev": "f9a1652a858329525c143450db2474ef439cf6c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                             |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`f9a1652a`](https://github.com/NixOS/nixpkgs/commit/f9a1652a858329525c143450db2474ef439cf6c1) | `python3Packages.heatzypy: init at 1.4.2`                                  |
| [`23f4fb4d`](https://github.com/NixOS/nixpkgs/commit/23f4fb4d14f37fe5772fe5e0f9511b0349e360d7) | `python3Packages.zeversolarlocal: init at 1.1.0`                           |
| [`e1fb73a3`](https://github.com/NixOS/nixpkgs/commit/e1fb73a3f2482869ebf3b36a4e33dbeedccf0331) | `python3Packages.hstspreload: 2021.11.1 -> 2021.12.1`                      |
| [`8e29af2f`](https://github.com/NixOS/nixpkgs/commit/8e29af2f5f2397cd66a198778614b44aa3703186) | `python3Packages.pykakasi: init at 2.2.1`                                  |
| [`4657c2e0`](https://github.com/NixOS/nixpkgs/commit/4657c2e07aaa793c57f23f5f47d3fb578a52dd44) | `python3Packages.jaconv: init at 0.3`                                      |
| [`6af367e1`](https://github.com/NixOS/nixpkgs/commit/6af367e180c33b74c8e655da6c87cd65f2c19636) | `python3Packages.tesla-wall-connector: init at 1.0.0`                      |
| [`dd15c5ce`](https://github.com/NixOS/nixpkgs/commit/dd15c5cec80ce18e47ac69be04869bf1534328df) | `agate: fix meta`                                                          |
| [`1a768ef4`](https://github.com/NixOS/nixpkgs/commit/1a768ef4da5450ce3e5afad447d238c54e66d103) | `genmap: init 1.3.0`                                                       |
| [`f0faf7cf`](https://github.com/NixOS/nixpkgs/commit/f0faf7cf3f72251a5d9ebbd034ccc34eb519704e) | `fwupd: 1.7.1 → 1.7.2 (#147032)`                                           |
| [`a3f918d3`](https://github.com/NixOS/nixpkgs/commit/a3f918d3400e817e77685287103da3de8d7b7343) | `libudev-zero: init at 1.0.0`                                              |
| [`8e6d403e`](https://github.com/NixOS/nixpkgs/commit/8e6d403e65c62b052123e4a8eed295885d3dd4eb) | `nixos/prometheus-postfix-exporter: whitelist addr-family `AF_UNIX``       |
| [`8e92c6c5`](https://github.com/NixOS/nixpkgs/commit/8e92c6c5101983f0dc67fe919e642943db09ef0e) | `nixos/consul: update deprecated webUi`                                    |
| [`6644e53b`](https://github.com/NixOS/nixpkgs/commit/6644e53bd0e9c25b100a2f49f4c18f88de6bd603) | `image-roll: add desktop entry`                                            |
| [`3745b58a`](https://github.com/NixOS/nixpkgs/commit/3745b58ace186e1fe59af44bb82df864fbb6f55d) | `gqrx: update support for different audio backends`                        |
| [`863ef0dd`](https://github.com/NixOS/nixpkgs/commit/863ef0dd47c0870c4772675aef18ca8f491880c6) | `quake3e: fix libcurl.so.4 location`                                       |
| [`a64683ad`](https://github.com/NixOS/nixpkgs/commit/a64683ad8caea40af700e90bb3804c491d498969) | `okapi: init at 1.2.0`                                                     |
| [`cdf88255`](https://github.com/NixOS/nixpkgs/commit/cdf88255ce8258df744110c630fd15b7b8be99eb) | `pythonPackages.awkward: 1.5.1 -> 1.7.0`                                   |
| [`d87d5731`](https://github.com/NixOS/nixpkgs/commit/d87d5731d5bcd495d7a4087949b0fbec4841b972) | `nixos/tests: fix nix-serve path`                                          |
| [`7ff45b0e`](https://github.com/NixOS/nixpkgs/commit/7ff45b0e3518beb9f0c91597bc85fa43b61481c5) | `argocd: 2.1.6 -> 2.1.7`                                                   |
| [`4ca4c228`](https://github.com/NixOS/nixpkgs/commit/4ca4c2283d2b68028e66e3c03ee8b16cac2b1ec7) | `mongodb-compass: 1.29.4 -> 1.29.5`                                        |
| [`d258ef3a`](https://github.com/NixOS/nixpkgs/commit/d258ef3ae351b31705140f43fd2081de7deb359b) | `velero: 1.7.0 -> 1.7.1`                                                   |
| [`6073b099`](https://github.com/NixOS/nixpkgs/commit/6073b099d05458ba4dc3ade6cae7cb838ae5b2b9) | `nixos/snapraid: relax permissions of snapraid-sync`                       |
| [`ea42e8e0`](https://github.com/NixOS/nixpkgs/commit/ea42e8e07ea31682ddd2c1d66ee4239ff1d4f106) | `Bump LLVM lit to 13.0.0`                                                  |
| [`a70b3d18`](https://github.com/NixOS/nixpkgs/commit/a70b3d1847bcbe42d685c2781dce1887cfc937f7) | `neovim: prepend `extraMakeWrapperArgs` in wrapper with a space (#148409)` |
| [`6573c478`](https://github.com/NixOS/nixpkgs/commit/6573c4784b70a4afb2b0d28dbf8de9f6fd7f790d) | `pulumi-bin: 3.17.1 -> 3.19.0`                                             |
| [`aed209a3`](https://github.com/NixOS/nixpkgs/commit/aed209a31571a7459ed2c96a9a6f0d22d21f75dc) | `vala_0_50: drop`                                                          |
| [`9ef385f9`](https://github.com/NixOS/nixpkgs/commit/9ef385f99373682f017d5871f5a140fd52d66eef) | `vala_0_46: drop`                                                          |
| [`17aff7a8`](https://github.com/NixOS/nixpkgs/commit/17aff7a84b61c607fdc0df5730e6a00bf8dff806) | `gnome.caribou: build with latest vala`                                    |
| [`954151ad`](https://github.com/NixOS/nixpkgs/commit/954151ad1133035edbed4fa1a093629948657a00) | `python38Packages.keyboard: init at 0.13.5`                                |
| [`7941fcd3`](https://github.com/NixOS/nixpkgs/commit/7941fcd3617d488b16b65f06f9825df9db7320b8) | `postgresql: fix build on riscv`                                           |
| [`98f3db90`](https://github.com/NixOS/nixpkgs/commit/98f3db9040739e3a88913423e61a2f79ce6a9467) | `libcamera: fix cross compilation`                                         |
| [`974271a5`](https://github.com/NixOS/nixpkgs/commit/974271a5e62ad4bb6cbadfcb193e9ed9c830eac8) | `k9s: fix for sandbox mode`                                                |
| [`5b153a84`](https://github.com/NixOS/nixpkgs/commit/5b153a8485a7590ba9f1134cb19c4a02772305e8) | `python3Packages.kubernetes: 18.20.0 -> 20.13.0`                           |
| [`8500a748`](https://github.com/NixOS/nixpkgs/commit/8500a748bb7d941e40768a07988082ae94fd6c16) | `isync: 1.4.3 -> 1.4.4`                                                    |
| [`cea2e32b`](https://github.com/NixOS/nixpkgs/commit/cea2e32bca42381197ab0a1214b74fd5d6a6d35d) | `k9s: 0.24.15 -> 0.25.7`                                                   |
| [`ea9adf56`](https://github.com/NixOS/nixpkgs/commit/ea9adf56546cd4dc8189abc3b2ee999f64ef1071) | `faas-cli: 0.13.15 -> 0.14.1`                                              |
| [`64a0cf0d`](https://github.com/NixOS/nixpkgs/commit/64a0cf0df2ad6e26be59f4da7ff4a568bc896ce0) | `nixos/waydroid: enable kernel psi interface if required`                  |
| [`77c4dbb0`](https://github.com/NixOS/nixpkgs/commit/77c4dbb017fc56b8caca6e56794a0408b258b369) | `cargo-wipe: 0.3.1 -> 0.3.2`                                               |
| [`2db21cf0`](https://github.com/NixOS/nixpkgs/commit/2db21cf063d49cf7c1265959c1799c8cc64da538) | `coqPackages.equations: 1.2.4 → 1.3 (for Coq 8.13)`                        |
| [`6a9274c5`](https://github.com/NixOS/nixpkgs/commit/6a9274c55f97d065373a6ed624c51729085e435c) | `cargo-generate: bump version 0.5.3 -> 0.11.0`                             |
| [`b5b74c91`](https://github.com/NixOS/nixpkgs/commit/b5b74c914e135834ee3d88c76a3db9f563ed4ca7) | `m17n_lib: fix m17n-db support`                                            |
| [`962d5c8e`](https://github.com/NixOS/nixpkgs/commit/962d5c8e0632b294504895e72f0e198dfad92f71) | `cargo-msrv: 0.4.0 -> 0.12.0`                                              |
| [`7fff1e9c`](https://github.com/NixOS/nixpkgs/commit/7fff1e9c0c77a22c83504bf9ba63c3c949bd66f0) | `tarlz: init at 0.11`                                                      |
| [`daeb6234`](https://github.com/NixOS/nixpkgs/commit/daeb62345c192b887ad8fe53f1607a1e02365dd1) | `lzlib: init at 1.10`                                                      |
| [`67523a38`](https://github.com/NixOS/nixpkgs/commit/67523a382db2aacb7dea57d2e5ef73a9857342dd) | `vimPlugins.venn-nvim: init at 2021-10-19`                                 |
| [`2a22d593`](https://github.com/NixOS/nixpkgs/commit/2a22d593646da25f1fc437913fde71c9b97d0bd4) | `vimPlugins.telescope-vim-bookmarks-nvim: init at 2021-08-12`              |
| [`62b4a25b`](https://github.com/NixOS/nixpkgs/commit/62b4a25b1a21251e5e4641eb4359c1caba616110) | `vimPlugins.telescope-lsp-handlers-nvim: init at 2021-09-07`               |
| [`920871ca`](https://github.com/NixOS/nixpkgs/commit/920871ca00f4bf399573c8034f5e2495c87bdc50) | `vimPlugins.nvim-metals: init at 2021-11-29`                               |
| [`6ff9d027`](https://github.com/NixOS/nixpkgs/commit/6ff9d02773b0c10af0a624518c7fafe57cf365ab) | `vimPlugins.nvim-jqx: init at 2021-11-25`                                  |
| [`4a8c8370`](https://github.com/NixOS/nixpkgs/commit/4a8c8370662ba771291bfe26833f5bf998b7e84b) | `vimPlugins.nvim-neoclip-lua: init at 2021-11-06`                          |
| [`3baeba26`](https://github.com/NixOS/nixpkgs/commit/3baeba2654c87ae9488cbbcc522777634a39041f) | `gnuradio: 3.9.3.0 -> 3.9.4.0`                                             |
| [`c23851c4`](https://github.com/NixOS/nixpkgs/commit/c23851c47e2d5e6c0b1d8364aad53cc9a4d18139) | `Fix shairport-sync module to create and set an explicit group`            |
| [`68c81b11`](https://github.com/NixOS/nixpkgs/commit/68c81b1132e0cd872c06aa9e51d9c8779bdbac5a) | `pdfpc: build with latest vala`                                            |
| [`d9873afa`](https://github.com/NixOS/nixpkgs/commit/d9873afadf1b059749fcda020c2fcbcbad2f3573) | `xfce.xfce4-namebar-plugin: build with vala 0.40`                          |
| [`72eff72c`](https://github.com/NixOS/nixpkgs/commit/72eff72cf0f70cae0396ba434ce55f177d3b5c21) | `vala: remove disable graphviz patch for 0.44`                             |
| [`6b7a314b`](https://github.com/NixOS/nixpkgs/commit/6b7a314be64fa1429775bc92ae1792bb613f7a9f) | `tootle: fix build with latest vala`                                       |
| [`7c7a0160`](https://github.com/NixOS/nixpkgs/commit/7c7a016054234824f7fe17050f5a3ac0db9e04da) | `xfce.xfce4-dockbarx-plugin: build with latest vala`                       |
| [`ebbfccf8`](https://github.com/NixOS/nixpkgs/commit/ebbfccf8a05baf55b0b6e4ac78c1a846589a22da) | `nixos/lightdm: fix tmpfile by changing 0 to -`                            |
| [`b059d729`](https://github.com/NixOS/nixpkgs/commit/b059d729f5f3d504a7808752d388a933bdd9b628) | `vala_0_52: 0.52.7 → 0.52.8`                                               |
| [`64899e83`](https://github.com/NixOS/nixpkgs/commit/64899e83e19e3987c77d793d35c070dfa3707e08) | `vala_0_48: 0.48.19 → 0.48.20`                                             |
| [`bd5b0553`](https://github.com/NixOS/nixpkgs/commit/bd5b055356ef8ce7681d9d0c59df045e59797524) | `mdbook-graphviz: 0.1.2 -> 0.1.3`                                          |
| [`7065725f`](https://github.com/NixOS/nixpkgs/commit/7065725f689dd64de1c79df8e59b06b6dd72b9d5) | `doc: add release notes for a wafHook change`                              |
| [`a0155bed`](https://github.com/NixOS/nixpkgs/commit/a0155bedf318e60cee2d5263351ecdb549062667) | `qpwgraph: init at 0.0.9`                                                  |
| [`43da59fe`](https://github.com/NixOS/nixpkgs/commit/43da59fe8d56baedc1532aee97beddbb04cc8595) | `maintainers: add kanashimia`                                              |
| [`19494f7e`](https://github.com/NixOS/nixpkgs/commit/19494f7eda101fad619f7d39069ee3463a44883c) | `gitlab: 14.5.0 -> 14.5.1`                                                 |
| [`2fb77151`](https://github.com/NixOS/nixpkgs/commit/2fb77151e8fb0c47509fc879e3df553fba7254b4) | `nix-serve: fix NIX_SECRET_KEY_FILE`                                       |
| [`4f1f96d8`](https://github.com/NixOS/nixpkgs/commit/4f1f96d81f53cbea929364aed57e75965e5a701f) | `exploitdb: 2021-11-27 -> 2021-12-02`                                      |
| [`b9599767`](https://github.com/NixOS/nixpkgs/commit/b9599767e8729ffe7309e7724e8cc50c0fd407d3) | `openipmi: 2.0.31 -> 2.0.32`                                               |
| [`510414da`](https://github.com/NixOS/nixpkgs/commit/510414da0ddb7b81436bad9aacb4e2c6bdf8f100) | `ansible-lint: 5.2.1 -> 5.3.0`                                             |
| [`e405114a`](https://github.com/NixOS/nixpkgs/commit/e405114a4e2ca4da9089823be698ea695236b6cd) | `python3Packages.jupyterhub-systemdspawner: use git tag from upstream`     |
| [`9a1fc1bc`](https://github.com/NixOS/nixpkgs/commit/9a1fc1bc9e9979145999f55347cb0f91a17332d8) | `hostess: init at 0.5.2`                                                   |
| [`f238222f`](https://github.com/NixOS/nixpkgs/commit/f238222f1bf43539397f241871922a866301bd13) | `datree: init at 0.14.49`                                                  |
| [`c86c470d`](https://github.com/NixOS/nixpkgs/commit/c86c470d619663c48d73e6e1ddb194aabc48333a) | `maintainers: add jceb`                                                    |
| [`7a89ee61`](https://github.com/NixOS/nixpkgs/commit/7a89ee617150801bed9699b3febf8ede88977552) | `nixos/lxd-image-server: fix logrotate`                                    |
| [`76799f3b`](https://github.com/NixOS/nixpkgs/commit/76799f3bc5bbd79a5e9f5f3b4bc1927188a88d96) | `dolphin-emu-primehack: init at 1.0.5`                                     |
| [`5094edf7`](https://github.com/NixOS/nixpkgs/commit/5094edf7eca7e7e6e2f89bf3aa7427841b5f2a46) | `nextcloud-client: 3.3.6 -> 3.4.0`                                         |
| [`90df19f1`](https://github.com/NixOS/nixpkgs/commit/90df19f130c5f84405572464b26f9fbb0020055a) | `patchmatrix: init at 0.26.0`                                              |
| [`154c9d52`](https://github.com/NixOS/nixpkgs/commit/154c9d52dcc89fed10d7ccc52aba63ec907734f8) | `mxu11x0: 1.4 -> 4.1`                                                      |
| [`63aa7585`](https://github.com/NixOS/nixpkgs/commit/63aa75850d11e954c6c392ec1ca0914ca48c6d1b) | `astro-ls: init to 0.8.1`                                                  |
| [`54a48750`](https://github.com/NixOS/nixpkgs/commit/54a487505a9c14fa4271ac6858a2af8c23eecbd0) | `llvmPackages_13.libcxx: require gcc >=10 on gcc platforms`                |
| [`fb7be3d9`](https://github.com/NixOS/nixpkgs/commit/fb7be3d99891b2c80a1f0cf2ed90e6f696e3c109) | `sauerbraten: add desktop-icon`                                            |
| [`ae4ab6a1`](https://github.com/NixOS/nixpkgs/commit/ae4ab6a1b7df492797f21cae3e96775cb151497e) | `gimp: re-enable tests on darwin`                                          |
| [`17444e7a`](https://github.com/NixOS/nixpkgs/commit/17444e7a7643a285923f43f422af2afd8bc05a12) | `pythonPackages.allure-pytest: init at 2.9.45`                             |
| [`5a13ad11`](https://github.com/NixOS/nixpkgs/commit/5a13ad11ee26387448ddebc1e5d691be37ae8695) | `pythonPackages.allure-python-commons: init at 2.9.45`                     |
| [`449564cc`](https://github.com/NixOS/nixpkgs/commit/449564ccce5a435ac3f19aa42bbc762e2a09433f) | `pythonPackages.allure-python-commons-test: init at 2.9.45`                |
| [`86630d9a`](https://github.com/NixOS/nixpkgs/commit/86630d9a5fbcecf04178e2d1f110f075ff3f8763) | `maintainers: add Madouura`                                                |