### PR TITLE
chore: remove `awscli2` until nixos 178313 lands

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,6 +1,5 @@
 { mkShell
 , lib
-, awscli2
 , cachix
 , curl
 , deploy-rs
@@ -108,7 +107,6 @@ mkShell {
   name = "nix-config";
 
   nativeBuildInputs = [
-    awscli2
     cachix
     deploy-rs
     git

--- a/users/cloud/core/voltrondata.nix
+++ b/users/cloud/core/voltrondata.nix
@@ -1,6 +1,5 @@
 { pkgs, ... }: {
   home.packages = with pkgs; [
-    awscli2
     google-cloud-sdk
     docker-credential-gcr
     amazon-ecr-credential-helper


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/178313.
