### PR TITLE
chore(flake/nixpkgs): `11e5bcc9` -> `f88b90f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1638653945,
-        "narHash": "sha256-kPi8BK3UmIskP1Z2sG6KI0QEXBd/SHu72dpSDOL0ZEw=",
+        "lastModified": 1638741798,
+        "narHash": "sha256-u6mir0D1ZkmhRnUX9EbB6/8mTEmn5FzcoPjrDL0LBDo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "11e5bcc974c36310ee5c38e1cd7eff4cfed04778",
+        "rev": "f88b90f5c329a5a4d49e142315fbcb27986a13b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                             |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`f88b90f5`](https://github.com/NixOS/nixpkgs/commit/f88b90f5c329a5a4d49e142315fbcb27986a13b1) | `facedetect: use Python 3`                                                 |
| [`eec28b8c`](https://github.com/NixOS/nixpkgs/commit/eec28b8cfd7923a876fb47af8a0459c1a550fd97) | `pypy3: 7.3.5 -> 7.3.7 (#147875)`                                          |
| [`a3647046`](https://github.com/NixOS/nixpkgs/commit/a3647046fee002a70a5c121101d46535afd640e0) | `add references for data a few commits behind`                             |
| [`29990fb8`](https://github.com/NixOS/nixpkgs/commit/29990fb83db4435cfafb45cb4221546f6cc067fb) | `pyautogui: init at 0.9.53`                                                |
| [`0af9db38`](https://github.com/NixOS/nixpkgs/commit/0af9db3847e55fdb9709c1e2072fd63d3674ac68) | `pytweening: init at 1.0.4`                                                |
| [`e52be73c`](https://github.com/NixOS/nixpkgs/commit/e52be73c2dbd7bf50f44a7e9902dec2f6d257780) | `pyscreeze: init at 0.1.26`                                                |
| [`11db3d40`](https://github.com/NixOS/nixpkgs/commit/11db3d404a4e4fb426f24dff6fc88af5333d405c) | `pyrect: init at 0.1.4`                                                    |
| [`7ed4633c`](https://github.com/NixOS/nixpkgs/commit/7ed4633ca3ae608b2b0d02de25f670f041b5b830) | `pygetwindow: init at 0.0.9`                                               |
| [`98111a62`](https://github.com/NixOS/nixpkgs/commit/98111a6214fcd5d3bac85cb45e17b2948875642b) | `pymsgbox: 1.0.6 -> 1.0.9`                                                 |
| [`ee9be8a4`](https://github.com/NixOS/nixpkgs/commit/ee9be8a41665724b1e20a7f7d4df46556aa8520c) | `mouseinfo: init at 0.1.3`                                                 |
| [`7c8bc33e`](https://github.com/NixOS/nixpkgs/commit/7c8bc33ec0a99cc6990784605329c3d7f6c27764) | `pyperclip: fix license`                                                   |
| [`6d1ec447`](https://github.com/NixOS/nixpkgs/commit/6d1ec4479e156344cc4a5dda8cc6be77eb5b8d7f) | `wike: 1.5.7 -> 1.6.2`                                                     |
| [`b7b26870`](https://github.com/NixOS/nixpkgs/commit/b7b2687082075c0a07c2e286d1b0d4c342238fc3) | `amass: 3.15.1 -> 3.15.2`                                                  |
| [`8437ca7e`](https://github.com/NixOS/nixpkgs/commit/8437ca7e839fe48c1e4daf4c141aeed38302d7b3) | `python38Packages.meshtastic: 1.2.43 -> 1.2.44`                            |
| [`7980f52d`](https://github.com/NixOS/nixpkgs/commit/7980f52d0c357338de269ee1b7138f901936942f) | `yabai: 3.3.4 -> 3.3.10`                                                   |
| [`406015be`](https://github.com/NixOS/nixpkgs/commit/406015beb873f2c0fcb2a2803c5ad49abe867bb1) | `xsnow: 3.3.1 -> 3.3.2`                                                    |
| [`735d400d`](https://github.com/NixOS/nixpkgs/commit/735d400d0877a28b53444ef9c917544a5861bdd9) | `cht-sh: unstable-2021-11-13 -> unstable-2021-11-17`                       |
| [`02ebf2f2`](https://github.com/NixOS/nixpkgs/commit/02ebf2f2bdf174aef8661f2f9154e16870f152d5) | `afterstep: explicitly disable parallel builds`                            |
| [`4e0f0930`](https://github.com/NixOS/nixpkgs/commit/4e0f0930e9813442fb28a8ac3f164f68079e269a) | `wasmer: 2.0.0 -> 2.1.0`                                                   |
| [`32451b55`](https://github.com/NixOS/nixpkgs/commit/32451b55b7926dc1e3b3a637cfd3b653e781b852) | `air: 1.27.3 -> 1.27.8`                                                    |
| [`8a88b0c2`](https://github.com/NixOS/nixpkgs/commit/8a88b0c28849a66d6e86756d87432ea30a67e833) | `act: 0.2.24 -> 0.2.25`                                                    |
| [`43ca0f5e`](https://github.com/NixOS/nixpkgs/commit/43ca0f5e74ab6b179306319cffcc1802558e3337) | `viewnior: 1.7 -> 1.8`                                                     |
| [`62f834b2`](https://github.com/NixOS/nixpkgs/commit/62f834b20caff433ed63b7ea3bcd7bf962504993) | `barman: 2.15 -> 2.17`                                                     |
| [`8bba694a`](https://github.com/NixOS/nixpkgs/commit/8bba694a6aa9b401422f204495a3f25e57765931) | `wsdd: 0.6.4 -> 0.7.0`                                                     |
| [`2fde20d4`](https://github.com/NixOS/nixpkgs/commit/2fde20d45c5e40c837b89c60a2232eac58da40bd) | `gnome.gnome-flashback: 3.42.0 → 3.42.1`                                   |
| [`b3035f04`](https://github.com/NixOS/nixpkgs/commit/b3035f0442552e27a94d24267fe906c5a15eed0f) | `autotiling: 1.5 -> 1.6`                                                   |
| [`ef4173bc`](https://github.com/NixOS/nixpkgs/commit/ef4173bca361bd561cfa92f04196316e251f0803) | `gnomeExtensions: auto-update`                                             |
| [`3cfab137`](https://github.com/NixOS/nixpkgs/commit/3cfab13751c23eeb46d4864780e7a564f39f276b) | `zfs-prune-snapshots: 1.1.0 -> 1.3.0`                                      |
| [`b716eba4`](https://github.com/NixOS/nixpkgs/commit/b716eba467a7a8472fe964c21e7ee526a2c9f887) | `libargs: 6.2.6 -> 6.2.7`                                                  |
| [`2bf5d8d0`](https://github.com/NixOS/nixpkgs/commit/2bf5d8d04f35457f8ff3ac6669d51e7d3ad45d81) | `zprint: 1.1.2 -> 1.2.0`                                                   |
| [`05bc708a`](https://github.com/NixOS/nixpkgs/commit/05bc708a7f16e71754810a7d5d2bf3871098d4f2) | `nixos/collectd: add missing group`                                        |
| [`7a3e80ab`](https://github.com/NixOS/nixpkgs/commit/7a3e80abeea52002b67304d9a44619061487ec91) | `cloud-hypervisor: 19.0 -> 20.0`                                           |
| [`1b9273ff`](https://github.com/NixOS/nixpkgs/commit/1b9273ffa625d5236f46a1c8ac08fd7097ade5b5) | `checkov: 2.0.626 -> 2.0.628`                                              |
| [`1a5a9b1e`](https://github.com/NixOS/nixpkgs/commit/1a5a9b1e9d6df53b73ee35f134fcb2c124d2777c) | `gnome.mutter: fix libdir path`                                            |
| [`8d0267dc`](https://github.com/NixOS/nixpkgs/commit/8d0267dc8f02e010785d6f90573ea1135b7957e7) | `treewide: use pname&version instead of name`                              |
| [`8e916a44`](https://github.com/NixOS/nixpkgs/commit/8e916a44611df59428f4ab9fef21e5eda77c1f56) | `maintainers: add ius`                                                     |
| [`a707ff8c`](https://github.com/NixOS/nixpkgs/commit/a707ff8c99a25ef0c8d6d3cb1980790c9f791915) | `redo-apenwarr: 0.42c -> 0.42d`                                            |
| [`64fbdc20`](https://github.com/NixOS/nixpkgs/commit/64fbdc2099e73b7a905245b1c28207419e0d46ee) | `git-branchless: 0.3.7 -> 0.3.8`                                           |
| [`10c725dc`](https://github.com/NixOS/nixpkgs/commit/10c725dc6bc28859870fd7c54d0d6399fcaecd7c) | `writers.makePythonWriter: drop flake8 checks for Python 2 scripts`        |
| [`138c3b58`](https://github.com/NixOS/nixpkgs/commit/138c3b581627430e5ebd448da20a2ca23523246f) | `python2Packages.flake8: disable since flake8 v4 dropped Python 2 support` |
| [`bdda2cca`](https://github.com/NixOS/nixpkgs/commit/bdda2cca74af24138fce810216d1f4c91e6eb13e) | `autorandr: install zsh completions`                                       |
| [`d400ed3e`](https://github.com/NixOS/nixpkgs/commit/d400ed3e66ff0ecf2dd44dbaf2d2feaf55eda3ba) | `electron_16: 16.0.2 -> 16.0.4`                                            |
| [`cdb43790`](https://github.com/NixOS/nixpkgs/commit/cdb43790eaa36a848a9fd635bba892b4129bf228) | `electron_15: 15.3.2 -> 15.3.3`                                            |
| [`c8eb62f2`](https://github.com/NixOS/nixpkgs/commit/c8eb62f29da84827f695566fe99658b86274eee3) | `electron_14: 14.2.1 -> 14.2.2`                                            |
| [`36c85e00`](https://github.com/NixOS/nixpkgs/commit/36c85e004838417e59e5ecc81c46afc0e8f2316c) | `electron_13: 13.6.2 -> 13.6.3`                                            |
| [`72000dce`](https://github.com/NixOS/nixpkgs/commit/72000dced2ec5036ed9eeaa0277f4b1bbf2de4c1) | `libsForQt5.bismuth: 2.1.0 -> 2.2.0 (#148673)`                             |
| [`0ff0d541`](https://github.com/NixOS/nixpkgs/commit/0ff0d54168c3d085243b254ef762524863936f0d) | `add self to maintainers`                                                  |
| [`5bd4dadb`](https://github.com/NixOS/nixpkgs/commit/5bd4dadb172ab9829c44021d8b599b75bff60422) | `python3Packages.empy: init at 3.3.4`                                      |
| [`143da123`](https://github.com/NixOS/nixpkgs/commit/143da12376d3522465bcfe2b4333501423c086f2) | `python39Packages.paste: add six dependency back (#148501)`                |
| [`cab6e339`](https://github.com/NixOS/nixpkgs/commit/cab6e3395ad407687e6fd3b9a1b33ef071caa4c9) | `rdkafka: 1.8.0 -> 1.8.2 (#144626)`                                        |
| [`8592d8f8`](https://github.com/NixOS/nixpkgs/commit/8592d8f8661c9a3de8e37eae51622b9fa1070a4b) | `senpai: unstable-2021-05-27 -> unstable-2021-11-29`                       |
| [`b6295037`](https://github.com/NixOS/nixpkgs/commit/b62950371dfa994b4e4b2881d524a3fb8a60c0bf) | `wezterm: 20210814-124438-54e29167 -> 20211204-082213-a66c61ee9`           |
| [`68dc5484`](https://github.com/NixOS/nixpkgs/commit/68dc5484e9515d0e349677a1347fede62418c67b) | `nixos/doc/manual/release-notes/rl-2111: add prometheus-smartctl-exporter` |
| [`34103240`](https://github.com/NixOS/nixpkgs/commit/341032407f6371857490da6ced6b88930f335a8a) | `Revert "neard: fix build"`                                                |
| [`6af3d13b`](https://github.com/NixOS/nixpkgs/commit/6af3d13bec9b13e8fa8e19594ffbcbe085387bdd) | `nixos/ddclient: fix permission for ddclient.conf (#148179)`               |
| [`c3a57a62`](https://github.com/NixOS/nixpkgs/commit/c3a57a62856dce4b5dc9154b2a5c6c3ae5f023d1) | `fnm: 1.27.0 -> 1.28.1 (#147798)`                                          |
| [`53801ef1`](https://github.com/NixOS/nixpkgs/commit/53801ef12226bd519db2c85c5a6a4a5fed951132) | `qmapshack: 1.16.0 -> 1.16.1`                                              |
| [`a6197d0f`](https://github.com/NixOS/nixpkgs/commit/a6197d0feb3162a8fa021a7b414d616147484cd5) | `clickclack: 0.1.1 -> 0.2`                                                 |
| [`54e0af39`](https://github.com/NixOS/nixpkgs/commit/54e0af392a7e32f3d159210577fa0509f2190d4f) | `python3Packages.ytmusicapi: 0.19.4 -> 0.19.5`                             |
| [`97fe3d9a`](https://github.com/NixOS/nixpkgs/commit/97fe3d9aa36d6f07324819e6fce1188cd7eeb103) | `ascii-image-converter: init at 1.11.0`                                    |
| [`62b03e2c`](https://github.com/NixOS/nixpkgs/commit/62b03e2c3967e6c0b618db490fc00e7aea4f4463) | `cpuid: 20211114 -> 20211129`                                              |
| [`7e1fbeeb`](https://github.com/NixOS/nixpkgs/commit/7e1fbeeb10a27ff85b4a6350288f7cd5f9aa74e5) | `kubeaudit: init at 0.16.0`                                                |
| [`d897bd56`](https://github.com/NixOS/nixpkgs/commit/d897bd56af04b0383075bd85d074d6c2be0bc6f3) | `netbeans: 12.5 -> 12.6`                                                   |
| [`e5c93511`](https://github.com/NixOS/nixpkgs/commit/e5c93511f34613a6c818734d1c21f6a6f51dad36) | `vault: add vault-postgresql to passthru.tests`                            |
| [`58ebdc31`](https://github.com/NixOS/nixpkgs/commit/58ebdc31541b3e233178bebf7a25cfad5201bfe6) | `goimapnotify: remove unused deps.nix`                                     |
| [`e97bf4b6`](https://github.com/NixOS/nixpkgs/commit/e97bf4b65308d5c9f7812869f96852243333009f) | `whitesur-gtk-theme: 2021-10-21 -> 2021-12-04`                             |
| [`cee0c4a8`](https://github.com/NixOS/nixpkgs/commit/cee0c4a831bf1cf111071ad1ee3929f290de99e7) | `python3Packages.ocrmypdf: 12.7.2 -> 13.0.0`                               |
| [`134db1c3`](https://github.com/NixOS/nixpkgs/commit/134db1c397873fb57864ebb9ae45bc55b19b9a0e) | `sysdig: fix pending upstream inclusion for ncurses-6.3`                   |
| [`8bf6b8fe`](https://github.com/NixOS/nixpkgs/commit/8bf6b8fe27c4a0759ff74bd83cd95067a4740242) | `python3Packages.pikepdf: 4.0.2 -> 4.1.0`                                  |
| [`d09271ab`](https://github.com/NixOS/nixpkgs/commit/d09271ab3517c3ce58de38b57150ecf77f941218) | `glitter: 1.5.9 -> 1.5.10`                                                 |
| [`6cf2385f`](https://github.com/NixOS/nixpkgs/commit/6cf2385f15986231ad98708aea227a62274f3aff) | `wireshark: 3.4.9 -> 3.4.10`                                               |
| [`4a0fbcbd`](https://github.com/NixOS/nixpkgs/commit/4a0fbcbd138ae1430df231fe134311a0ac62acf1) | `liboping: fix format arguments for printf()`                              |
| [`e9917d53`](https://github.com/NixOS/nixpkgs/commit/e9917d53cf17691bea8fc23f70487b3a4bbcdb28) | `gitlint: 0.16.0 -> 0.17.0`                                                |
| [`4752689c`](https://github.com/NixOS/nixpkgs/commit/4752689cfb89d5945612fade8c8ac7430f083a2f) | `postgresqlPackages.pg_auto_failover: upstream fix for ncurses-6.3`        |
| [`1ff7318a`](https://github.com/NixOS/nixpkgs/commit/1ff7318a565cb531b8746bd575f24ceefb6b9ed4) | `trillian: 1.3.13 -> 1.4.0`                                                |
| [`e906657a`](https://github.com/NixOS/nixpkgs/commit/e906657a50edc800858dac355e32950cb6040616) | `ocenaudio: 3.10.6 -> 3.11.0`                                              |
| [`80f86077`](https://github.com/NixOS/nixpkgs/commit/80f8607721e9c211bae9dbcdb7bac584812b7bf6) | `xdot: needs graphviz in PATH`                                             |
| [`146ddee1`](https://github.com/NixOS/nixpkgs/commit/146ddee13b81cd096f0136ebf217947aab114ddc) | `nixos/tests/knot: add extra cpu core to master`                           |
| [`893f7af2`](https://github.com/NixOS/nixpkgs/commit/893f7af236bf11fba03ef1c21b381d3ccc5df3f7) | `nixos/tests/knot: log systemd unit hardening info`                        |
| [`67f102d8`](https://github.com/NixOS/nixpkgs/commit/67f102d8d8dee9cd12c082d013081cb296199e1f) | `nixos/knot: update systemd hardening`                                     |
| [`d1916993`](https://github.com/NixOS/nixpkgs/commit/d1916993471b4e31ba593caf60f828d2edc2c0c2) | `terminal-typeracer: 2.0.4 -> 2.0.8`                                       |
| [`2bf95bbc`](https://github.com/NixOS/nixpkgs/commit/2bf95bbc7c3288708a87e75bc4a826ba0c17f1a5) | `intel-media-driver: 21.4.2 -> 21.4.3`                                     |
| [`13a662b4`](https://github.com/NixOS/nixpkgs/commit/13a662b45bf4b0ab5d3092c280382cd64d537f99) | `python3Packages.poetry: 1.1.11 -> 1.1.12`                                 |
| [`da4ca766`](https://github.com/NixOS/nixpkgs/commit/da4ca766df3d7f45eb867edf437fd86d7b209519) | `gitea: 1.15.6 -> 1.15.7`                                                  |
| [`d69ee7c4`](https://github.com/NixOS/nixpkgs/commit/d69ee7c4090834fb49c8022e925e3ba0d88994ed) | `warzone2100: set platforms to all, mark darwin as broken`                 |
| [`7dcc14f5`](https://github.com/NixOS/nixpkgs/commit/7dcc14f57b7d0975056722b6860a6e7ae152ab81) | `junicode: 1.002 -> 1.003`                                                 |
| [`9b2d7ed0`](https://github.com/NixOS/nixpkgs/commit/9b2d7ed016da78d00a8a1ae5653ff87bde136de6) | `python3Packages.aiomusiccast: 0.14.0 -> 0.14.2`                           |
| [`ee4f0476`](https://github.com/NixOS/nixpkgs/commit/ee4f04766781d52cf69496c31b3e4061135d8e73) | `python3Packages.flux-led: 0.25.10 -> 0.25.13`                             |
| [`33ab3790`](https://github.com/NixOS/nixpkgs/commit/33ab379081e9c89cde81aca1bd86ca0a11321ed9) | `checkov: 2.0.625 -> 2.0.626`                                              |
| [`f9c667ab`](https://github.com/NixOS/nixpkgs/commit/f9c667ab991e4dfcb7b4343697f9d95b7c6e9e08) | `ytcc: 2.5.3 -> 2.5.4`                                                     |
| [`dc102405`](https://github.com/NixOS/nixpkgs/commit/dc102405ceafa50634484487d1652435b33cb94c) | `rocketchat-desktop: 3.6.0 -> 3.7.0`                                       |
| [`25d88c7c`](https://github.com/NixOS/nixpkgs/commit/25d88c7c6f04b824d97579bbf4db210650da7a56) | `fishPlugins.fzf-fish: 7.3 -> 7.4`                                         |
| [`118ed78e`](https://github.com/NixOS/nixpkgs/commit/118ed78ec71a493052690bcbb709dbb7f832e110) | `tor: fix build on aarch64-darwin by disabling tests`                      |
| [`faa4f8de`](https://github.com/NixOS/nixpkgs/commit/faa4f8de408f55cd463b2f0089edfdbee4ee9e4f) | `insomnia: 2021.4.1 -> 2021.6.0`                                           |
| [`00ddf8c7`](https://github.com/NixOS/nixpkgs/commit/00ddf8c77b7fda41849b069bd8cc290f0884a0ad) | `fspy: init at 1.0.3`                                                      |
| [`20c2237f`](https://github.com/NixOS/nixpkgs/commit/20c2237f9f1c603c238582ec8cbcd8324433d48a) | `mobilecoin-wallet: init at 1.4.1`                                         |
| [`5ac79dd2`](https://github.com/NixOS/nixpkgs/commit/5ac79dd2ce7b9fb86668241170188787fee9af14) | `heroic: init at 1.10.3`                                                   |
| [`cd142455`](https://github.com/NixOS/nixpkgs/commit/cd142455e71bc497c1a77c8c95a7342d7939add6) | `kaldi: enable parallel building`                                          |
| [`6d660b27`](https://github.com/NixOS/nixpkgs/commit/6d660b27e1e49b4de780075e01d3b4c4ad675b88) | `kaldi: 2020-12-26 -> 2021-12-03`                                          |
| [`8b2a9e89`](https://github.com/NixOS/nixpkgs/commit/8b2a9e89486dad564324eb8e4ac41df614548aef) | `turbogit: 3.0.1 -> 3.1.1`                                                 |
| [`3f58a236`](https://github.com/NixOS/nixpkgs/commit/3f58a236764193e2d5330ca772d795a7fa4cd9e1) | `python3Packages.frigidaire: 0.18.3 -> 0.18.4`                             |
| [`92b7ce26`](https://github.com/NixOS/nixpkgs/commit/92b7ce268d86f936f2f3a4bc5f3445497c33121c) | `python3Packages.casbin: 1.11.1 -> 1.12.0`                                 |
| [`ce494f54`](https://github.com/NixOS/nixpkgs/commit/ce494f547f6287b2ce6dd3fd73cf6e415a8ee644) | `gimpPlugins.texturize: 2.2.2017-07-28 → 2.2+unstable=2021-12-03`          |
| [`b0a20089`](https://github.com/NixOS/nixpkgs/commit/b0a200896f7df96a388b38d16413e3b52fa9ce8a) | `arkade: 0.8.9 -> 0.8.11`                                                  |
| [`ac8a9c3f`](https://github.com/NixOS/nixpkgs/commit/ac8a9c3f03e11faba46d75a3b52a63a74ea725cc) | `Revert "nixos/borgbackup: specify systemd WorkingDirectory"`              |
| [`639c8aac`](https://github.com/NixOS/nixpkgs/commit/639c8aac781370deac15711cd1169d96f95a3cad) | `wl-clipboard-x11: Init at 5`                                              |
| [`001eb457`](https://github.com/NixOS/nixpkgs/commit/001eb45718fc5b7d5b0b11e1b80987b225e8c148) | `libdeltachat: 1.69.0 -> 1.70.0`                                           |
| [`57502818`](https://github.com/NixOS/nixpkgs/commit/5750281892f24ae8f52c6ef72081ec63d58fe08e) | `udisks2 - 2.8.4 -> 2.9.4`                                                 |
| [`bee1adfd`](https://github.com/NixOS/nixpkgs/commit/bee1adfd41f575e62ff700325114eccb40d60792) | `steampipe: 0.9.1 -> 0.10.0`                                               |
| [`f469351a`](https://github.com/NixOS/nixpkgs/commit/f469351a3d1b9ba88b78d37f640467bdd8d9b940) | `kalendar: init at 0.3.1`                                                  |
| [`25fc09ce`](https://github.com/NixOS/nixpkgs/commit/25fc09ce0d30611385eaa9a18fcb08a0b863d6ba) | `alpine-make-vm-image: 0.7.0 -> 0.8.0`                                     |
| [`c283a575`](https://github.com/NixOS/nixpkgs/commit/c283a575ab7bcda0cefc3c6ddfe7b481783d7850) | `apk-tools: 2.12.7 -> 2.12.8`                                              |
| [`7343c157`](https://github.com/NixOS/nixpkgs/commit/7343c157c1862fb8449b1d9123d71eae71bb6f76) | `maintainers: add chuangzhu`                                               |
| [`aca96fc3`](https://github.com/NixOS/nixpkgs/commit/aca96fc3dd5d0882a9053c23c3f5f342737002ad) | `python3Packages.django-redis: 5.0.0 -> 5.1.0`                             |
| [`6b885cf4`](https://github.com/NixOS/nixpkgs/commit/6b885cf4008e1518edd505265c0fe09447984a2e) | `material-kwin-decoration: init at 20211028`                               |
| [`14aee2e9`](https://github.com/NixOS/nixpkgs/commit/14aee2e9c86812db874e419aab143bb064f00f28) | `dave: init at 0.4.0`                                                      |
| [`fa93595c`](https://github.com/NixOS/nixpkgs/commit/fa93595ccb7c78fd02c9691a37245c2f12691dd5) | `beyond-identity: init at 2.45.0-0`                                        |
| [`3ebf573c`](https://github.com/NixOS/nixpkgs/commit/3ebf573cca5f8d86a9e7686f38f3cee50aae4a7c) | `maintainers: add klden`                                                   |
| [`28a115ed`](https://github.com/NixOS/nixpkgs/commit/28a115edc418b3e725dc96199dc384ad52ab9ab3) | `pantheon.extra-elementary-contracts: drop`                                |
| [`b5038e51`](https://github.com/NixOS/nixpkgs/commit/b5038e5127e728ebd9b0cd30aef0211ff4df035b) | `pantheon.gnome-bluetooth-contract: init at unstable-2021-02-23`           |
| [`0a9d1ce1`](https://github.com/NixOS/nixpkgs/commit/0a9d1ce156c564024b12e7f8c6fd4817421cb6ca) | `pantheon.file-roller-contract: init at unstable-2021-02-23`               |
| [`8cf46186`](https://github.com/NixOS/nixpkgs/commit/8cf461868555e7ffb11ed190a963fc4f48398aac) | `restream: Change wrapping method so that --help page is readable`         |
| [`30924d82`](https://github.com/NixOS/nixpkgs/commit/30924d82e1be133b22c3d44c4ad351c3664673cc) | `restream: Add nc command to wrapper`                                      |
| [`4f2a1283`](https://github.com/NixOS/nixpkgs/commit/4f2a12835b607147106436ebbc41a4332dc8e984) | `restream: 1.1 -> 1.2.0`                                                   |
| [`71d446eb`](https://github.com/NixOS/nixpkgs/commit/71d446eb25a74d2a7c6a04d16b92e5e86ae57960) | `rust-analyzer: 2021-10-25 -> 2021-11-29`                                  |
| [`7f4e0712`](https://github.com/NixOS/nixpkgs/commit/7f4e071274424c3e37847fc26bd7e4343ce9522c) | `nixos/tests/drbd: init`                                                   |
| [`aa37441c`](https://github.com/NixOS/nixpkgs/commit/aa37441c3ee910ae071156cb8914f767c8403baf) | `nixos/drbd: fix`                                                          |
| [`036b9094`](https://github.com/NixOS/nixpkgs/commit/036b9094211e223dce4de233c0063a6fcd47deb8) | `drbd: 8.4.4 -> 9.19.1, ocf-resource-agents: init at 4.10.0`               |
| [`37ab0777`](https://github.com/NixOS/nixpkgs/commit/37ab07778964a8158bedf5b7604331ceafcf0400) | `hugo: 0.88.1 -> 0.89.4`                                                   |
| [`1eeba577`](https://github.com/NixOS/nixpkgs/commit/1eeba57791d6e294e642ced356d0bed735a47aab) | `pps-tools: 1.0.2 -> 1.0.3`                                                |
| [`53566fb3`](https://github.com/NixOS/nixpkgs/commit/53566fb3c3fa94b9c8776e405a9d810966351db0) | `lite-xl: 2.0.1 -> 2.0.3`                                                  |
| [`02316a45`](https://github.com/NixOS/nixpkgs/commit/02316a4565428d6c392dfa5f3ff3e87771783184) | `nixos/tests/prometheus.exporters.smartctl: init`                          |
| [`386a1e79`](https://github.com/NixOS/nixpkgs/commit/386a1e79eb2df31c43bdf2b27828467a655318a8) | `nixos/smartctl-exporter: init`                                            |
| [`0f4340da`](https://github.com/NixOS/nixpkgs/commit/0f4340da1d9b21a91ba442ec246c594a9c64ae10) | `prometheus-smartctl-exporter: init at unstable-2020-11-14`                |
| [`32c2b49a`](https://github.com/NixOS/nixpkgs/commit/32c2b49a404b4b6ec2c6aa0c6b1a45c5bb00c1f6) | `neard: 0.16 → 0.18`                                                       |
| [`effbe428`](https://github.com/NixOS/nixpkgs/commit/effbe4285fcdc19f2066a670fe61c3009b4d8482) | `python38Packages.celery: remove click & moto patches`                     |
| [`d45b0b0f`](https://github.com/NixOS/nixpkgs/commit/d45b0b0f05cd04f00c4f18b0ae3d44492c2a3992) | `python38Packages.celery: 5.1.2 -> 5.2.0`                                  |
| [`ef24ce42`](https://github.com/NixOS/nixpkgs/commit/ef24ce42a5c722621b541b966ba5da8f331457fa) | `s3ql: 3.7.3 -> 3.8.0`                                                     |
| [`8c2acce1`](https://github.com/NixOS/nixpkgs/commit/8c2acce1d64f97f49147784c638b506951a935e0) | `wesnoth: remove enableTools option as it was removed from wesnoth`        |
| [`6942a645`](https://github.com/NixOS/nixpkgs/commit/6942a6450462c47646a816ea202b2a34335eb40f) | `adwaita-qt: 1.4.0 -> 1.4.1`                                               |
| [`666e1579`](https://github.com/NixOS/nixpkgs/commit/666e1579cc4c946292d45d52aeca3a68ebfcd773) | `mdbtools: 0.9.4 -> 1.0.0`                                                 |
| [`17b1406f`](https://github.com/NixOS/nixpkgs/commit/17b1406f8c4076ba232f8fbbb64d2a32aade15c1) | `loksh: 6.9 -> 7.0`                                                        |
| [`88ac7b1b`](https://github.com/NixOS/nixpkgs/commit/88ac7b1ba26251b64fd99a24340d7a958213d67c) | `cgreen: 1.4.0 -> 1.4.1`                                                   |
| [`e75e62cc`](https://github.com/NixOS/nixpkgs/commit/e75e62cca378ed2090d0884488fb9097ce6b5dc5) | `maintainers: add danth`                                                   |